### PR TITLE
fix: 由于新图层的加入，导致TouchArea的点击事件无法穿透到底层

### DIFF
--- a/frontend_vue/src/components/game/standard/GameAvatar.vue
+++ b/frontend_vue/src/components/game/standard/GameAvatar.vue
@@ -16,6 +16,15 @@
     ></div>
     <!-- 修改结束 -->
 
+    <!-- 触摸区域组件 -->
+    <TouchAreas
+      v-for="(part, key) in gameStore.avatar.body_part"
+      :key="key"
+      :game-store="gameStore"
+      :part="part"
+      :part-key="key"
+    />
+
     <div :class="bubbleClasses" :style="bubbleStyles" class="bubble"></div>
 
     <!-- 主音频播放器 -->
@@ -32,6 +41,7 @@ import { useGameStore } from '@/stores/modules/game'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import { EMOTION_CONFIG, EMOTION_CONFIG_EMO } from '@/controllers/emotion/config'
 import './avatar-animation.css'
+import TouchAreas from './TouchAreas.vue'
 
 const gameStore = useGameStore()
 const uiStore = useUIStore()

--- a/frontend_vue/src/components/game/standard/TouchAreas.vue
+++ b/frontend_vue/src/components/game/standard/TouchAreas.vue
@@ -15,9 +15,6 @@
         class="polygon-shape"
       />
     </svg>
-
-    <!-- 触摸音效播放器 -->
-    <audio ref="touchAudio" preload="auto"></audio>
   </div>
 </template>
 
@@ -117,6 +114,10 @@ const isPointInPolygon = (x: number, y: number, polygon: readonly [number, numbe
 
 // 处理多边形点击
 const handlePolygonClick = (event: MouseEvent) => {
+  if (gameStore.command !== 'touch') {
+    return
+  }
+
   // 防抖检查：如果距离上次点击时间不足 debounceDelay 毫秒，则忽略此次点击
   const currentTime = Date.now()
   if (currentTime - lastClickTime.value < debounceDelay) {
@@ -197,7 +198,7 @@ onUnmounted(() => {
 @reference "tailwindcss";
 
 .touch-areas-container {
-  @apply fixed inset-0 pointer-events-none z-100;
+  @apply fixed inset-0 z-2 pointer-events-none;
 }
 
 .polygon-area {


### PR DESCRIPTION
## 📝 Description / 描述

fix: 由于新图层的加入，导致TouchArea的点击事件无法穿透到底层

### 🛠️ Modifications / 改动点

TouchArea的原理是一层遮罩层touch-areas-container并设置pointer-events-none让事件穿透，然后在polygon-area中捕获点击事件。原始设置z-index = 100, 新加图层的z-index = 2，优先级较高会先捕获，这样就不能继续传播了。

解决方式是设置touch-areas-container的z-index = 2。

如果以后万一需要加z-index = 3的全屏遮罩，也会有类似问题。

### 📸 Screenshots or Test Results / 运行截图或测试结果

修改前：


https://github.com/user-attachments/assets/258d95ad-527b-47c8-bca3-631ae58dab66

修改后：
---

https://github.com/user-attachments/assets/5ef3c355-c1d1-4210-9515-3efc2e0720b9



### ✅ Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.
