### PR TITLE
修复了ollama.py 无法正确实现与ollama端的模型通信的问题

### DIFF
--- a/backend/core/llm_providers/ollama.py
+++ b/backend/core/llm_providers/ollama.py
@@ -4,36 +4,43 @@ from typing import Dict, List
 from core.logger import logger
 import os
 
+
 class OllamaProvider(BaseLLMProvider):
     def __init__(self):
         super().__init__()
         self.base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
         self.model_type = os.environ.get("OLLAMA_MODEL", "llama3")
-    
+
+    def initialize_client(self):
+        """初始化 Ollama 客户端（占位实现）"""
+        logger.info(f"Initializing Ollama client with model {self.model_type} at {self.base_url}")
+        # 如果后续有 client 对象（例如 requests.Session）可以在这里初始化
+        pass
+
     def generate_response(self, messages: List[Dict]) -> str:
         """生成Ollama模型响应"""
         try:
             logger.debug(f"Sending request to Ollama API: {self.base_url}/api/chat")
-            
+
             payload = {
                 "model": self.model_type,
                 "messages": messages,
                 "stream": False
             }
-            
+
             response = requests.post(
                 f"{self.base_url}/api/chat",
                 json=payload
             )
-            
+
             if response.status_code != 200:
                 error_msg = f"Ollama API returned error: {response.status_code} - {response.text}"
                 logger.error(error_msg)
                 raise Exception(error_msg)
-                
+
             response_json = response.json()
             return response_json.get("message", {}).get("content", "")
-            
+
         except Exception as e:
             logger.error(f"Ollama API call failed: {str(e)}")
             raise


### PR DESCRIPTION
Main原代码在使用ollama时会产生如下报错
[ERROR]: 创建LLM提供商 ollama 失败: Can't instantiate abstract class OllamaProvider with abstract method initialize_client
出错了,
Can't instantiate abstract class OllamaProvider with abstract method initialize_client
Traceback (most recent call last):
File "D:\code\LingChat\backend\api\chat_info.py", line 27, in init_web_infos
ai_service = service_manager.init_ai_service(settings)
File "D:\code\LingChat\backend\core\service_manager.py", line 13, in init_ai_service
self.ai_service = AIService(settings)
File "D:\code\LingChat\backend\core\ai_service.py", line 32, in init
self.llm_model = LLMManager()
File "D:\code\LingChat\backend\core\llm_providers\manager.py", line 15, in init
self.provider = self._initialize_provider()
File "D:\code\LingChat\backend\core\llm_providers\manager.py", line 28, in _initialize_provider
return LLMProviderFactory.create_provider(provider_type)
File "D:\code\LingChat\backend\core\llm_providers\provider_factory.py", line 27, in create_provider
return OllamaProvider()
TypeError: Can't instantiate abstract class OllamaProvider with abstract method initialize_client

其原因是定义的 OllamaProvider 类继承了抽象基类 BaseLLMProvider，而 该基类声明了一个抽象方法 initialize_client()，但你在子类 OllamaProvider 中 没有实现这个方法

故应改为

##LingChat\backend\core\llm_providers\ollama.py
import requests
from .base import BaseLLMProvider
from typing import Dict, List
from core.logger import logger
import os

class OllamaProvider(BaseLLMProvider):
    def __init__(self):
        super().__init__()
        self.base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
        self.model_type = os.environ.get("OLLAMA_MODEL", "llama3")

        def initialize_client(self):
        """初始化 Ollama 客户端（占位实现）"""
        logger.info(f"Initializing Ollama client with model {self.model_type} at {self.base_url}")
        # 如果后续有 client 对象（例如 requests.Session）可以在这里初始化
        pass

    def generate_response(self, messages: List[Dict]) -> str:
        """生成Ollama模型响应"""
        try:
            logger.debug(f"Sending request to Ollama API: {self.base_url}/api/chat")

            payload = {
                "model": self.model_type,
                "messages": messages,
                "stream": False
            }

            response = requests.post(
                f"{self.base_url}/api/chat",
                json=payload
            )

            if response.status_code != 200:
                error_msg = f"Ollama API returned error: {response.status_code} - {response.text}"
                logger.error(error_msg)
                raise Exception(error_msg)

            response_json = response.json()
            return response_json.get("message", {}).get("content", "")

        except Exception as e:
            logger.error(f"Ollama API call failed: {str(e)}")
            raise