### PR TITLE
当情感分析没有配置时，自动采用original tag

### DIFF
--- a/backend/core/ai_service.py
+++ b/backend/core/ai_service.py
@@ -446,7 +446,7 @@ class AIService:
         total_parts = len(segments)
         return [{
             "type": "reply",
-            "emotion": seg['predicted'],
+            "emotion": seg['predicted'] or seg["original_tag"],
             "originalTag": seg['original_tag'],
             "message": seg['following_text'],
             "motionText": seg['motion_text'],

--- a/backend/core/predictor.py
+++ b/backend/core/predictor.py
@@ -82,7 +82,7 @@ class EmotionClassifier:
                     "warning": f"置信度低于阈值({confidence_threshold:.0%})"
                 }
             
-            label = self.id2label.get(str(pred_id), "未知")
+            label = self.id2label.get(str(pred_id), "")
             logger.debug(f"情绪识别: {text} -> {label} ({pred_prob:.2%})")
             return {
                 "label": label,
@@ -92,7 +92,7 @@ class EmotionClassifier:
         except Exception as e:
             logger.error(f"情绪预测错误: {e}")
             return {
-                "label": "未知",
+                "label": "",
                 "confidence": 0.0,
                 "top3": [],
                 "error": str(e)
@@ -103,7 +103,7 @@ class EmotionClassifier:
         top3_probs, top3_ids = torch.topk(probs, 3)
         return [
             {
-                "label": self.id2label.get(str(idx.item()), "未知"),
+                "label": self.id2label.get(str(idx.item()), ""),
                 "probability": prob.item()
             }
             for prob, idx in zip(top3_probs[0], top3_ids[0])


### PR DESCRIPTION
为了轻量化，有些用户（比如我）可能会选择不使用情感分析模型，这时候需要把情感判断fallback到大模型给出的情感上去