### PR TITLE
memorybank，超级拼装！

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ TRANSLATE_MODEL="qwen3-30b-a3b-instruct-2507" # 翻译模型（不建议修改�
 ## 对话功能设定 BEGIN # 配置RAG（检索增强生成）系统，让AI能“记忆”历史对话
 USE_RAG=false       # 是否启用RAG系统
 USE_TIME_SENSE=true # 是否启用时间感知
+USE_PERSISTENT_MEMORY=false # 是否启用“永久记忆/记忆压缩”（需用户显式开启） [type: bool]
+MEMORY_UPDATE_INTERVAL=250  # 多少条“可见台词”触发一次压缩（约等于旧50轮对话） [type: number]
+MEMORY_RECENT_WINDOW=15     # 压缩后保留多少条全局台词窗口用于衔接 [type: number]
 ## 对话功能设定 END
 
 # 基础设置 END

--- a/.github/workflows/test-with-conda.yml
+++ b/.github/workflows/test-with-conda.yml
@@ -50,7 +50,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           echo "Running on Linux"
-          conda run -n LingChat uv run pytest tests/ --cov=src -v
+          conda run -n LingChat uv run pytest tests/ --cov=ling_chat -v
 
       - name: Run tests on macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/test-with-conda.yml
+++ b/.github/workflows/test-with-conda.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Install uv
         run: |
           conda run -n LingChat pip install uv
+      - name: Install project (with deps)
+        run: |
+          # 安装当前项目及其依赖，避免 tests/import 阶段缺包（例如 sqlmodel/pyyaml 等）
+          conda run -n LingChat pip install -e .
       - name: Install test dependencies
         run: |
           conda run -n LingChat uv pip install pytest pytest-asyncio pytest-cov

--- a/.github/workflows/test-with-uv.yml
+++ b/.github/workflows/test-with-uv.yml
@@ -48,7 +48,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           echo "Running on Linux"
-          uv run pytest tests/ --cov=src -v
+          uv run pytest tests/ --cov=ling_chat -v
 
       - name: Run tests on macOS
         if: runner.os == 'macOS'

--- a/ling_chat/api/app_server.py
+++ b/ling_chat/api/app_server.py
@@ -19,7 +19,7 @@ from ling_chat.utils.runtime_path import user_data_path
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     try:
-        logger.info("正在初始化数据库...") # 骗你的其实不是在这里初始化的，在包被导入的时候自动初始化了
+        logger.info("正在初始化数据库...")
         init_db()
 
         logger.info("正在同步游戏角色数据...")

--- a/ling_chat/api/chat_history.py
+++ b/ling_chat/api/chat_history.py
@@ -7,6 +7,7 @@ from ling_chat.core.service_manager import service_manager
 from ling_chat.game_database.managers.save_manager import SaveManager
 from ling_chat.game_database.managers.user_manager import UserManager
 from ling_chat.game_database.managers.role_manager import RoleManager
+from ling_chat.game_database.managers.memory_manager import MemoryManager
 
 router = APIRouter(prefix="/api/v1/chat/history", tags=["Chat History"])
 
@@ -101,6 +102,8 @@ async def create_user_conversations(request: Request):
             # 让后端运行时与用户最近存档保持一致，便于 MemoryBank 持久化
             UserManager.update_last_save(user_id=user_id, save_id=save_id)
             service_manager.ai_service.set_active_save_id(save_id)
+            # 仅在“创建存档”时写入 MemoryBank
+            service_manager.ai_service.persist_memory_banks(save_id)
 
         # TODO: 根据 GameStatus 中的其他状态，更新 save 中的其他字段
 
@@ -152,6 +155,8 @@ async def save_user_conversation(request: Request):
         SaveManager.sync_lines(save_id=conversation_id, input_lines=line_list)
         # 维持当前激活存档（用于 MemoryBank 自动压缩）
         service_manager.ai_service.set_active_save_id(conversation_id)
+        # 仅在“保存存档”时写入 MemoryBank
+        service_manager.ai_service.persist_memory_banks(conversation_id)
 
 
         # 如果需要更新标题
@@ -205,6 +210,12 @@ async def delete_user_conversation(request: Request):
 
         if not deleted:
             raise HTTPException(status_code=404, detail="对话不存在或已被删除")
+
+        # 同步删除 MemoryBank
+        try:
+            MemoryManager.delete_memories_by_save(conversation_id)
+        except Exception:
+            pass
 
         return {
             "code": 200,

--- a/ling_chat/api/chat_history.py
+++ b/ling_chat/api/chat_history.py
@@ -54,7 +54,7 @@ async def load_user_conversations(user_id: int, conversation_id: int):
             character_settings["character_id"] = role_id
             if service_manager.ai_service is not None:
                 service_manager.ai_service.import_settings(settings=character_settings)
-                service_manager.ai_service.load_lines(line_list, role_id)
+                service_manager.ai_service.load_lines(line_list, role_id, save_id=conversation_id)
 
             print("成功调用记忆存储")
             return {
@@ -98,6 +98,9 @@ async def create_user_conversations(request: Request):
         if save_id:
             SaveManager.sync_lines(save_id,line_list)
             SaveManager.update_save_main_role(save_id, service_manager.ai_service.game_status.main_role.role_id)
+            # 让后端运行时与用户最近存档保持一致，便于 MemoryBank 持久化
+            UserManager.update_last_save(user_id=user_id, save_id=save_id)
+            service_manager.ai_service.set_active_save_id(save_id)
 
         # TODO: 根据 GameStatus 中的其他状态，更新 save 中的其他字段
 
@@ -147,6 +150,8 @@ async def save_user_conversation(request: Request):
         # 获取当前消息记忆
         line_list = service_manager.ai_service.get_lines()
         SaveManager.sync_lines(save_id=conversation_id, input_lines=line_list)
+        # 维持当前激活存档（用于 MemoryBank 自动压缩）
+        service_manager.ai_service.set_active_save_id(conversation_id)
 
 
         # 如果需要更新标题

--- a/ling_chat/core/ai_service/core.py
+++ b/ling_chat/core/ai_service/core.py
@@ -155,9 +155,17 @@ class AIService:
     def get_lines(self):
         return self.game_status.line_list
     
-    def load_lines(self, lines:list[GameLine], main_role_id: int):
+    def set_active_save_id(self, save_id: int | None):
+        """
+        设置当前激活存档，用于 MemoryBank 持久化/自动压缩等逻辑。
+        """
+        self.game_status.active_save_id = save_id
+
+    def load_lines(self, lines:list[GameLine], main_role_id: int, save_id: int | None = None):
         self.game_status.line_list = lines
-        self.game_status.role_manager.sync_memories(self.game_status.line_list)
+        if save_id is not None:
+            self.set_active_save_id(save_id)
+        self.game_status.role_manager.sync_memories(self.game_status.line_list, save_id=self.game_status.active_save_id)
         main_role = self.game_status.role_manager.get_role(role_id=main_role_id)
 
         if main_role:

--- a/ling_chat/core/ai_service/core.py
+++ b/ling_chat/core/ai_service/core.py
@@ -165,7 +165,15 @@ class AIService:
         self.game_status.line_list = lines
         if save_id is not None:
             self.set_active_save_id(save_id)
-        self.game_status.role_manager.sync_memories(self.game_status.line_list, save_id=self.game_status.active_save_id)
+            # 仅在“载入存档”时从 DB 载入 MemoryBank 到运行时缓存
+            involved_role_ids = set()
+            for line in self.game_status.line_list:
+                if line.sender_role_id:
+                    involved_role_ids.add(line.sender_role_id)
+                involved_role_ids.update(line.perceived_role_ids or [])
+            self.game_status.role_manager.load_memory_banks_from_db(save_id, list(involved_role_ids))
+
+        self.game_status.role_manager.sync_memories(self.game_status.line_list)
         main_role = self.game_status.role_manager.get_role(role_id=main_role_id)
 
         if main_role:
@@ -177,6 +185,12 @@ class AIService:
 
     def reset_lines(self):
         self._init_game_status()
+
+    def persist_memory_banks(self, save_id: int):
+        """
+        将运行时的 memory_bank 缓存写入 DB（仅在创建/保存存档时调用）。
+        """
+        self.game_status.role_manager.persist_memory_banks_to_db(save_id)
     
     def _init_game_status(self):
         self.game_status.line_list = []

--- a/ling_chat/core/ai_service/game_system/game_status.py
+++ b/ling_chat/core/ai_service/game_system/game_status.py
@@ -34,6 +34,9 @@ class GameStatus:
     # 剧本模式中记录的额外信息
     script_status: Optional[ScriptStatus] = None
 
+    # 当前激活的存档ID（用于 MemoryBank 持久化/载入/自动压缩）
+    active_save_id: Optional[int] = None
+
     def add_line(self, line: LineBase):
         # 转换为GameLine
         game_line = GameLine(
@@ -46,4 +49,4 @@ class GameStatus:
         self.refresh_memories()
     
     def refresh_memories(self):
-        self.role_manager.sync_memories(self.line_list)
+        self.role_manager.sync_memories(self.line_list, save_id=self.active_save_id)

--- a/ling_chat/core/ai_service/game_system/game_status.py
+++ b/ling_chat/core/ai_service/game_system/game_status.py
@@ -49,4 +49,5 @@ class GameStatus:
         self.refresh_memories()
     
     def refresh_memories(self):
-        self.role_manager.sync_memories(self.line_list, save_id=self.active_save_id)
+        # 自动压缩只写入运行时缓存，不触发 DB
+        self.role_manager.sync_memories(self.line_list)

--- a/ling_chat/core/ai_service/game_system/memory_builder.py
+++ b/ling_chat/core/ai_service/game_system/memory_builder.py
@@ -86,10 +86,15 @@ class MemoryBuilder:
                 # 处理 User + Context 混合块
                 split_index = len(current_buffer)
                 for i in range(len(current_buffer) - 1, -1, -1):
-                    if current_buffer[i].attribute != 'user':
+                    a = current_buffer[i].attribute
+                    try:
+                        a_val = a.value
+                    except Exception:
+                        a_val = str(a)
+                    if a_val != 'user':
                         split_index = i + 1
                         break
-                    if i == 0 and current_buffer[i].attribute == 'user':
+                    if i == 0 and a_val == 'user':
                         split_index = 0
 
                 context_lines = current_buffer[:split_index]
@@ -119,11 +124,18 @@ class MemoryBuilder:
             current_buffer = []
             buffer_type = None
 
+        def _attr_value(line: GameLine) -> str:
+            a = line.attribute
+            try:
+                return a.value
+            except Exception:
+                return str(a)
+
         for line in lines:
-            line_obj = line # Type hinting alias
+            line_obj = line
             
             # System 处理
-            if line.attribute == 'system':
+            if _attr_value(line) == 'system':
                 # 系统消息只有感知到了才添加
                 if self._is_target(line_obj):
                     flush_buffer()

--- a/ling_chat/core/ai_service/game_system/persistent_memory_system.py
+++ b/ling_chat/core/ai_service/game_system/persistent_memory_system.py
@@ -1,0 +1,273 @@
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+import os
+
+from ling_chat.core.llm_providers.manager import LLMManager
+from ling_chat.core.logger import TermColors, logger
+from ling_chat.game_database.managers.memory_manager import MemoryManager
+
+
+def _safe_read_int(key: str, default: int) -> int:
+    try:
+        return int(os.environ.get(key, default))
+    except Exception:
+        return default
+
+
+@dataclass
+class PersistentMemoryMeta:
+    """
+    使用全局 line_list 的索引作为“已归档指针”，避免依赖 DB line_id（运行时可能为 None）。
+    """
+    last_processed_global_idx: int = 0
+    updated_at: str = ""
+
+
+class PersistentMemorySystem:
+    """
+    面向 0.4.0 新架构的“永久记忆（MemoryBank）+ 自动压缩”实现：
+    - key = (save_id, role_id)，保证多人物独立
+    - 当累计新台词达到阈值（默认 50）时，触发后台 LLM 总结并写回 DB MemoryBank
+    - 对 LLM 上下文：在角色 system prompt 之后插入 memory_bank 文本，并裁剪历史台词窗口
+    """
+
+    def __init__(self, save_id: int, role_id: int):
+        self.save_id = save_id
+        self.role_id = role_id
+
+        # 多少条“全局新增台词”触发一次总结
+        self.update_interval = _safe_read_int("MEMORY_UPDATE_INTERVAL", 50)
+        # 总结后保留多少条“全局台词”作为上下文重叠窗口
+        self.recent_window = _safe_read_int("MEMORY_RECENT_WINDOW", 15)
+
+        self.is_updating = False
+        self.meta = PersistentMemoryMeta()
+
+        self.memory_data: Dict[str, str] = {
+            "short_term": "暂无近期对话摘要。",
+            "long_term": "暂无长期关键经历。",
+            "user_info": "暂无用户特征记录。",
+            "promises": "暂无未完成的约定。",
+        }
+
+        self._memory_row_id: Optional[int] = None
+        self._llm = LLMManager()
+        self._init_prompts()
+        self._load_from_db()
+
+    def _init_prompts(self) -> None:
+        base_role = (
+            "你是一个专业的【记忆档案管理员】。你的任务是基于【旧的记忆档案】和【新增的对话日志】，"
+            "生成一份更新后的、逻辑连贯的记忆文本。\n"
+            "通用规则：\n"
+            "1. 视角：必须严格使用【第三人称】（例如：'用户提到...'，'AI感到...'）。\n"
+            "2. 时态：使用陈述语气，客观记录事实。\n"
+            "3. 输出：直接输出更新后的内容本身，不要包含任何解释。\n"
+            "4. 逻辑：如果没有新信息需要更新，请原样保留【旧的记忆档案】的内容。\n"
+        )
+
+        self.section_prompts: Dict[str, str] = {
+            "short_term": (
+                f"{base_role}\n"
+                "【任务目标】：生成一份【短期上下文摘要】，用于在下一次对话中承接话题。\n"
+                "【处理逻辑】：\n"
+                "1. 概括话题：他们刚才在聊什么？话题是否已经结束？\n"
+                "2. 捕捉氛围：当前的对话气氛如何？\n"
+                "3. 遗忘机制：删除旧记忆中已经过时、结束或不再相关的琐碎细节。\n"
+                "4. 篇幅控制：保持在 100-200 字以内。\n"
+            ),
+            "long_term": (
+                f"{base_role}\n"
+                "【任务目标】：编撰一份【角色经历编年史】，记录具有长期价值的核心事件。\n"
+                "【处理逻辑】：\n"
+                "1. 过滤噪音：忽略日常问候和闲聊。\n"
+                "2. 提取事件：只记录具有里程碑意义的事件。\n"
+                "3. 累积更新：将新发生的关键事件追加到旧档案中。\n"
+            ),
+            "user_info": (
+                f"{base_role}\n"
+                "【任务目标】：更新【用户画像】，确保 AI 了解屏幕对面的人。\n"
+                "【处理逻辑】：\n"
+                "1. 事实提取：提取用户的姓名、年龄、职业、喜好、雷点等。\n"
+                "2. 冲突修正：如果信息冲突（如换了工作），以【新增对话】为准。\n"
+            ),
+            "promises": (
+                f"{base_role}\n"
+                "【任务目标】：维护一份【待办与契约清单】。\n"
+                "【处理逻辑】：\n"
+                "1. 新增约定：提取对话中明确达成的承诺。\n"
+                "2. 状态核销：如果能够在【新增对话】中找到已完成的证据，从清单中【删除】该条目。\n"
+            ),
+        }
+
+    def _load_from_db(self) -> None:
+        try:
+            memory = MemoryManager.get_latest_memory(save_id=self.save_id, role_id=self.role_id)
+            if not memory:
+                return
+            self._memory_row_id = memory.id
+            info = memory.info or {}
+            data = info.get("data") or {}
+            meta = info.get("meta") or {}
+
+            # 容错：不同版本字段名
+            self.memory_data.update({k: str(v) for k, v in data.items() if k in self.memory_data})
+            self.meta.last_processed_global_idx = int(meta.get("last_processed_global_idx", 0) or 0)
+            self.meta.updated_at = str(meta.get("updated_at", "") or "")
+        except Exception as e:
+            logger.error(f"PersistentMemorySystem: 加载 MemoryBank 失败: {e}", exc_info=True)
+
+    def _persist_to_db(self) -> None:
+        info = {
+            "schema_version": 1,
+            "meta": {
+                "last_processed_global_idx": self.meta.last_processed_global_idx,
+                "updated_at": self.meta.updated_at,
+            },
+            "data": dict(self.memory_data),
+        }
+        try:
+            self._memory_row_id = MemoryManager.upsert_memory(
+                save_id=self.save_id,
+                role_id=self.role_id,
+                info=info,
+                memory_id=self._memory_row_id,
+            ).id
+        except Exception as e:
+            logger.error(f"PersistentMemorySystem: 保存 MemoryBank 失败: {e}", exc_info=True)
+
+    def get_memory_prompt(self) -> str:
+        return (
+            "\n====== 核心记忆库 (Memory Bank) ======\n"
+            f"【用户信息】：{self.memory_data.get('user_info', '')}\n"
+            f"【重要约定】：{self.memory_data.get('promises', '')}\n"
+            f"【长期经历】：{self.memory_data.get('long_term', '')}\n"
+            f"【近期回顾】：{self.memory_data.get('short_term', '')}\n"
+            "====================================\n"
+        )
+
+    def get_slice_start_index(self) -> int:
+        """
+        返回给 GameRoleManager 用于裁剪 line_list 的起点。
+        注意：这里用的是全局 line_list 索引窗口（而不是“可见台词数”窗口），简化实现并保持稳定。
+        """
+        return max(0, self.meta.last_processed_global_idx - self.recent_window)
+
+    def check_and_trigger_auto_update(self, all_lines: List[Any]) -> None:
+        if self.is_updating:
+            return
+
+        current_total = len(all_lines)
+        # 取出这段区间的可见台词文本（只总结“该角色说过/听到过”的内容）
+        new_lines = all_lines[self.meta.last_processed_global_idx:current_total]
+        chat_text, visible_count = self._build_chat_text_and_count(new_lines)
+        target_idx = current_total
+
+        # 以“该角色可见台词数”作为触发条件（多人物同剧本时确保每个角色独立计数）
+        if visible_count < self.update_interval:
+            return
+
+        if not chat_text.strip():
+            # 这段区间对该角色完全不可见，直接移动指针，避免无限触发
+            self.meta.last_processed_global_idx = target_idx
+            self.meta.updated_at = time.strftime("%Y-%m-%d %H:%M:%S")
+            self._persist_to_db()
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # 没有 event loop（例如同步调用），跳过异步压缩
+            logger.debug("PersistentMemorySystem: 当前无事件循环，跳过自动压缩触发。")
+            return
+
+        logger.info_color(
+            f"MemoryBank: role_id={self.role_id} 累积未归档可见台词 {visible_count} 条 (阈值 {self.update_interval})，触发自动压缩...",
+            TermColors.YELLOW,
+        )
+        self.is_updating = True
+        asyncio.create_task(self._run_update_pipeline(loop, chat_text, target_idx))
+
+    def _build_chat_text_and_count(self, lines: List[Any]) -> Tuple[str, int]:
+        """
+        将 GameLine 列表转换为“User/AI: ...”日志。
+        规则：
+        - 忽略 system 台词（system 主要用于 persona/prompt，不参与摘要）
+        - 对该角色来说：自己说的 => AI；别人说的（且可见）=> User
+        - 只纳入“可见台词”：sender == role_id 或 role_id in perceived_role_ids
+        """
+        chunks: List[str] = []
+        visible_count = 0
+        for line in lines:
+            try:
+                if getattr(line, "attribute", None) == "system":
+                    continue
+
+                sender_role_id = getattr(line, "sender_role_id", None)
+                perceived_ids = getattr(line, "perceived_role_ids", []) or []
+
+                is_visible = (sender_role_id == self.role_id) or (self.role_id in perceived_ids)
+                if not is_visible:
+                    continue
+
+                content = (getattr(line, "content", "") or "").strip()
+                if not content:
+                    continue
+
+                role = "AI" if sender_role_id == self.role_id else "User"
+                chunks.append(f"{role}: {content}")
+                visible_count += 1
+            except Exception:
+                continue
+
+        return ("\n".join(chunks) + ("\n" if chunks else "")), visible_count
+
+    async def _run_update_pipeline(self, loop: asyncio.AbstractEventLoop, chat_text: str, new_total_idx: int) -> None:
+        try:
+            logger.info(
+                f"MemoryBank: 开始处理记忆压缩 role_id={self.role_id} (范围: {self.meta.last_processed_global_idx} -> {new_total_idx})..."
+            )
+            start_time = time.time()
+
+            async def update_section(section_key: str) -> Tuple[str, str]:
+                old_content = self.memory_data.get(section_key, "")
+                prompt_req = self.section_prompts[section_key]
+
+                full_prompt = (
+                    f"{prompt_req}\n\n"
+                    f"【旧内容】：\n{old_content}\n\n"
+                    f"【新增对话】：\n{chat_text}\n\n"
+                    "【新内容】(直接输出结果，不要废话)："
+                )
+
+                messages = [{"role": "user", "content": full_prompt}]
+                response = await loop.run_in_executor(None, self._llm.process_message, messages)
+                cleaned = (response or "").strip()
+                return section_key, (cleaned if cleaned else old_content)
+
+            tasks = [
+                update_section("short_term"),
+                update_section("long_term"),
+                update_section("user_info"),
+                update_section("promises"),
+            ]
+
+            results = await asyncio.gather(*tasks)
+            for key, new_val in results:
+                self.memory_data[key] = new_val
+
+            self.meta.last_processed_global_idx = new_total_idx
+            self.meta.updated_at = time.strftime("%Y-%m-%d %H:%M:%S")
+            self._persist_to_db()
+
+            logger.info_color(
+                f"MemoryBank: role_id={self.role_id} 记忆库更新完成! 指针已移动至 {self.meta.last_processed_global_idx}，耗时 {time.time() - start_time:.2f}s",
+                TermColors.GREEN,
+            )
+        except Exception as e:
+            logger.error(f"MemoryBank 更新流水线严重错误: {e}", exc_info=True)
+        finally:
+            self.is_updating = False
+

--- a/ling_chat/core/ai_service/game_system/role_manager.py
+++ b/ling_chat/core/ai_service/game_system/role_manager.py
@@ -63,11 +63,12 @@ class GameRoleManager:
             short_term_prefix = ""
             try:
                 mb = self._get_memory_bank_system(role)
-                # 触发后台自动压缩
-                mb.check_and_trigger_auto_update(source_lines)
-                slice_start_idx = mb.get_slice_start_index()
-                system_addendum = mb.get_system_memory_text()
-                short_term_prefix = mb.get_short_term_user_text()
+                # 只有用户显式开启永久记忆时才触发自动压缩
+                if mb.is_enabled():
+                    mb.check_and_trigger_auto_update(source_lines)
+                    slice_start_idx = mb.get_slice_start_index()
+                    system_addendum = mb.get_system_memory_text()
+                    short_term_prefix = mb.get_short_term_user_text()
             except Exception as e:
                 logger.error(f"MemoryBank: role_id={rid} 初始化/更新失败: {e}", exc_info=True)
 

--- a/ling_chat/core/ai_service/type.py
+++ b/ling_chat/core/ai_service/type.py
@@ -1,5 +1,95 @@
-from dataclasses import dataclass, field
-from typing import Optional, List, Dict, Any
+from dataclasses import dataclass, field, asdict
+from typing import Optional, List, Dict, Any, Self
+
+
+@dataclass
+class GameMemoryBankMeta:
+    """
+    MemoryBank 元信息（运行时缓存与 DB JSON 共用）
+    - last_processed_global_idx: 用全局 line_list 的索引作为“已归档指针”
+    """
+    last_processed_global_idx: int = 0
+    updated_at: str = ""
+
+    def model_dump(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def model_validate(cls, obj: Dict[str, Any] | None) -> "GameMemoryBankMeta":
+        obj = obj or {}
+        return cls(
+            last_processed_global_idx=int(obj.get("last_processed_global_idx", 0) or 0),
+            updated_at=str(obj.get("updated_at", "") or ""),
+        )
+
+
+@dataclass
+class GameMemoryBankData:
+    """
+    MemoryBank 的结构化正文。
+    """
+    short_term: str = "暂无近期对话摘要。"
+    long_term: str = "暂无长期关键经历。"
+    user_info: str = "暂无用户特征记录。"
+    promises: str = "暂无未完成的约定。"
+
+    def model_dump(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def model_validate(cls, obj: Dict[str, Any] | None) -> "GameMemoryBankData":
+        obj = obj or {}
+        return cls(
+            short_term=str(obj.get("short_term", cls().short_term) or cls().short_term),
+            long_term=str(obj.get("long_term", cls().long_term) or cls().long_term),
+            user_info=str(obj.get("user_info", cls().user_info) or cls().user_info),
+            promises=str(obj.get("promises", cls().promises) or cls().promises),
+        )
+
+
+@dataclass
+class GameMemoryBank:
+    """
+    运行时缓存用的 MemoryBank 结构。
+    约定：与 DB MemoryBank.info 的 JSON 结构保持一致：
+    {
+      "schema_version": 1,
+      "meta": {...},
+      "data": {...}
+    }
+    """
+    schema_version: int = 1
+    meta: GameMemoryBankMeta = field(default_factory=GameMemoryBankMeta)
+    data: GameMemoryBankData = field(default_factory=GameMemoryBankData)
+
+    def model_dump(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "meta": self.meta.model_dump(),
+            "data": self.data.model_dump(),
+        }
+
+    @classmethod
+    def model_validate(cls, obj: Dict[str, Any] | None) -> "GameMemoryBank":
+        obj = obj or {}
+        schema_version = int(obj.get("schema_version", 1) or 1)
+        meta = GameMemoryBankMeta.model_validate(obj.get("meta"))
+        data = GameMemoryBankData.model_validate(obj.get("data"))
+        return cls(schema_version=schema_version, meta=meta, data=data)
+
+    def to_prompt_text(self) -> str:
+        """
+        将结构化记忆渲染为注入到 system prompt 的文本。
+        注意：为了保持 LLM 消息结构标准，推荐“合并进同一条 system”，而不是新增 system 消息。
+        """
+        return (
+            "\n\n====== 核心记忆库 (Memory Bank) ======\n"
+            f"【用户信息】：{self.data.user_info}\n"
+            f"【重要约定】：{self.data.promises}\n"
+            f"【长期经历】：{self.data.long_term}\n"
+            f"【近期回顾】：{self.data.short_term}\n"
+            "====================================\n"
+        )
 
 @dataclass
 class GameRole:
@@ -15,7 +105,7 @@ class GameRole:
     settings: dict = field(default_factory=dict)
     resource_path: Optional[str] = None
     prompt: Optional[str] = None
-    memory_bank: dict = field(default_factory=dict)
+    memory_bank: GameMemoryBank = field(default_factory=GameMemoryBank)
     
     def __hash__(self):
         # Hash based on role_id if present, otherwise id of object

--- a/ling_chat/game_database/__init__.py
+++ b/ling_chat/game_database/__init__.py
@@ -1,4 +1,13 @@
-from ling_chat.game_database.database import init_db
+"""
+game_database 包初始化。
 
-# TODO: 包被导入的时候自动初始化数据库，不过这个逻辑建议还是直接在main中实现吧？
-init_db()
+注意：不要在 import 时自动初始化/建库。
+原因：
+- import 发生在非常多的场景（例如 pytest 收集测试、类型检查、只读工具等）
+- 自动建库会触发文件系统写入与数据库连接，在 CI/只读环境中容易失败
+
+正确姿势：在应用启动生命周期中显式调用 `ling_chat.game_database.database.init_db()`，
+例如 `ling_chat/api/app_server.py` 的 lifespan。
+"""
+
+from ling_chat.game_database.database import init_db  # noqa: F401

--- a/ling_chat/game_database/managers/memory_manager.py
+++ b/ling_chat/game_database/managers/memory_manager.py
@@ -172,3 +172,18 @@ class MemoryManager:
             
             session.commit()
             return count
+
+    @staticmethod
+    def delete_memories_by_save(save_id: int) -> int:
+        """
+        删除某个存档下的所有 MemoryBank 记录。
+        仅建议在“删除存档”时调用，避免误删。
+        """
+        with Session(engine, expire_on_commit=False) as session:
+            stmt = select(MemoryBank).where(MemoryBank.save_id == save_id)
+            memories = session.exec(stmt).all()
+            count = len(memories)
+            for memory in memories:
+                session.delete(memory)
+            session.commit()
+            return count

--- a/ling_chat/game_database/managers/memory_manager.py
+++ b/ling_chat/game_database/managers/memory_manager.py
@@ -1,5 +1,5 @@
 from typing import List, Optional, Dict, Any
-from sqlmodel import Session, select
+from sqlmodel import Session, select, desc
 from ling_chat.game_database.database import engine
 from ling_chat.game_database.models import MemoryBank
 
@@ -50,6 +50,62 @@ class MemoryManager:
                 stmt = stmt.where(MemoryBank.role_id == role_id)
             
             return session.exec(stmt).all()
+
+    @staticmethod
+    def get_latest_memory(save_id: int, role_id: int) -> Optional[MemoryBank]:
+        """
+        获取某个存档下某个角色最新的一条 MemoryBank 记录。
+        约定：同 (save_id, role_id) 通常只会维护一条记录；若历史上出现多条，则取 id 最大者。
+        """
+        with Session(engine, expire_on_commit=False) as session:
+            stmt = (
+                select(MemoryBank)
+                .where(MemoryBank.save_id == save_id)
+                .where(MemoryBank.role_id == role_id)
+                .order_by(desc(MemoryBank.id))
+                .limit(1)
+            )
+            return session.exec(stmt).first()
+
+    @staticmethod
+    def upsert_memory(
+        save_id: int,
+        role_id: int,
+        info: Dict[str, Any],
+        memory_id: Optional[int] = None,
+    ) -> MemoryBank:
+        """
+        Upsert：优先按 memory_id 更新；否则按 (save_id, role_id) 查找最新记录更新；仍不存在则创建。
+        """
+        with Session(engine, expire_on_commit=False) as session:
+            memory: Optional[MemoryBank] = None
+
+            if memory_id is not None:
+                memory = session.get(MemoryBank, memory_id)
+
+            if memory is None:
+                stmt = (
+                    select(MemoryBank)
+                    .where(MemoryBank.save_id == save_id)
+                    .where(MemoryBank.role_id == role_id)
+                    .order_by(desc(MemoryBank.id))
+                    .limit(1)
+                )
+                memory = session.exec(stmt).first()
+
+            if memory is None:
+                memory = MemoryBank(save_id=save_id, role_id=role_id, info=info)
+                session.add(memory)
+                session.commit()
+                session.refresh(memory)
+                return memory
+
+            memory.info = info
+            memory.role_id = role_id
+            session.add(memory)
+            session.commit()
+            session.refresh(memory)
+            return memory
 
     @staticmethod
     def update_memory(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,42 @@
+from ling_chat.core.ai_service.type import GameMemoryBank, GameRole
+from ling_chat.core.ai_service.game_system.role_manager import GameRoleManager
+
+
+def test_memory_bank_roundtrip():
+    mb = GameMemoryBank()
+    dumped = mb.model_dump()
+    loaded = GameMemoryBank.model_validate(dumped)
+    assert loaded.model_dump() == dumped
+
+
+def test_merge_memory_bank_keeps_single_system():
+    mgr = GameRoleManager()
+
+    memory = [
+        {"role": "system", "content": "persona"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+
+    merged = mgr._merge_memory_bank_into_context(  # noqa: SLF001 (test private helper)
+        memory,
+        system_addendum="\n\n[MB] long term",
+        short_term_prefix="[MB] short term\n",
+    )
+
+    # 仍然只有一个 system（合并到同一条）
+    assert sum(1 for m in merged if m.get("role") == "system") == 1
+    assert merged[0]["role"] == "system"
+    assert "persona" in merged[0]["content"]
+    assert "[MB] long term" in merged[0]["content"]
+
+    # short term 被拼到 user 前缀
+    user_msgs = [m for m in merged if m.get("role") == "user"]
+    assert user_msgs
+    assert user_msgs[0]["content"].startswith("[MB] short term")
+
+
+def test_game_role_has_typed_memory_bank():
+    role = GameRole(role_id=1)
+    assert isinstance(role.memory_bank, GameMemoryBank)
+


### PR DESCRIPTION
## 📝 Description / 描述

本次更新把历史上放在 `rag_manager.py`/`MemorySystem` 里的“结构化记忆库 + 自动压缩”思路，迁移并正式接入 0.4.0 新架构（台词表 `line_list` → `MemoryBuilder` → 角色上下文），让**剧本模式/多人物同剧本**下每个角色都能拥有独立的永久记忆，并在该角色可见上下文超过阈值（默认 50 条）时自动进行上下文压缩，避免上下文无限膨胀。

这是一项“基础设施级”改造：对外表现为对话越来越长时不再爆上下文，并且角色能持续带着结构化的长期记忆推进剧情。

---

### 🛠️ Modifications / 改动点

**新增模块： `ling_chat/core/ai_service/game_system/persistent_memory_system.py`**

 - 新的 `PersistentMemorySystem`：以 `(save_id, role_id)` 为 key 的永久记忆系统，负责：从 DB 读取/写入 `MemoryBank`、累计计数、触发后台压缩、生成注入用的 MemoryBank prompt、提供裁剪窗口起点

**数据库访问层增强：`ling_chat/game_database/managers/memory_manager.py`**

 - 新增 `get_latest_memory(save_id, role_id)`：取某存档某角色最新一条 MemoryBank
 - 新增 `upsert_memory(save_id, role_id, info, memory_id=None)`：按 memory_id 或 (save_id, role_id) 更新/创建

**运行时记忆构建链路接入：`ling_chat/core/ai_service/game_system/game_status.py`与`ling_chat/core/ai_service/game_system/role_manager.py`**
- 新增 `active_save_id`（当前激活存档 ID）
- `refresh_memories()` 透传 `save_id` 给 `GameRoleManager.sync_memories(...)`
- `sync_memories(..., save_id: Optional[int])`：在 `MemoryBuilder` 前接入：
    - 触发 `PersistentMemorySystem.check_and_trigger_auto_update(...)`（达到阈值才会调用 LLM 压缩）
    - 将 MemoryBank prompt 以 `system` 消息注入到该角色的上下文中（插在角色人设 system 后）
    - 按 `recent_window` 裁剪台词，避免上下文无限增长
 - 将 DB 记忆结构镜像到 `game_role.memory_bank`（便于调试/命令查看）

**存档链路贯通 save_id：`ling_chat/core/ai_service/core.py`与`ling_chat/api/chat_history.py`**

 - 新增 `AIService.set_active_save_id(save_id)`
 - `AIService.load_lines(..., save_id=None)` 支持传入存档 ID，并触发带 `save_id` 的 `sync_memories`
 - `GET /api/v1/chat/history/load`：加载存档时把 `conversation_id` 传入 `AIService.load_lines(..., save_id=conversation_id)`
 - `POST /api/v1/chat/history/create`：创建存档后同步设置 `active_save_id`
 - `POST /api/v1/chat/history/save`：保存时维持 `active_save_id`

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。  
  - 说明：新增参数均为 Optional 且提供默认值；原调用不需要改动即可继续运行（但不传 `save_id` 则不会落库 MemoryBank）。

---

### ✅ 设计要点
- **独立计数的定义**  
  “超过 50 条触发压缩”不是看“发送给 LLM 的总上下文条数”，而是看：
  - 从 `meta.last_processed_global_idx` 到当前 `line_list` 末尾这段“新增区间”里
  - **对该角色可见**（自己说的或在 `perceived_role_ids` 中）的台词数量 `visible_count`
  - `visible_count >= MEMORY_UPDATE_INTERVAL` 才触发压缩  
  这保证了多人物同剧本时每个人物独立触发，不会互相污染，也不会每次 +1 就压缩。

- **压缩写入 DB 的 schema（MemoryBank.info）**
  - `schema_version: 1`
  - `meta.last_processed_global_idx`: int（全局台词索引指针）
  - `meta.updated_at`: str
  - `data.short_term / long_term / user_info / promises`: str  
  说明：这是“公告级”约定，后续如要升级 schema 请显式 bump `schema_version` 并做兼容读取。

- **上下文注入位置**
  - 若 `MemoryBuilder.build()` 产物第一条是 `system`（角色人设），则 MemoryBank 作为第二条插入
  - 否则 MemoryBank 作为第一条 `system` 插入  
  目的：**不覆盖人设 prompt**，且保证每次对话都能带上长期记忆。

---

### 🔧 配置项（环境变量）
- `MEMORY_UPDATE_INTERVAL`：触发阈值，默认 **50**
- `MEMORY_RECENT_WINDOW`：压缩后保留的衔接窗口，默认 **15**

---

### 📌 函数与接口使用须知
- 后端“当前存档”必须明确
  MemoryBank 是按 `(save_id, role_id)` 存的，因此：
  - 加载存档后必须设置 `active_save_id`
  - 创建/保存存档也应更新 `active_save_id`  
  本次已在 `chat_history` 的 `load/create/save` 里做了贯通；如果你在其他入口（例如未来新增的剧本存档恢复接口）绕过了这些 API，记得补同样的设置逻辑。

- **如何读取某角色当前永久记忆（运行时）**
  - `game_status.role_manager.get_role(role_id).memory_bank`  
  这里是 DB 结构的镜像，主要用于调试/展示。

- **数据库层直接操作**
  - 推荐仅通过 `MemoryManager.upsert_memory(...)`、`get_latest_memory(...)` 维护  
  - 不建议业务侧自己拼 SQL 或散落多处写入，避免 schema 漂移
---

### ✅ Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.
