### PR TITLE
解决第2行注释被意外执行并影响第3行代码执行

### DIFF
--- a/backend/install.bat
+++ b/backend/install.bat
@@ -1,5 +1,5 @@
 @echo off
-:: 基础Python库安装
+echo :: "基础Python库安装"
 pip install openai
 pip install transformers
 pip install torch


### PR DESCRIPTION
对**第2行**注释前面添加*无用且无影响的* **echo** *命令*解决注释意外输出并影响第三行代码运行。
*已**亲测**可以完全正常运行。*

我猜测应该是**注释不能独占一行**，~或是*cmd默认第一排必须为命令？*~*(不确定)*