### PR TITLE
更正文件名错误导致切换默认背景纯白

### DIFF
--- a/public/css/menu.css
+++ b/public/css/menu.css
@@ -160,7 +160,7 @@
 
 /* 背景类 */
 body.bg-default {
-  background-image: url("../pictures/backgrounds/homepage_bg3.jpg");
+  background-image: url("../pictures/backgrounds/homepage_bg.jpeg"); /*更正文件名错误*/
 }
 
 body.bg-night {


### PR DESCRIPTION
修改”LingChat-main\public\css\menu.css“的第163行
将”background-image: url("../pictures/backgrounds/homepage_bg3.jpg");“
修改为“background-image: url("../pictures/backgrounds/homepage_bg.jpeg");”