### PR TITLE
fix: webview 启动崩溃时多后端降级 + 浏览器 fallback (#406)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@
 
 ## ⭐ 快速上手
 
+官方教程视频：[B站-手把手教你安装LingChat~](https://www.bilibili.com/video/BV1PoRRBNEuG)
+
 ### Step -1: 选择适合的版本
 
-- 如果是Windows10 64位或者更高请使用最新版本`0.4.0 Pre`！
+- 如果是Windows10 64位或者更高请使用最新版本`0.4.1`！
 - 如果是32位机器请用兼容版喵~
 
 ### Step 0: 开始之前的准备

--- a/ling_chat/core/webview.py
+++ b/ling_chat/core/webview.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import os
+import platform
 
 import webview
 
@@ -24,6 +25,23 @@ class Api:
         logger.info("收到退出请求，正在关闭应用...")
         if self._window:
             self._window.destroy()
+
+
+def _get_gui_backends():
+    """返回按优先级排列的 pywebview GUI 后端列表
+
+    Windows 上优先使用 edgechromium（WebView2，Win10 19041+ / Win11 自带），
+    然后依次降级到 edgehtml、cef，最后回退到 winforms（旧行为）。
+    某些后端（如 winforms）依赖 pythonnet 加载 Python.Runtime.dll，
+    与嵌入式 Python 3.13 不兼容，所以放在最后兜底。
+    """
+    system = platform.system()
+    if system == "Windows":
+        return ["edgechromium", "edgehtml", "cef", "winforms"]
+    elif system == "Darwin":
+        return ["cocoa"]
+    else:
+        return ["gtk", "qt"]
 
 
 def func_webview():
@@ -51,11 +69,33 @@ def func_webview():
         # print(f"图标路径: {icon_path}")
         # print(f"图标文件是否存在: {icon_path.exists()}")
 
-        webview.start(
-            http_server=True,
-            icon=str(icon_path),  # 在这里设置图标
-            storage_path=str(user_data_path / "webview_storage_path"),
-        )
+        backends = _get_gui_backends()
+        started = False
+
+        for gui in backends:
+            try:
+                logger.info(f"尝试使用 pywebview 后端: {gui}")
+                webview.start(
+                    gui=gui,
+                    http_server=True,
+                    icon=str(icon_path),  # 在这里设置图标
+                    storage_path=str(user_data_path / "webview_storage_path"),
+                )
+                started = True
+                break
+            except Exception as e:
+                logger.warning(
+                    f"pywebview 后端 '{gui}' 启动失败: {e}，尝试下一个后端..."
+                )
+                continue
+
+        if not started:
+            logger.error(
+                "所有 pywebview 后端均启动失败。"
+                f"请打开浏览器访问 http://{frontend_bind_addr}:{frontend_port}/"
+            )
+            # 用非零退出码通知主进程，便于主进程提示用户
+            raise SystemExit(1)
 
     except KeyboardInterrupt:
         logger.info("WebView被中断")

--- a/ling_chat/main.py
+++ b/ling_chat/main.py
@@ -143,7 +143,28 @@ def run_main_program(args, is_wv=False):
             print_logo()
             logger.warning("[前端界面已启用，可使用 --nogui 启用无前端窗口模式")
             try:
-                start_webview()
+                webview_process = start_webview()
+                # 子进程异常退出时（比如所有 pywebview 后端都启动失败），
+                # 不要让主程序也跟着退出，提示用户用浏览器访问即可。
+                exit_code = getattr(webview_process, "exitcode", 0)
+                if exit_code:
+                    frontend_bind_addr = os.getenv(
+                        "FRONTEND_BIND_ADDR"
+                    ) or os.getenv("BACKEND_BIND_ADDR", "127.0.0.1")
+                    frontend_port = os.getenv("FRONTEND_PORT") or os.getenv(
+                        "BACKEND_PORT", "8765"
+                    )
+                    logger.warning(
+                        f"前端窗口启动失败（exitcode={exit_code}），"
+                        f"请打开浏览器访问 http://{frontend_bind_addr}:{frontend_port}/"
+                    )
+                    # 后端继续运行，等待用户手动关闭
+                    while (
+                        (not exit_event.is_set())
+                        and (app_thread is not None)
+                        and app_thread.is_alive()
+                    ):
+                        time.sleep(0.1)
             except KeyboardInterrupt:
                 logger.info("用户关闭程序")
         else:


### PR DESCRIPTION
看到 #406 的报错，研究了一下是嵌入式 Python 3.13 + pywebview 默认走 winforms 后端的兼容问题。pythonnet 的 .NET Framework 桥接在这个环境下加载不了 `Python.Runtime.dll`。

思路是让它不再一条路走到黑：

- `webview.start()` 改为按 edgechromium → edgehtml → cef → winforms 顺序尝试，失败了换下一个
- 全部失败也不让主程序崩溃，控制台提示用户用浏览器访问
- Win10 19041+ / Win11 走 edgechromium（WebView2 Runtime 系统自带），直接绕开 pythonnet

有个兼容性的点想提一下：切后端后浏览器缓存目录结构会变，老用户升级可能丢前端缓存。如果你们觉得需要处理可以在 release notes 提一句，或者我加个迁移逻辑。

另外不确定目标用户里有没有 Win10 LTSC 旧版本（不带 WebView2 Runtime）的情况，如果有的话文档里可以加个安装链接。

希望能解决 #406 的问题~