### PR TITLE
修复112行的window.location.host错误于 talk.js

### DIFF
--- a/public/js/talk.js
+++ b/public/js/talk.js
@@ -109,7 +109,7 @@ const expressionConfig = {
 };
 
 // 获取当前域名，如果为空则使用 localhost
-const host = window.location.host || 'localhost';
+const host = window.location.hostname || 'localhost';
 let protocol;
 if (window.location.protocol === 'http:') {
     protocol = 'ws';


### PR DESCRIPTION
修改112行的window.location.host改为**window.location.hostname**

 _抱歉犯傻了>﹏<_ 