### PR TITLE
feat(schedule): 待办事项详情页增加返回按钮 (#411)

### DIFF
--- a/frontend_vue/src/components/schedule/ScheduleContent.vue
+++ b/frontend_vue/src/components/schedule/ScheduleContent.vue
@@ -69,8 +69,8 @@
       <header class="mt-2 p-6 flex justify-between items-center border-b border-cyan-300">
         <div class="flex items-center space-x-4 pl-4">
           <button
-            v-show="uiStore.scheduleView === 'schedule_detail'"
-            @click="uiStore.scheduleView = 'schedule_groups'"
+            v-show="uiStore.scheduleView === 'schedule_detail' || uiStore.scheduleView === 'todo_detail'"
+            @click="uiStore.scheduleView = uiStore.scheduleView === 'schedule_detail' ? 'schedule_groups' : 'todo_groups'"
             class="p-2 hover:bg-cyan-50 rounded-full text-cyan-600 transition-all"
           >
             <ChevronLeft />


### PR DESCRIPTION
看到 #411 提的需求，待办事项打开任务组后没有返回按钮，但日程主题那边是有的。

看了一下代码发现 `ScheduleContent.vue` 的 header 里已经有一个 `ChevronLeft` 返回按钮，只是 `v-show` 条件只写了 `schedule_detail`，没覆盖 `todo_detail`。

改动很小，就是把条件扩展了一下，同时让点击事件根据当前视图返回到对应的列表页。跟日程主题的交互保持一致。