### PR TITLE
修改RAG中部分内容

### DIFF
--- a/backend/core/RAG.py
+++ b/backend/core/RAG.py
@@ -102,7 +102,7 @@ class RAGSystem:
             if not os.path.isdir(local_model_path):
                 logger.error(f"本地模型路径不存在或不是文件夹: {local_model_path}")
                 logger.error("请确保模型已下载到 'backend/core/memory_rag/models' 目录下。")
-                logger.error("您可以运行 'backend/core/memory_rag/download_model.py' 脚本来下载模型。")
+                logger.error("您可以运行 'backend/core/memory_rag/downloading.py' 脚本来下载模型。")
                 return False
 
             logger.debug(f"RAG: 初始化Sentence Transformer模型...")

--- a/backend/core/memory_rag/downloading.py
+++ b/backend/core/memory_rag/downloading.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from sentence_transformers import SentenceTransformer
 
 def download_embedding_model():
     """
@@ -33,8 +32,14 @@ def download_embedding_model():
 
     os.makedirs(save_path, exist_ok=True)
     print(f"\n[步骤 1/3] 已创建或确认目录存在: {save_path}")
-
+    
     try:
+        mirror_use = str(input("\n[提示] 在中国网络环境中可能无法下载模型，要使用镜像站加速吗？（回答 yes 或者回车忽略）："))
+        if mirror_use == "yes":
+            os.environ['HF_ENDPOINT'] = 'https://hf-mirror.com'
+        
+        from sentence_transformers import SentenceTransformer
+        
         print("\n[步骤 2/3] 正在从Hugging Face Hub下载模型...")
         print("这个过程可能需要一些时间，取决于您的网络连接。请耐心等待。")
         


### PR DESCRIPTION
修改内容：

1. 修改了 RAG.py 中下载脚本文件名的错误。
2. 在 downloading.py 中添加了启用镜像站下载的功能。（为实现此功能，需要在设置环境变量之后import，所以动了import的顺序）

在termux-proot-debian-bookworm上测试通过

（另外吐槽一句：这 sentence_transformers 的 import 真慢啊）