### PR TITLE
fix(docker): 修复了一堆docker部署时无法正常使用的bug

### DIFF
--- a/.env.example.docker
+++ b/.env.example.docker
@@ -40,18 +40,18 @@ SYSTEM_PROMPT="
         "
 
 # VITS语音配置
-VITS_API_URL="http://localhost:23456/voice/vits"
+VITS_API_URL="http://vits-simple-api-vits:23456/voice/vits"
 VITS_SPEAKER_ID=4
 
-# 注意：当从Docker部署时，此路径需去掉backend/
 EMOTION_MODEL_PATH="emotion_model_12emo"
 
 BACKEND_BIND_ADDR="0.0.0.0"
-BACKEND_ADDR="localhost"
+BACKEND_ADDR="python-backend"
 BACKEND_PORT=8765
 
-TEMP_VOICE_DIR="frontend/public/audio"
+TEMP_VOICE_DIR="audio"
 
 FRONTEND_BIND_ADDR="0.0.0.0"
+# 如果你希望从公网访问，这里前端地址需要换成公网ip或URL
 FRONTEND_ADDR="localhost"
 FRONTEND_PORT=3000

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,5 +1,5 @@
 FROM node:22-alpine
-ENV ROOT /usr/src/app
+ENV ROOT /app
 WORKDIR ${ROOT}
 COPY frontend/package.json .
 RUN npm install

--- a/Dockerfile-python
+++ b/Dockerfile-python
@@ -11,4 +11,4 @@ COPY backend/ .
 COPY .env.docker .env
 EXPOSE 8765
 
-CMD ["python", "webChat.py"]
+CMD ["python", "webChat.docker.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8765:8765"
     volumes:
-      - ./backend:/app
+      - ./volume/data:/app/audio
     environment:
       - FLASK_ENV=development
     env_file:
@@ -21,11 +21,14 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./frontend:/app
+      - ./volume/data:/app/public/audio
     depends_on:
       - python-backend
     networks:
       - app-network
+
+# 如果使用vits语音docker，请将其docker加入lingchat container network, 否则后端无法与其通信生成语音
+# docker network connect lingchat_app-network vits-simple-api-vits
 
 networks:
   app-network:


### PR DESCRIPTION
- 在docker env文件添加了注释提醒前端地址
- docker env文件中后端地址和vits地址改为使用docker容器默认名称，依赖docker自身DNS解析通信
- 修复不一致且不必要的前端dockerfile WORKDIR
- 修复py后端入口代码更名但dockerfile没更名的问题
- docker compose文件中修改前后端挂载卷路径，只挂载数据目录且对齐各自期望的路径
- docker compose文件添加注释提醒如果希望使用vits语音docker需要加入network