### PR TITLE
fix: 修复剧本对话模式下翻译器同步阻塞与管道清理超时导致的前端卡死

### DIFF
--- a/ling_chat/core/ai_service/message_system/message_generator.py
+++ b/ling_chat/core/ai_service/message_system/message_generator.py
@@ -68,7 +68,6 @@ class MessageGenerator:
 
             logger.debug(f"句子处理时间: {end_time - start_time} 秒")
 
-    # 主方法现在充当协调器角色
     async def process_message_stream(
         self,
         user_message: Optional[str] = None,
@@ -84,7 +83,7 @@ class MessageGenerator:
         current_context = []
 
         line = None
-        # 1. 处理用户消息，提取临时指令，构建台词
+        # 2. 处理用户消息，提取临时指令，构建台词
         if user_message is not None:
             processed_user_message_dict = (
                 await self.message_processor.append_user_message(user_message)
@@ -200,15 +199,32 @@ class MessageGenerator:
             # 当上面的while循环完成时，生产者任务也必须完成
             accumulated_response = await producer_task
 
-            # 等待消费者完成队列中的任何剩余项目
-            await sentence_queue.join()
+            try:
+                cleanup_timeout = max(1, int(os.environ.get("PIPELINE_CLEANUP_TIMEOUT", "10")))
+            except (ValueError, TypeError):
+                cleanup_timeout = 10
+            try:
+                await asyncio.wait_for(sentence_queue.join(), timeout=cleanup_timeout)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"消费者处理超时（>{cleanup_timeout}s），跳过剩余队列，强制进入清理"
+                )
+                from ling_chat.core.messaging.broker import message_broker
+
+                timeout_msg = {
+                    "type": "error",
+                    "error_code": "voice_timeout",
+                    "detail": f"语音合成超时（>{cleanup_timeout}s），已跳过剩余语音生成",
+                }
+                for client_id in self.config.clients:
+                    await message_broker.publish(client_id, timeout_msg)
+
+            # 发布者任务在发送最终消息后应该已经完成
+            # 我们在finally块中等待所有任务以进行清理
 
             # 向消费者发送停止信号
             for _ in range(self.concurrency):
                 await sentence_queue.put(None)
-
-            # 发布者任务在发送最终消息后应该已经完成
-            # 我们在finally块中等待所有任务以进行清理
 
             # 6. 后续处理
             ai_name = ""
@@ -223,9 +239,6 @@ class MessageGenerator:
                     # self.game_status.line_list[append_line_index] = line 这行应该没必要
                     self.game_status.refresh_memories()
 
-                # if self.use_rag and self.rag_manager:
-                #     self.rag_manager.save_messages_to_rag(current_context)
-
                 self.ai_logger.log_conversation(ai_name, accumulated_response)
             else:
                 self.ai_logger.log_conversation(ai_name, "未生成响应。")
@@ -233,9 +246,9 @@ class MessageGenerator:
         except Exception as e:
             logger.error(f"消息流管道中发生错误: {e}", exc_info=True)
 
-            # 准备错误代码（前端负责翻译）
             from ling_chat.core.messaging.broker import message_broker
 
+            # 准备错误代码（前端负责翻译）
             error_message = str(e)
             error_code = "default_error"  # 默认错误代码
 

--- a/ling_chat/core/ai_service/translator.py
+++ b/ling_chat/core/ai_service/translator.py
@@ -36,9 +36,9 @@ class Translator:
             result += "<" + i["following_text"] + ">"
         return result
 
-    async def translate_ai_response(self, results: List[Dict], script: bool = True):
+    async def translate_ai_response(self, results: List[Dict]):
         """将中文翻译成日文并合成语音"""
-        if not self.enable_translate and not script:
+        if not self.enable_translate:
             return
 
         full_chinese_response: str = self.get_all_chinese_part(results)
@@ -51,12 +51,12 @@ class Translator:
         send_messages = self.messages.copy()
         send_messages.append({"role": "user", "content": full_chinese_response})
 
-        if os.environ.get("TRANSLATE_STREAM", "true") == "true" and not script:
-            # 流式处理
+        japanese_stream = self.translator_llm.process_message_stream(send_messages)
+
+        if os.environ.get("TRANSLATE_STREAM", "true") == "true":
+            # 流式处理 - 逐块翻译并实时生成语音
             buffer = ""
             current_segment_index = 0
-
-            japanese_stream = self.translator_llm.process_message_stream(send_messages)
 
             async for chunk in japanese_stream:
                 print(chunk, end="", flush=True)
@@ -87,12 +87,14 @@ class Translator:
 
                             current_segment_index += 1
         else:
-            # 非流式处理 - 等待完整响应
-            japanese_response = self.translator_llm.process_message(send_messages)
-            logger.info(f"完整日语翻译结果: {japanese_response}")
+            # 非流式处理 - 使用异步流式API收集完整响应，避免阻塞事件循环
+            full_response = ""
+            async for chunk in japanese_stream:
+                full_response += chunk
+            logger.info(f"完整日语翻译结果: {full_response}")
 
             # 解析完整响应并提取句子
-            buffer = japanese_response
+            buffer = full_response
             current_segment_index = 0
 
             # 处理完整响应中的所有句子


### PR DESCRIPTION
# 📝 描述
剧本对话模式下前端随机卡死，由两个独立问题引起：

问题一：翻译器同步阻塞事件循环
translate_ai_response() 的 script=True 默认参数强制走非流式路径，调用 WebLLMProvider.generate_response() 使用同步 OpenAI() 客户端发起 HTTP 请求，阻塞 asyncio 事件循环，WebSocket 无法收发数据。

问题二：管道退出清理无限等待
process_message_stream() 退出时 await sentence_queue.join() 等待所有消费者完成。TTS 语音合成走远程 API 时耗时不可控，脚本事件处理器被阻塞无法推进到下一事件。

# 🛠️ 改动点
## Fix 1：翻译器统一走异步流式路径 translator.py
- 移除 script 默认参数
- 非流式分支从同步 process_message() 改为异步 process_message_stream() 收集完整响应
- japanese_response = self.translator_llm.process_message(send_messages)   # 同步阻塞
+ japanese_stream = self.translator_llm.process_message_stream(send_messages)  # 异步非阻塞
## Fix 2：管道清理加超时保护 message_generator.py
- sentence_queue.join() 外层包裹 asyncio.wait_for，默认超时 10s
- 超时后发送 error_code: "voice_timeout" 通知前端
- 环境变量 PIPELINE_CLEANUP_TIMEOUT 可自定义阈值
- 非法值 fallback 到 10s，最小值 1s
- await sentence_queue.join()                              # 无限等待 TTS
+ await asyncio.wait_for(sentence_queue.join(), timeout=N) # 超时保护
This is NOT a breaking change.
# ✅ 检查清单
- [x] 我的更改经过了良好的测试
- [x] 我确保没有引入新依赖库
- [x] 我的更改没有引入恶意代码

Closes #402