### PR TITLE
修改服务器 连接 代码 于111行 talk.js

### DIFF
--- a/public/js/talk.js
+++ b/public/js/talk.js
@@ -108,8 +108,19 @@ const expressionConfig = {
   },
 };
 
+// 获取当前域名，如果为空则使用 localhost
+const host = window.location.host || 'localhost';
+let protocol;
+if (window.location.protocol === 'http:') {
+    protocol = 'ws';
+} else if (window.location.protocol === 'https:') {
+    protocol = 'wss';
+} else {
+    // 若为 file:// 协议，默认使用 ws
+    protocol = 'ws';
+}
 // 创建 WebSocket 连接
-const socket = new WebSocket("ws://localhost:3000/ws");
+const socket = new WebSocket(`${protocol}://${host}:3000/ws`);    
 
 // const socket = new WebSocket("wss://frp-oil.com:58025//ws");
 


### PR DESCRIPTION
修改**自动判断协议**和**域名**，可用于搭建服务器时使用
window.location.host 判断当前页面的域名
window.location.protocol 判断当前协议