### PR TITLE
fix: 流式 pipeline 死锁导致前端永久转圈

### DIFF
--- a/ling_chat/core/ai_service/message_system/message_generator.py
+++ b/ling_chat/core/ai_service/message_system/message_generator.py
@@ -158,14 +158,43 @@ class MessageGenerator:
 
             # 4. 现在，主协程的工作是从管道生成结果
             # 需要同时监听 producer_task 以便捕获 LLM 异常
+            # 同时设置一个超时兜底，避免 publisher/consumer 出现意外死锁时
+            # 主协程永远阻塞在 output_queue.get() 上 —— 那会让外层的
+            # _generation_lock 永不释放，前端持续转圈无法恢复。
+            pipeline_idle_timeout = float(
+                os.environ.get("PIPELINE_IDLE_TIMEOUT", 90)
+            )
+            timed_out = False
             while True:
                 # 创建一个获取队列的任务
                 queue_get_task = asyncio.create_task(output_queue.get())
 
                 # 同时等待队列和producer任务，看哪个先完成
                 done, pending = await asyncio.wait(
-                    [queue_get_task, producer_task], return_when=asyncio.FIRST_COMPLETED
+                    [queue_get_task, producer_task],
+                    return_when=asyncio.FIRST_COMPLETED,
+                    timeout=pipeline_idle_timeout,
                 )
+
+                # 整体超时：done 为空说明这一轮里 producer 和 queue 都没产出任何东西
+                # 这通常意味着 publisher/consumer 出现死锁。立刻取消 queue 等待，
+                # yield 一个错误响应让外层退出循环并释放生成锁。
+                if not done:
+                    queue_get_task.cancel()
+                    try:
+                        await queue_get_task
+                    except (asyncio.CancelledError, Exception):
+                        pass
+                    logger.error(
+                        f"流式管道在 {pipeline_idle_timeout}s 内无任何输出，疑似死锁，"
+                        "强制结束本轮生成以释放生成锁。"
+                    )
+                    timed_out = True
+                    error_response = ResponseFactory.create_error_reply(
+                        "AI 回复超时，请重试。"
+                    )
+                    yield error_response
+                    break
 
                 # 检查 producer_task 是否出错
                 if producer_task in done:
@@ -182,8 +211,23 @@ class MessageGenerator:
                         raise producer_exception
 
                     # 如果 producer 正常完成但队列还没有数据，继续等待队列
+                    # 同样要带超时，避免 publisher 死锁导致永远拿不到数据。
                     if queue_get_task not in done:
-                        response = await output_queue.get()
+                        try:
+                            response = await asyncio.wait_for(
+                                output_queue.get(), timeout=pipeline_idle_timeout
+                            )
+                        except asyncio.TimeoutError:
+                            logger.error(
+                                f"producer 已完成但 publisher 在 {pipeline_idle_timeout}s 内"
+                                "未产出任何剩余消息，强制结束本轮生成。"
+                            )
+                            timed_out = True
+                            error_response = ResponseFactory.create_error_reply(
+                                "AI 回复超时，请重试。"
+                            )
+                            yield error_response
+                            break
                     else:
                         response = queue_get_task.result()
                 else:
@@ -195,6 +239,11 @@ class MessageGenerator:
                     break
 
             # 5. 优雅关闭和后续处理
+
+            # 如果是被超时强制中断，跳过后续依赖 producer/consumer 的清理逻辑，
+            # 让 finally 块统一取消所有后台任务即可。
+            if timed_out:
+                return
 
             # 现在可以安全地等待producer_task以获取完整响应
             # 当上面的while循环完成时，生产者任务也必须完成

--- a/ling_chat/core/ai_service/message_system/pipeline_sentinels.py
+++ b/ling_chat/core/ai_service/message_system/pipeline_sentinels.py
@@ -1,0 +1,23 @@
+"""
+流式管道使用的内部 sentinel 对象。
+
+当 consumer 处理某个 index 失败、得不到合法 ReplyResponse 时，
+不能简单地不写 results_store 也不 set publish_events，否则
+publisher 会在该 index 上永久阻塞，导致整个流式输出 pipeline 死锁。
+
+为此 consumer 改为写入一个 SkippedSentence 占位，并 set 事件。
+publisher 拿到占位后跳过该 index；如果占位还携带 isFinal=True，
+说明流已结束，publisher 直接退出循环。
+"""
+
+
+class SkippedSentence:
+    """Sentinel for sentences that failed processing but should not block the pipeline."""
+
+    __slots__ = ("isFinal",)
+
+    def __init__(self, is_final: bool = False) -> None:
+        self.isFinal = is_final
+
+    def __repr__(self) -> str:  # pragma: no cover - 调试辅助
+        return f"SkippedSentence(isFinal={self.isFinal})"

--- a/ling_chat/core/ai_service/message_system/response_publisher.py
+++ b/ling_chat/core/ai_service/message_system/response_publisher.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import Dict
 
 from ling_chat.core.ai_service.ai_logger import logger
+from ling_chat.core.ai_service.message_system.pipeline_sentinels import SkippedSentence
 from ling_chat.core.schemas.responses import ReplyResponse
 
 
@@ -33,13 +34,25 @@ class ResponsePublisher:
                 await self.publish_events[next_index_to_publish].wait()
 
                 response = self.results_store.pop(next_index_to_publish, None)
-                if response:
+                # 该索引解析失败，consumer 写入了 SkippedSentence 占位
+                if isinstance(response, SkippedSentence):
+                    logger.warning(
+                        f"跳过第 {next_index_to_publish} 条消息（解析失败，is_final={response.isFinal}）"
+                    )
+                    del self.publish_events[next_index_to_publish]
+                    if response.isFinal:
+                        logger.info("最后一个消息（占位）已处理，退出发布循环")
+                        break
+                    next_index_to_publish += 1
+                    continue
+
+                if response is not None:
                     logger.info(f"正在发布第 {next_index_to_publish} 条消息")
                     await self.output_queue.put(response)
 
                 del self.publish_events[next_index_to_publish]
 
-                if response and response.isFinal:
+                if response is not None and response.isFinal:
                     logger.info("最后一个消息发送完毕，退出发布循环")
                     break
 

--- a/ling_chat/core/ai_service/message_system/sentence_comsumer.py
+++ b/ling_chat/core/ai_service/message_system/sentence_comsumer.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 from ling_chat.core.ai_service.ai_logger import logger
 from ling_chat.core.ai_service.game_system.game_status import GameStatus
 from ling_chat.core.ai_service.message_system.message_processor import MessageProcessor
+from ling_chat.core.ai_service.message_system.pipeline_sentinels import SkippedSentence
 from ling_chat.core.ai_service.translator import Translator
 from ling_chat.core.schemas.response_models import ResponseFactory
 from ling_chat.core.schemas.responses import ReplyResponse
@@ -50,16 +51,20 @@ class SentenceConsumer:
                     sentence, self.user_message, is_final
                 )
 
-                # If processing produced no response, skip storing but still mark task done and notify if needed.
+                # 无论 consumer 是否产出有效 response，都必须写入 results_store
+                # 并 set 对应的 publish_event，否则 publisher 会在该 index 上
+                # 永久阻塞 (await event.wait())，导致整条流式管道死锁。
                 if response is None:
                     logger.warning(
-                        f"Consumer {self.consumer_id} returned no response for index {index}."
+                        f"Consumer {self.consumer_id} returned no response for index {index} (is_final={is_final})."
                     )
+                    # 写入 sentinel 占位，携带 is_final 标记，让 publisher 能识别流结束
+                    self.results_store[index] = SkippedSentence(is_final=is_final)
                 else:
-                    # Store the result and notify the publisher
                     self.results_store[index] = response
-                    if index in self.publish_events:
-                        self.publish_events[index].set()
+
+                if index in self.publish_events:
+                    self.publish_events[index].set()
 
                 # TODO: 还需要返回这个response才对
 

--- a/ling_chat/core/ai_service/message_system/stream_producer.py
+++ b/ling_chat/core/ai_service/message_system/stream_producer.py
@@ -166,10 +166,19 @@ class StreamProducer:
             )  # 为这个索引创建一个事件
             await self.sentence_queue.put(
                 (final_content, current_index, True)
-            )  # is_final=False
+            )  # is_final=True
             sentence_index += 1
             # asyncio.create_task(self.process_sentence_and_send(final_content, user_message, True))
             # await self.process_sentence(final_content, emotion_segments)
+        else:
+            # 流以完整 【情绪】句子 结尾，没有剩余 buffer。
+            # 仍然必须发送一条 is_final=True 的标记消息，否则
+            # publisher 永远不会收到 isFinal 信号，主协程的 while 循环
+            # 会在 output_queue.get() 上永久阻塞。
+            current_index = sentence_index
+            self.publish_events[current_index] = asyncio.Event()
+            await self.sentence_queue.put(("", current_index, True))
+            sentence_index += 1
 
         # 打印结束换行
         print("\n=== 流式输出结束 ===")


### PR DESCRIPTION
使用过程中偶尔遇到 AI 回复完了但前端一直转圈、后续对话全部无响应的情况。翻了 `message_system/` 下的 pipeline 代码，定位到两处死锁风险：

1. `SentenceConsumer` 在解析失败时（`response is None`）不 set `publish_events`，Publisher 在那个 index 上永久阻塞，后面的消息全部堵住
2. `StreamProducer` 末尾 `final_content` 为空时不发 `is_final=True`，主协程永久等待

两种情况都会让 `_generation_lock` 永不释放。

修复思路：
- Consumer 失败时写入一个 `SkippedSentence` 占位并 set 事件，Publisher 拿到后跳过继续
- Producer 末尾空内容时补发 `is_final=True` 标记
- 主协程加了 90s 空闲超时作为最后一道防线

正常场景行为不变，只有模型输出格式不规范时（比如开了思考链路、或者模型偶尔不遵循格式指令）会触发跳过逻辑。

不确定你们有没有收到过类似"对话卡死必须重启"的反馈？如果这个方向没问题的话希望能合进去，让对话体验稳定一些。有什么想讨论的随时聊~