### PR TITLE
feat: 为所有 Provider 补齐网络代理支持（扩展 #138）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,15 @@ GEMINI_MODEL_TYPE="gemini-2.5-flash" # （选填）Gemini 配置 - 模型
 GEMINI_PROXY_URL=""                  # （选填）Gemini 配置 - 代理地址
 ## LLM 模型设置 END
 
+## API 反代与网络代理 BEGIN # 当你无法直连 API 服务器时（例如使用机场），通过 *_PROXY_URL 让 LingChat 走代理。支持 http:// https:// socks5:// 格式。留空则直连。
+GLOBAL_PROXY_URL=""             # （选填）全局网络代理，所有 Provider 默认使用此代理
+LLM_PROXY_URL=""                # （选填）主 LLM 单独代理，留空则使用 GLOBAL_PROXY_URL
+TRANSLATE_PROXY_URL=""          # （选填）翻译 LLM 单独代理，留空则使用 GLOBAL_PROXY_URL
+VD_PROXY_URL=""                 # （选填）视觉模型单独代理，留空则使用 GLOBAL_PROXY_URL
+OLLAMA_PROXY_URL=""             # （选填）Ollama 单独代理，留空则使用 GLOBAL_PROXY_URL
+LMSTUDIO_PROXY_URL=""           # （选填）LM Studio 单独代理，留空则使用 GLOBAL_PROXY_URL
+## API 反代与网络代理 END
+
 ## 视觉模型设置 BEGIN # 配置 视觉模型相关的密钥和地址
 VD_API_KEY="sk-114514"                      # 图像识别模型的 API Key
 VD_BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1" # 视觉模型的 API 访问地址

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@
 
 ## ⭐ 快速上手
 
+官方教程视频：[B站-手把手教你安装LingChat~](https://www.bilibili.com/video/BV1PoRRBNEuG)
+
 ### Step -1: 选择适合的版本
 
-- 如果是Windows10 64位或者更高请使用最新版本`0.4.0 Pre`！
+- 如果是Windows10 64位或者更高请使用最新版本`0.4.1`！
 - 如果是32位机器请用兼容版喵~
 
 ### Step 0: 开始之前的准备

--- a/docs/manual/expand/proxy.md
+++ b/docs/manual/expand/proxy.md
@@ -1,0 +1,60 @@
+---
+title: 使用反代和网络代理
+description: 当你需要走中转商、自建反代或机场访问 LLM API 时，参考这里的配置方法。
+---
+
+# 🌐 使用反代和网络代理
+
+## 概念区分
+
+- **API 反代/中转**：把 `CHAT_BASE_URL` 等改成中转商或自建反代地址。这个功能已经支持，直接在设置里改对应的 `*_BASE_URL` 字段即可。
+- **网络代理**：当你无法直连 API 服务器时（比如用了机场），通过 `*_PROXY_URL` 让 LingChat 走代理。
+
+两者可以同时使用。
+
+## 配置方式
+
+在「设置 → 高级设置 → API 反代与网络代理」中填写：
+
+- `GLOBAL_PROXY_URL`：全局代理，所有模型默认走这个
+- `LLM_PROXY_URL`：主对话模型单独代理（留空则用全局）
+- `TRANSLATE_PROXY_URL`：翻译模型单独代理（留空则用全局）
+- `VD_PROXY_URL`：视觉模型单独代理（留空则用全局）
+- `OLLAMA_PROXY_URL`：Ollama 单独代理（留空则用全局）
+- `LMSTUDIO_PROXY_URL`：LM Studio 单独代理（留空则用全局）
+- `GEMINI_PROXY_URL`：Gemini 单独代理（留空则用全局）
+
+支持的格式：
+
+- `http://127.0.0.1:7890`
+- `http://user:pass@host:port`
+- `socks5://127.0.0.1:1080`
+
+::: tip 优先级
+单独的 `*_PROXY_URL` 优先于 `GLOBAL_PROXY_URL`。所有字段留空即视为不开代理，等同直连。
+:::
+
+## 常见场景
+
+### 场景 1：用机场（Clash / V2Ray 等）
+
+填 `GLOBAL_PROXY_URL=http://127.0.0.1:7890`（端口看你机场客户端的设置），所有模型都会走代理。
+
+### 场景 2：用国内中转商
+
+不需要填 `*_PROXY_URL`，直接把 `CHAT_BASE_URL` 改成中转商给的地址，`CHAT_API_KEY` 改成中转商给的 key。
+
+### 场景 3：自建反代（Cloudflare Worker / Vercel / Nginx）
+
+把 `CHAT_BASE_URL` 改成你的反代地址，API key 保持原版不变。如果反代部署在境外需要走代理访问，再填 `LLM_PROXY_URL`。
+
+### 场景 4：内网网关（LiteLLM / One-API）
+
+`CHAT_BASE_URL=http://192.168.x.x:4000/v1`，不需要代理。
+
+## 排查
+
+- 配置后不生效：确认点了"保存"，部分配置修改后即时生效无需重启
+- 持续超时：代理本身不通，先用浏览器确认代理能正常访问目标网站
+- 格式错误：确保带协议头（`http://` 或 `socks5://`）
+- 使用 `socks5://` 时若报错，说明 httpx 缺少 socks 依赖，可执行 `pip install "httpx[socks]"`

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -56,6 +56,7 @@ LingChat还有很多附加的强力功能！你可以查看额外功能了解与
 - [RAG 功能](/manual/expand/rag)：这是 LingChat 能够实现无限记忆的秘诀
 - [语音生成](/manual/expand/voice)：这可以给人物生成逼真的语音
 - [视觉功能](/manual/expand/vision)：这可以让人物看到你的桌面
+- [反代和网络代理](/manual/expand/proxy)：在你无法直连 API 的网络环境下让 LingChat 走代理
 
 ## 附属项目
 

--- a/ling_chat/core/ai_service/core.py
+++ b/ling_chat/core/ai_service/core.py
@@ -121,6 +121,17 @@ class AIService:
         仅在有相关键变动时做最小开销的重建。
         """
         try:
+            # 代理相关 key —— 任意一个变动都意味着相关 Provider 的网络配置需要重建
+            proxy_keys = {
+                "GLOBAL_PROXY_URL",
+                "LLM_PROXY_URL",
+                "TRANSLATE_PROXY_URL",
+                "VD_PROXY_URL",
+                "OLLAMA_PROXY_URL",
+                "LMSTUDIO_PROXY_URL",
+                "GEMINI_PROXY_URL",
+            }
+
             llm_keys = {
                 "LLM_PROVIDER",
                 "MODEL_TYPE",
@@ -130,11 +141,79 @@ class AIService:
                 "TRANSLATE_MODEL",
                 "TRANSLATE_API_KEY",
                 "TRANSLATE_BASE_URL",
+                "GLOBAL_PROXY_URL",
+                "LLM_PROXY_URL",
+                "TRANSLATE_PROXY_URL",
+                "VD_PROXY_URL",
+                "OLLAMA_PROXY_URL",
+                "LMSTUDIO_PROXY_URL",
+                "GEMINI_PROXY_URL",
             }
             if any(k in updates for k in llm_keys):
                 self.llm_model = LLMManager()
                 self.message_generator.llm_model = self.llm_model
                 logger.info("运行时配置更新：LLMManager 已重建并替换。")
+
+            # Translator 内部持有独立的 LLMManager(llm_job="translator")，
+            # 翻译相关字段或代理变更后需要重建以让新配置生效。
+            translator_keys = {
+                "TRANSLATE_LLM_PROVIDER",
+                "TRANSLATE_MODEL",
+                "TRANSLATE_API_KEY",
+                "TRANSLATE_BASE_URL",
+                "ENABLE_TRANSLATE",
+                "GLOBAL_PROXY_URL",
+                "TRANSLATE_PROXY_URL",
+                # 翻译复用主 LLM 配置时，主 LLM 变动也要影响翻译
+                "LLM_PROVIDER",
+                "MODEL_TYPE",
+                "CHAT_API_KEY",
+                "CHAT_BASE_URL",
+                "LLM_PROXY_URL",
+            }
+            if any(k in updates for k in translator_keys):
+                try:
+                    self.translator = Translator(self.game_status)
+                    self.message_generator.translator = self.translator
+                    logger.info("运行时配置更新：Translator 已重建并替换。")
+                except Exception as e:
+                    logger.warning(f"运行时配置更新：Translator 重建失败：{e}")
+
+            # DesktopAnalyzer 持有 OpenAI client，视觉模型相关字段或代理变更需要重建。
+            vision_keys = {
+                "VD_API_KEY",
+                "VD_BASE_URL",
+                "VD_MODEL",
+                "GLOBAL_PROXY_URL",
+                "VD_PROXY_URL",
+            }
+            if any(k in updates for k in vision_keys):
+                try:
+                    from ling_chat.core.pic_analyzer import DesktopAnalyzer
+
+                    new_analyzer = DesktopAnalyzer()
+                    # MessageProcessor 持有的实例
+                    if hasattr(self.message_processor, "desktop_analyzer"):
+                        self.message_processor.desktop_analyzer = new_analyzer
+                    # ProactiveSystem 内 StrategyDispatcher 也各自持有
+                    proactive = getattr(self, "proactive_system", None)
+                    if proactive is not None:
+                        dispatcher = getattr(proactive, "strategy_dispatcher", None)
+                        if dispatcher is not None and hasattr(
+                            dispatcher, "desktop_analyzer"
+                        ):
+                            dispatcher.desktop_analyzer = new_analyzer
+                    logger.info("运行时配置更新：DesktopAnalyzer 已重建并替换。")
+                except Exception as e:
+                    logger.warning(
+                        f"运行时配置更新：DesktopAnalyzer 重建失败（可能是 VD_API_KEY 未配置）：{e}"
+                    )
+
+            # 仅代理键变动时（且未触发上面的重建路径），给个友好日志
+            if any(k in updates for k in proxy_keys):
+                logger.info(
+                    "运行时配置更新：网络代理设置已变更，相关 Provider 将在下次请求时按新配置生效。"
+                )
 
             if "COMSUMERS" in updates:
                 try:

--- a/ling_chat/core/llm_providers/gemini.py
+++ b/ling_chat/core/llm_providers/gemini.py
@@ -6,6 +6,7 @@ import httpx
 
 from ling_chat.core.llm_providers.base import BaseLLMProvider
 from ling_chat.core.logger import logger
+from ling_chat.utils.proxy_helper import get_proxy_url
 
 
 # 文档：https://ai.google.dev/api
@@ -17,7 +18,8 @@ class GeminiProvider(BaseLLMProvider):
             "GEMINI_API_URL", "https://generativelanguage.googleapis.com/v1beta"
         )
         self.model_type = os.environ.get("GEMINI_MODEL_TYPE", "gemini-2.5-flash")
-        self.proxy_url = os.environ.get("GEMINI_PROXY_URL")
+        # GEMINI_PROXY_URL 优先，其次回落到 GLOBAL_PROXY_URL
+        self.proxy_url = get_proxy_url("GEMINI_PROXY_URL")
         self.temperature = float(os.environ.get("TEMPERATURE", 1.0))
         self.top_p = float(os.environ.get("TOP_P", 1.0))
 
@@ -31,14 +33,18 @@ class GeminiProvider(BaseLLMProvider):
         """获取HTTP客户端，支持代理"""
         timeout_config = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
         if self.proxy_url and self.proxy_url.strip():
-            return httpx.Client(proxy=self.proxy_url, timeout=timeout_config)
+            return httpx.Client(
+                proxy=self.proxy_url, trust_env=False, timeout=timeout_config
+            )
         return httpx.Client(timeout=timeout_config)
 
     def _get_async_http_client(self):
         """获取异步HTTP客户端，支持代理"""
         timeout_config = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
         if self.proxy_url and self.proxy_url.strip():
-            return httpx.AsyncClient(proxy=self.proxy_url, timeout=timeout_config)
+            return httpx.AsyncClient(
+                proxy=self.proxy_url, trust_env=False, timeout=timeout_config
+            )
         return httpx.AsyncClient(timeout=timeout_config)
 
     def _convert_messages_to_contents(

--- a/ling_chat/core/llm_providers/lmstudio.py
+++ b/ling_chat/core/llm_providers/lmstudio.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncGenerator, Dict, List, Optional
 import httpx
 
 from ling_chat.core.logger import logger
+from ling_chat.utils.proxy_helper import get_proxy_url
 
 from .base import BaseLLMProvider
 
@@ -18,6 +19,7 @@ class LMStudioProvider(BaseLLMProvider):
         base_url = os.environ.get("LMSTUDIO_BASE_URL", "http://localhost:1234")
         self.base_url = base_url.replace("/v1", "")
         self.api_token = os.environ.get("LMSTUDIO_API_TOKEN", "")
+        self.proxy_url = get_proxy_url("LMSTUDIO_PROXY_URL")
 
     def initialize_client(self):
         """LM Studio 客户端在每次请求时创建，无需初始化"""
@@ -30,19 +32,26 @@ class LMStudioProvider(BaseLLMProvider):
             headers["Authorization"] = f"Bearer {self.api_token}"
         return headers
 
+    def _common_client_kwargs(self) -> dict:
+        """构建 httpx 客户端的公共参数（含代理设置）"""
+        timeout_config = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
+        kwargs: dict = {
+            "base_url": self.base_url,
+            "headers": self._get_headers(),
+            "timeout": timeout_config,
+        }
+        if self.proxy_url:
+            kwargs["proxy"] = self.proxy_url
+            kwargs["trust_env"] = False
+        return kwargs
+
     def _get_http_client(self):
         """获取同步 HTTP 客户端"""
-        timeout_config = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
-        return httpx.Client(
-            base_url=self.base_url, headers=self._get_headers(), timeout=timeout_config
-        )
+        return httpx.Client(**self._common_client_kwargs())
 
     def _get_async_client(self):
         """获取异步 HTTP 客户端"""
-        timeout_config = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
-        return httpx.AsyncClient(
-            base_url=self.base_url, headers=self._get_headers(), timeout=timeout_config
-        )
+        return httpx.AsyncClient(**self._common_client_kwargs())
 
     def _build_input_messages(self, messages: List[Dict]) -> List[Dict]:
         """

--- a/ling_chat/core/llm_providers/ollama.py
+++ b/ling_chat/core/llm_providers/ollama.py
@@ -6,6 +6,7 @@ import httpx
 
 from ling_chat.core.llm_providers.base import BaseLLMProvider
 from ling_chat.core.logger import logger
+from ling_chat.utils.proxy_helper import get_proxy_url
 
 
 def _normalize_base_url(raw: str) -> str:
@@ -29,9 +30,18 @@ class OllamaProvider(BaseLLMProvider):
         self._timeout = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
         self.temperature = float(os.environ.get("TEMPERATURE", 1.3))
         self.top_p = float(os.environ.get("TOP_P", 0.9))
+        self.proxy_url = get_proxy_url("OLLAMA_PROXY_URL")
 
     def initialize_client(self):
         pass
+
+    def _client_kwargs(self) -> dict:
+        """构建 httpx Client/AsyncClient 的初始化参数（含代理与 trust_env 设置）"""
+        kwargs: dict = {"timeout": self._timeout}
+        if self.proxy_url:
+            kwargs["proxy"] = self.proxy_url
+            kwargs["trust_env"] = False
+        return kwargs
 
     def generate_response(self, messages: List[Dict]) -> str:
         """生成Ollama模型响应"""
@@ -48,7 +58,7 @@ class OllamaProvider(BaseLLMProvider):
                 "stream": False,
             }
 
-            with httpx.Client(timeout=self._timeout) as client:
+            with httpx.Client(**self._client_kwargs()) as client:
                 response = client.post(f"{self.base_url}/api/chat", json=payload)
 
                 if response.status_code != 200:
@@ -83,7 +93,7 @@ class OllamaProvider(BaseLLMProvider):
                 "stream": True,
             }
 
-            async with httpx.AsyncClient(timeout=self._timeout) as client:
+            async with httpx.AsyncClient(**self._client_kwargs()) as client:
                 async with client.stream(
                     "POST",
                     f"{self.base_url}/api/chat",

--- a/ling_chat/core/llm_providers/qwen_translate.py
+++ b/ling_chat/core/llm_providers/qwen_translate.py
@@ -6,6 +6,11 @@ import httpx
 from openai import AsyncOpenAI, OpenAI
 
 from ling_chat.core.logger import logger
+from ling_chat.utils.proxy_helper import (
+    create_proxied_async_httpx_client,
+    create_proxied_httpx_client,
+    get_proxy_url,
+)
 
 from .base import BaseLLMProvider
 
@@ -33,10 +38,31 @@ class QwenTranslateProvider(BaseLLMProvider):
             return
 
         self._timeout = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
-        self.client = OpenAI(api_key=api_key, base_url=base_url, timeout=self._timeout)
-        self.async_client = AsyncOpenAI(
-            api_key=api_key, base_url=base_url, timeout=self._timeout
+
+        proxy_url = get_proxy_url("TRANSLATE_PROXY_URL")
+        http_client = create_proxied_httpx_client(proxy_url, timeout=self._timeout)
+        async_http_client = create_proxied_async_httpx_client(
+            proxy_url, timeout=self._timeout
         )
+
+        client_kwargs = {
+            "api_key": api_key,
+            "base_url": base_url,
+            "timeout": self._timeout,
+        }
+        if http_client is not None:
+            self.client = OpenAI(**client_kwargs, http_client=http_client)
+            logger.info(f"Qwen翻译模型已启用代理: {proxy_url}")
+        else:
+            self.client = OpenAI(**client_kwargs)
+
+        if async_http_client is not None:
+            self.async_client = AsyncOpenAI(
+                **client_kwargs, http_client=async_http_client
+            )
+        else:
+            self.async_client = AsyncOpenAI(**client_kwargs)
+
         self.model_type = os.environ.get("TRANSLATE_MODEL", "qwen-mt-plus")
 
         logger.info("Qwen翻译模型初始化完毕！")

--- a/ling_chat/core/llm_providers/web_llm.py
+++ b/ling_chat/core/llm_providers/web_llm.py
@@ -6,6 +6,11 @@ from openai import AsyncOpenAI, OpenAI
 
 from ling_chat.core.llm_providers.base import BaseLLMProvider
 from ling_chat.core.logger import logger
+from ling_chat.utils.proxy_helper import (
+    create_proxied_async_httpx_client,
+    create_proxied_httpx_client,
+    get_proxy_url,
+)
 
 
 class WebLLMProvider(BaseLLMProvider):
@@ -34,10 +39,30 @@ class WebLLMProvider(BaseLLMProvider):
             return
 
         self._timeout = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
-        self.client = OpenAI(api_key=api_key, base_url=base_url, timeout=self._timeout)
-        self.async_client = AsyncOpenAI(
-            api_key=api_key, base_url=base_url, timeout=self._timeout
+
+        proxy_url = get_proxy_url("LLM_PROXY_URL")
+        http_client = create_proxied_httpx_client(proxy_url, timeout=self._timeout)
+        async_http_client = create_proxied_async_httpx_client(
+            proxy_url, timeout=self._timeout
         )
+
+        client_kwargs = {
+            "api_key": api_key,
+            "base_url": base_url,
+            "timeout": self._timeout,
+        }
+        if http_client is not None:
+            self.client = OpenAI(**client_kwargs, http_client=http_client)
+            logger.info(f"通用网络大模型已启用代理: {proxy_url}")
+        else:
+            self.client = OpenAI(**client_kwargs)
+
+        if async_http_client is not None:
+            self.async_client = AsyncOpenAI(
+                **client_kwargs, http_client=async_http_client
+            )
+        else:
+            self.async_client = AsyncOpenAI(**client_kwargs)
         logger.info("通用网络大模型初始化完毕！")
 
     def _add_thinking_extra_body(self, create_kwargs: dict) -> None:

--- a/ling_chat/core/pic_analyzer.py
+++ b/ling_chat/core/pic_analyzer.py
@@ -8,6 +8,8 @@ import httpx
 from openai import OpenAI
 from PIL import ImageGrab
 
+from ling_chat.utils.proxy_helper import create_proxied_httpx_client, get_proxy_url
+
 
 class DesktopAnalyzer:
     def __init__(self):
@@ -29,9 +31,19 @@ class DesktopAnalyzer:
 
         # 初始化 OpenAI 客户端
         self._timeout = httpx.Timeout(15.0)
-        self.client = OpenAI(
-            api_key=self.api_key, base_url=self.base_url, timeout=self._timeout
-        )
+
+        proxy_url = get_proxy_url("VD_PROXY_URL")
+        http_client = create_proxied_httpx_client(proxy_url, timeout=self._timeout)
+
+        client_kwargs = {
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+            "timeout": self._timeout,
+        }
+        if http_client is not None:
+            self.client = OpenAI(**client_kwargs, http_client=http_client)
+        else:
+            self.client = OpenAI(**client_kwargs)
 
     def _capture_desktop_sync(self):
         """

--- a/ling_chat/utils/proxy_helper.py
+++ b/ling_chat/utils/proxy_helper.py
@@ -1,0 +1,54 @@
+"""网络代理配置工具
+
+为各 LLM Provider 提供统一的代理配置读取与 httpx 客户端构造能力。
+
+读取优先级：Provider 专属 *_PROXY_URL > GLOBAL_PROXY_URL > None。
+留空则视为不开启代理，行为与未配置代理时完全一致。
+"""
+
+import os
+from typing import Optional
+
+import httpx
+
+
+def get_proxy_url(provider_key: str) -> Optional[str]:
+    """获取指定 Provider 的代理 URL，支持 fallback 到全局代理。
+
+    优先级：Provider 专属（如 LLM_PROXY_URL） > GLOBAL_PROXY_URL > None
+    """
+    specific = os.environ.get(provider_key, "").strip()
+    if specific:
+        return specific
+    global_proxy = os.environ.get("GLOBAL_PROXY_URL", "").strip()
+    return global_proxy if global_proxy else None
+
+
+def create_proxied_httpx_client(
+    proxy_url: Optional[str], timeout: Optional[httpx.Timeout] = None
+) -> Optional[httpx.Client]:
+    """创建带代理的 httpx.Client。
+
+    proxy_url 为空则返回 None（让上层 SDK 使用其默认 client，避免破坏既有行为）。
+    """
+    if not proxy_url:
+        return None
+    kwargs = {"proxy": proxy_url, "trust_env": False}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    return httpx.Client(**kwargs)
+
+
+def create_proxied_async_httpx_client(
+    proxy_url: Optional[str], timeout: Optional[httpx.Timeout] = None
+) -> Optional[httpx.AsyncClient]:
+    """创建带代理的 httpx.AsyncClient。
+
+    proxy_url 为空则返回 None。
+    """
+    if not proxy_url:
+        return None
+    kwargs = {"proxy": proxy_url, "trust_env": False}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    return httpx.AsyncClient(**kwargs)


### PR DESCRIPTION
hi，用 LingChat 的时候发现装了机场但对话还是连不上 OpenAI，排查了一下发现 #138 之前只覆盖了 Gemini 的 `GEMINI_PROXY_URL`，其他走 OpenAI SDK 的 Provider 都没有网络代理能力。

研究了一下现有架构，发现 `.env.example` 的元注释自动渲染机制很方便——加字段就有 UI，不用动前端。基于这个思路做了个实现：

**主要改动：**
- 新增 `proxy_helper.py` 统一处理代理读取，支持 `GLOBAL_PROXY_URL` 全局兜底 + 各 Provider 独立覆盖
- WebLLM / 翻译 / 视觉模型 / Ollama / LM Studio 全部接入代理能力，跟 Gemini 的写法对齐
- 顺手修了 Translator 和 DesktopAnalyzer 的热更新断点（改完代理不用重启）
- 加了一篇 `docs/manual/expand/proxy.md` 区分"反代/中转"和"网络代理"

`GEMINI_PROXY_URL` 没动，只是加了 fallback 到全局代理。所有新字段默认空，不影响现有用户。

有几个设计上的取舍想听听你们的想法：
1. 全局兜底我用了 `GLOBAL_PROXY_URL`，普通用户填一处就全部生效——如果觉得字段太多可以砍掉独立的只留全局
2. 显式代理客户端统一关了 `trust_env`，避免系统 `HTTP_PROXY` 环境变量干扰，不确定这样是否符合你们的预期
3. 没加"测试连接"按钮，觉得可以单独做，这个 PR 先保持纯净

希望对项目有帮助，有什么想调整的随时说~