### PR TITLE
feat: 全局网络代理（重做 #422，基于新 LLM 配置系统）

### DIFF
--- a/frontend_vue/src/api/services/llm-config.ts
+++ b/frontend_vue/src/api/services/llm-config.ts
@@ -21,12 +21,18 @@ export interface LlmModelSection {
   enable_thinking?: string
 }
 
+/** 全局网络配置 */
+export interface LlmNetworkSection {
+  proxy: string
+}
+
 /** 完整配置方案 */
 export interface LlmConfigScheme {
   config_name?: string
   config_description?: string
   main: LlmModelSection
   translator: LlmModelSection
+  network?: LlmNetworkSection
   providers?: Record<string, any>
 }
 

--- a/frontend_vue/src/components/settings/pages/SettingsLlmConfig.vue
+++ b/frontend_vue/src/components/settings/pages/SettingsLlmConfig.vue
@@ -166,6 +166,17 @@
                   </FormField>
                 </template>
 
+                <div class="text-[var(--accent-color)] font-bold text-sm pb-1 border-b border-white/10 mt-1">全局网络</div>
+                <FormField label="HTTP 代理">
+                  <input
+                    type="text"
+                    :value="form.network?.proxy ?? ''"
+                    @input="onProxyInput"
+                    class="w-full px-3 py-2 rounded-lg border border-white/12 bg-white/8 text-white text-sm outline-none focus:border-[var(--accent-color)] placeholder:text-white/25"
+                    placeholder="留空走系统代理，本地模型自动绕过"
+                  />
+                </FormField>
+
                 <div class="flex gap-2.5 pt-2">
                   <button class="px-5 py-2 rounded-lg bg-[var(--accent-color)] text-white text-sm font-medium hover:opacity-85 disabled:opacity-50 transition-all" @click="doSave" :disabled="saving">
                     {{ saving ? '保存中...' : '保存' }}
@@ -248,6 +259,7 @@ const form = reactive<LlmConfigScheme>({
   config_description: '',
   main: { provider: 'webllm', model: '', api_key: '', base_url: '' },
   translator: { provider: 'none', model: '', api_key: '', base_url: '' },
+  network: { proxy: '' },
 })
 const saving = ref(false)
 const saveMsg = ref('')
@@ -290,6 +302,12 @@ function onBack() {
   }
 }
 
+function onProxyInput(e: Event) {
+  const value = (e.target as HTMLInputElement).value
+  if (!form.network) form.network = { proxy: '' }
+  form.network.proxy = value
+}
+
 // ——— 列表操作 ———
 async function activateConfig(name: string) {
   try { await store.switchTo(name) }
@@ -301,12 +319,14 @@ async function startAdd() {
   try {
     const tpl = await getConfigTemplate()
     Object.assign(form, tpl)
+    if (!form.network) form.network = { proxy: '' }
   } catch {
     // fallback: 用最小空模板
     Object.assign(form, {
       config_name: '', config_description: '',
       main: { provider: 'webllm', model: '', api_key: '', base_url: '' },
       translator: { provider: 'none', model: '', api_key: '', base_url: '' },
+      network: { proxy: '' },
     })
   }
   view.value = 'edit'
@@ -321,6 +341,7 @@ async function startEdit(name: string) {
       config_description: cfg.config_description || '',
       main: { ...cfg.main },
       translator: { ...cfg.translator },
+      network: { proxy: '', ...(cfg.network || {}) },
     })
     view.value = 'edit'
   } catch (e) {

--- a/frontend_vue/src/stores/modules/llm-config.ts
+++ b/frontend_vue/src/stores/modules/llm-config.ts
@@ -71,7 +71,6 @@ export const useLlmConfigStore = defineStore('llm-config', {
           model: '',
           api_key: '',
           base_url: 'https://api.deepseek.com/v1',
-          proxy: '',
           temperature: 1.3,
           top_p: 0.9,
           enable_thinking: 'none',
@@ -81,6 +80,9 @@ export const useLlmConfigStore = defineStore('llm-config', {
           model: '',
           api_key: '',
           base_url: '',
+        },
+        network: {
+          proxy: '',
         },
       }
     },

--- a/ling_chat/configs/llm_config.py
+++ b/ling_chat/configs/llm_config.py
@@ -74,7 +74,6 @@ class LLMConfig:
             "top_p": float(os.environ.get("TOP_P", "0.9")),
             "max_tokens": int(os.environ.get("MAX_TOKENS", "8192")),
             "enable_thinking": os.environ.get("ENABLE_THINKING", "none").lower(),
-            "proxy": "",
         }
 
         # 按 provider 映射旧环境变量到统一字段
@@ -83,13 +82,11 @@ class LLMConfig:
                 "api_key": ("CHAT_API_KEY", ""),
                 "base_url": ("CHAT_BASE_URL", "https://api.deepseek.com/v1"),
                 "model": ("MODEL_TYPE", "deepseek-chat"),
-                "proxy": ("CHAT_PROXY_URL", ""),
             },
             "gemini": {
                 "api_key": ("GEMINI_API_KEY", ""),
                 "base_url": ("GEMINI_BASE_URL", "https://generativelanguage.googleapis.com/v1beta"),
                 "model": ("GEMINI_MODEL_TYPE", "gemini-2.5-flash"),
-                "proxy": ("GEMINI_PROXY_URL", ""),
             },
             "ollama": {
                 "base_url": ("OLLAMA_BASE_URL", "http://localhost:11434"),
@@ -106,10 +103,31 @@ class LLMConfig:
         for key, (env_var, default) in mapping.items():
             main[key] = os.environ.get(env_var, default)
 
+        # 从旧 provider 专用代理环境变量迁移到全局 network.proxy
+        # 优先级: 当前 provider 对应的旧变量 > CHAT_PROXY_URL > GEMINI_PROXY_URL
+        proxy_env_map = {
+            "webllm": "CHAT_PROXY_URL",
+            "gemini": "GEMINI_PROXY_URL",
+        }
+        proxy_value = ""
+        primary_var = proxy_env_map.get(provider)
+        if primary_var:
+            proxy_value = os.environ.get(primary_var, "")
+        if not proxy_value:
+            # 任何旧变量非空都尝试迁移过来
+            for env_var in ("CHAT_PROXY_URL", "GEMINI_PROXY_URL"):
+                value = os.environ.get(env_var, "")
+                if value:
+                    proxy_value = value
+                    break
+
         return {
             "config_name": "默认配置",
             "config_description": "从.env自动迁移的默认配置",
             "main": main,
+            "network": {
+                "proxy": proxy_value,
+            },
             "translator": {
                 "provider": os.environ.get("TRANSLATE_LLM_PROVIDER", "none"),
                 "model": os.environ.get("TRANSLATE_MODEL", ""),
@@ -131,6 +149,36 @@ class LLMConfig:
                 return
 
         self._config = self._parse_toml(config_path)
+        # 一次性迁移：旧版本将 proxy 放在 [main]，需挪到 [network]
+        self._migrate_legacy_proxy(config_path)
+
+    def _migrate_legacy_proxy(self, config_path: Path) -> None:
+        """将旧 main.proxy 迁移到 network.proxy 并写回磁盘
+
+        触发条件：
+        - main.proxy 存在（无论是否为空）
+        - 且 [network] 段不存在或没有 proxy 字段（避免覆盖已有设置）
+        """
+        main = self._config.get("main")
+        if not isinstance(main, dict) or "proxy" not in main:
+            return
+
+        legacy_proxy = main.pop("proxy", "")
+        network = self._config.get("network")
+        if not isinstance(network, dict):
+            network = {}
+            self._config["network"] = network
+
+        # 已有 network.proxy 时不覆盖；否则把旧值搬过去
+        if "proxy" not in network:
+            network["proxy"] = legacy_proxy or ""
+
+        # 落盘，下次启动就不再触发
+        try:
+            self._write_toml(config_path, self._config)
+            logger.info(f"已将旧版 main.proxy 迁移到 network.proxy: {config_path}")
+        except Exception as e:
+            logger.warning(f"迁移 main.proxy 到 network.proxy 写盘失败: {e}")
 
     def _parse_toml(self, path: Path) -> Dict[str, Any]:
         """解析TOML文件"""
@@ -177,6 +225,13 @@ class LLMConfig:
                             lines.append(self._format_toml_line(key, value))
                         lines.append("")
 
+            # 写入network配置（全局网络设置，置于providers之后）
+            if "network" in config:
+                lines.append("[network]")
+                for key, value in config["network"].items():
+                    lines.append(self._format_toml_line(key, value))
+                lines.append("")
+
             with open(path, "w", encoding="utf-8") as f:
                 f.write("\n".join(lines))
 
@@ -207,7 +262,6 @@ class LLMConfig:
                 "model": "deepseek-chat",
                 "api_key": "",
                 "base_url": "https://api.deepseek.com/v1",
-                "proxy": "",
                 "temperature": 1.3,
                 "top_p": 0.9,
                 "max_tokens": 8192,
@@ -218,6 +272,9 @@ class LLMConfig:
                 "model": "",
                 "api_key": "",
                 "base_url": "",
+            },
+            "network": {
+                "proxy": "",
             },
             "providers": {},
         }
@@ -279,6 +336,16 @@ class LLMConfig:
         if trans.get("provider", "none") in ["none", ""]:
             return self.get_main_config()
         return trans
+
+    def get_network_config(self) -> Dict[str, Any]:
+        """获取全局网络配置（合入默认值，新键自动补全）
+
+        当前包含：
+        - proxy: HTTP/HTTPS 代理地址；留空表示走系统代理（trust_env=True）
+        """
+        defaults = {"proxy": ""}
+        config = self._config.get("network", {}) or {}
+        return {**defaults, **config}
 
     def get_provider_config(self, provider: str) -> Dict[str, Any]:
         """获取指定提供商的配置"""
@@ -363,7 +430,6 @@ class LLMConfig:
                 "model": "",
                 "api_key": "",
                 "base_url": "https://api.deepseek.com/v1",
-                "proxy": "",
                 "temperature": 1.3,
                 "top_p": 0.9,
                 "max_tokens": 8192,
@@ -374,6 +440,9 @@ class LLMConfig:
                 "model": "",
                 "api_key": "",
                 "base_url": "",
+            },
+            "network": {
+                "proxy": "",
             },
             "providers": {},
         }

--- a/ling_chat/configs/llm_toml_config.py
+++ b/ling_chat/configs/llm_toml_config.py
@@ -18,6 +18,7 @@ from ling_chat.core.logger import logger
 SECTION_DESCRIPTIONS: Dict[str, str] = {
     "main": "主对话模型配置 — 配置 LLM 提供商、API 密钥、模型参数等",
     "translator": "翻译模型配置 — 配置日语翻译功能相关的 LLM 参数",
+    "network": "全局网络配置 — 所有 LLM 请求共用的代理设置",
 }
 
 KEY_DESCRIPTIONS: Dict[str, Dict[str, str]] = {
@@ -26,7 +27,6 @@ KEY_DESCRIPTIONS: Dict[str, Dict[str, str]] = {
         "model": "模型名称",
         "api_key": "API 密钥",
         "base_url": "API 访问地址",
-        "proxy": "HTTP 代理地址",
         "temperature": "温度，控制模型输出的随机性，0-2.0 之间 [type:number]",
         "top_p": "核采样，控制模型的选词范围，0-1.0 之间 [type:number]",
         "max_tokens": "最大输出令牌数，控制单次生成的最大长度 [type:number]",
@@ -38,13 +38,15 @@ KEY_DESCRIPTIONS: Dict[str, Dict[str, str]] = {
         "api_key": "翻译模型 API 密钥",
         "base_url": "翻译模型 API 访问地址",
     },
+    "network": {
+        "proxy": "全局 HTTP 代理地址（留空走系统代理；本地模型自动绕过）",
+    },
 }
 
 PROVIDER_KEY_DESCRIPTIONS: Dict[str, str] = {
     "api_key": "API 密钥",
     "base_url": "API 访问地址",
     "model": "模型名称",
-    "proxy": "HTTP 代理地址",
 }
 
 

--- a/ling_chat/core/llm_providers/_http.py
+++ b/ling_chat/core/llm_providers/_http.py
@@ -1,0 +1,70 @@
+"""HTTP 客户端工厂 — 统一处理全局代理配置
+
+设计要点：
+- 全局代理配置位于 [network] 段，所有 provider 共用
+- 留空走系统代理（httpx 默认 trust_env=True）
+- 配了代理则强制走该代理（trust_env=False）
+- 当 base_url 指向本地地址时强制不走代理（避免 Ollama/LMStudio 等被中断）
+"""
+
+from typing import Any, Optional, Union
+from urllib.parse import urlparse
+
+import httpx
+
+_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
+
+
+def _is_local_url(url: Optional[str]) -> bool:
+    """判断 URL 是否指向本机地址"""
+    if not url:
+        return False
+    try:
+        host = urlparse(url).hostname or ""
+    except Exception:
+        return False
+    return host.lower() in _LOCAL_HOSTS
+
+
+def build_httpx_client(
+    *,
+    async_client: bool = False,
+    timeout: Any = None,
+    base_url: Optional[str] = None,
+    **kwargs: Any,
+) -> Union[httpx.Client, httpx.AsyncClient]:
+    """构造 httpx 客户端，统一处理全局代理。
+
+    行为：
+    - 配置了全局代理且 base_url 非本地 → ``proxy=值, trust_env=False``
+    - 留空 → 使用 httpx 默认（``trust_env=True``，识别系统 ``HTTP_PROXY/HTTPS_PROXY``）
+    - base_url 指向本地（localhost / 127.0.0.1 / ::1 / 0.0.0.0）→ 不走代理
+
+    Args:
+        async_client: 是否构造 ``httpx.AsyncClient``，默认 ``httpx.Client``
+        timeout: httpx 超时配置
+        base_url: 既用于判断是否本地连接，也会作为 httpx 客户端的 ``base_url``
+            参数透传（仅在请求使用相对路径时生效，对绝对 URL 请求无影响）。
+            传 ``None`` 时不设置。
+        **kwargs: 透传给 httpx.Client/AsyncClient 的其他参数
+
+    Returns:
+        ``httpx.Client`` 或 ``httpx.AsyncClient`` 实例
+    """
+    # 延迟导入避免与 llm_config 形成循环依赖
+    from ling_chat.configs.llm_config import llm_config
+
+    proxy = (llm_config.get_network_config().get("proxy") or "").strip()
+
+    cls = httpx.AsyncClient if async_client else httpx.Client
+    init_kwargs: dict = dict(kwargs)
+    if timeout is not None:
+        init_kwargs["timeout"] = timeout
+    if base_url:
+        init_kwargs.setdefault("base_url", base_url)
+
+    if proxy and not _is_local_url(base_url):
+        init_kwargs["proxy"] = proxy
+        init_kwargs["trust_env"] = False
+
+    return cls(**init_kwargs)

--- a/ling_chat/core/llm_providers/gemini.py
+++ b/ling_chat/core/llm_providers/gemini.py
@@ -4,20 +4,20 @@ from typing import AsyncGenerator, Dict, List, Optional
 import httpx
 
 from ling_chat.configs.llm_config import llm_config
+from ling_chat.core.llm_providers._http import build_httpx_client
 from ling_chat.core.llm_providers.base import BaseLLMProvider
 from ling_chat.core.logger import logger
 
 
 # 文档：https://ai.google.dev/api
 class GeminiProvider(BaseLLMProvider):
-    def __init__(self, model_type: str = "", api_key: str = "", base_url: str = "", proxy: str = ""):
+    def __init__(self, model_type: str = "", api_key: str = "", base_url: str = ""):
         super().__init__()
         main_cfg = llm_config.get_main_config()
 
         self.api_key = api_key or main_cfg.get("api_key", "")
         self.model_type = model_type or main_cfg.get("model", "gemini-2.5-flash")
         self.base_url = base_url or main_cfg.get("base_url", "https://generativelanguage.googleapis.com/v1beta")
-        self.proxy_url = proxy or main_cfg.get("proxy", "")
         self.temperature = main_cfg.get("temperature", 1.0)
         self.top_p = main_cfg.get("top_p", 1.0)
         self.max_tokens = int(main_cfg.get("max_tokens", 8192))
@@ -29,18 +29,16 @@ class GeminiProvider(BaseLLMProvider):
         pass
 
     def _get_http_client(self):
-        """获取HTTP客户端，支持代理"""
+        """获取HTTP客户端（同步），由全局 [network] 代理决定是否走代理"""
         timeout_config = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
-        if self.proxy_url and self.proxy_url.strip():
-            return httpx.Client(proxy=self.proxy_url, timeout=timeout_config)
-        return httpx.Client(timeout=timeout_config)
+        return build_httpx_client(timeout=timeout_config, base_url=self.base_url)
 
     def _get_async_http_client(self):
-        """获取异步HTTP客户端，支持代理"""
+        """获取异步HTTP客户端，由全局 [network] 代理决定是否走代理"""
         timeout_config = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
-        if self.proxy_url and self.proxy_url.strip():
-            return httpx.AsyncClient(proxy=self.proxy_url, timeout=timeout_config)
-        return httpx.AsyncClient(timeout=timeout_config)
+        return build_httpx_client(
+            async_client=True, timeout=timeout_config, base_url=self.base_url
+        )
 
     def _convert_messages_to_contents(
         self, messages: List[Dict]

--- a/ling_chat/core/llm_providers/kimi_code.py
+++ b/ling_chat/core/llm_providers/kimi_code.py
@@ -4,6 +4,7 @@ from typing import AsyncGenerator, Dict, List
 import httpx
 from anthropic import Anthropic, AsyncAnthropic
 
+from ling_chat.core.llm_providers._http import build_httpx_client
 from ling_chat.core.llm_providers.base import BaseLLMProvider
 from ling_chat.core.logger import logger
 
@@ -44,17 +45,24 @@ class KimiCodeProvider(BaseLLMProvider):
         self._timeout = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
         default_headers = {"User-Agent": self.KIMI_CODE_USER_AGENT}
 
+        http_client = build_httpx_client(timeout=self._timeout, base_url=self.base_url)
+        async_http_client = build_httpx_client(
+            async_client=True, timeout=self._timeout, base_url=self.base_url
+        )
+
         self.client = Anthropic(
             api_key=api_key,
             base_url=self.base_url,
             timeout=self._timeout,
             default_headers=default_headers,
+            http_client=http_client,
         )
         self.async_client = AsyncAnthropic(
             api_key=api_key,
             base_url=self.base_url,
             timeout=self._timeout,
             default_headers=default_headers,
+            http_client=async_http_client,
         )
         logger.info("Kimi Code 大模型初始化完毕！")
 

--- a/ling_chat/core/llm_providers/lmstudio.py
+++ b/ling_chat/core/llm_providers/lmstudio.py
@@ -4,6 +4,7 @@ from typing import Any, AsyncGenerator, Dict, List, Optional
 import httpx
 
 from ling_chat.configs.llm_config import llm_config
+from ling_chat.core.llm_providers._http import build_httpx_client
 from ling_chat.core.logger import logger
 
 from .base import BaseLLMProvider
@@ -12,7 +13,7 @@ from .base import BaseLLMProvider
 # LM Studio API 文档：https://lmstudio.ai/docs/developer/rest/chat
 # POST /api/v1/chat
 class LMStudioProvider(BaseLLMProvider):
-    def __init__(self, model_type: str = "", api_key: str = "", base_url: str = "", proxy: str = ""):
+    def __init__(self, model_type: str = "", api_key: str = "", base_url: str = ""):
         super().__init__()
         main_cfg = llm_config.get_main_config()
         self.model_type = model_type or main_cfg.get("model", "")
@@ -34,17 +35,22 @@ class LMStudioProvider(BaseLLMProvider):
         return headers
 
     def _get_http_client(self):
-        """获取同步 HTTP 客户端"""
+        """获取同步 HTTP 客户端（本地地址自动绕过全局代理）"""
         timeout_config = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
-        return httpx.Client(
-            base_url=self.base_url, headers=self._get_headers(), timeout=timeout_config
+        return build_httpx_client(
+            timeout=timeout_config,
+            base_url=self.base_url,
+            headers=self._get_headers(),
         )
 
     def _get_async_client(self):
-        """获取异步 HTTP 客户端"""
+        """获取异步 HTTP 客户端（本地地址自动绕过全局代理）"""
         timeout_config = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
-        return httpx.AsyncClient(
-            base_url=self.base_url, headers=self._get_headers(), timeout=timeout_config
+        return build_httpx_client(
+            async_client=True,
+            timeout=timeout_config,
+            base_url=self.base_url,
+            headers=self._get_headers(),
         )
 
     def _build_input_messages(self, messages: List[Dict]) -> List[Dict]:

--- a/ling_chat/core/llm_providers/manager.py
+++ b/ling_chat/core/llm_providers/manager.py
@@ -22,7 +22,6 @@ class LLMManager:
         self.model_type = cfg.get("model", "deepseek-chat")
         self.api_key = cfg.get("api_key", "")
         self.base_url = cfg.get("base_url", "https://api.deepseek.com/v1")
-        self.proxy = cfg.get("proxy", "")
         provider_type = self.llm_provider_type.lower()
         logger.info(f"初始化LLM {provider_type} 提供商中...")
 
@@ -38,7 +37,7 @@ class LLMManager:
         # 确保provider_type存在
         provider_type = self.llm_provider_type.lower()
         return LLMProviderFactory.create_provider(
-            provider_type, self.model_type, self.api_key, self.base_url, self.proxy
+            provider_type, self.model_type, self.api_key, self.base_url
         )
 
     def process_message(self, messages: List[Dict]):

--- a/ling_chat/core/llm_providers/ollama.py
+++ b/ling_chat/core/llm_providers/ollama.py
@@ -4,6 +4,7 @@ from typing import AsyncGenerator, Dict, List
 import httpx
 
 from ling_chat.configs.llm_config import llm_config
+from ling_chat.core.llm_providers._http import build_httpx_client
 from ling_chat.core.llm_providers.base import BaseLLMProvider
 from ling_chat.core.logger import logger
 
@@ -18,7 +19,7 @@ def _normalize_base_url(raw: str) -> str:
 
 
 class OllamaProvider(BaseLLMProvider):
-    def __init__(self, model_type: str = "", api_key: str = "", base_url: str = "", proxy: str = ""):
+    def __init__(self, model_type: str = "", api_key: str = "", base_url: str = ""):
         super().__init__()
         self.model_type = model_type or "llama3"
         self.base_url = _normalize_base_url(base_url or "http://localhost:11434")
@@ -47,7 +48,9 @@ class OllamaProvider(BaseLLMProvider):
                 "stream": False,
             }
 
-            with httpx.Client(timeout=self._timeout) as client:
+            with build_httpx_client(
+                timeout=self._timeout, base_url=self.base_url
+            ) as client:
                 response = client.post(f"{self.base_url}/api/chat", json=payload)
 
                 if response.status_code != 200:
@@ -83,7 +86,9 @@ class OllamaProvider(BaseLLMProvider):
                 "stream": True,
             }
 
-            async with httpx.AsyncClient(timeout=self._timeout) as client:
+            async with build_httpx_client(
+                async_client=True, timeout=self._timeout, base_url=self.base_url
+            ) as client:
                 async with client.stream(
                     "POST",
                     f"{self.base_url}/api/chat",

--- a/ling_chat/core/llm_providers/provider_factory.py
+++ b/ling_chat/core/llm_providers/provider_factory.py
@@ -11,30 +11,37 @@ from ling_chat.core.logger import logger
 class LLMProviderFactory:
     @staticmethod
     def create_provider(
-        provider_type: str, model_type: str = "", api_key: str = "", base_url: str = "", proxy: str = ""
+        provider_type: str, model_type: str = "", api_key: str = "", base_url: str = "", **kwargs
     ) -> BaseLLMProvider:
         """
         创建指定类型的大模型提供者
 
         :param provider_type: 提供者类型 (webllm, ollama, lmstudio, gemini, qwen, kimi-code)
-        :param config: 配置字典
+        :param model_type: 模型名称
+        :param api_key: API 密钥
+        :param base_url: API 访问地址
         :return: 大模型提供者实例
+
+        网络代理由全局 ``[network]`` 配置统一管理，无需在此传入。
         """
+        # 兼容旧调用：忽略遗留的 proxy 参数
+        kwargs.pop("proxy", None)
+
         provider_type = provider_type.lower()
 
         try:
             if provider_type == "webllm":
                 logger.info("创建通用联网大模型服务提供商")
-                return WebLLMProvider(model_type, api_key, base_url, proxy)
+                return WebLLMProvider(model_type, api_key, base_url)
             elif provider_type == "ollama":
                 logger.info("创建OLLAMA服务提供商")
-                return OllamaProvider(model_type, api_key, base_url, proxy)
+                return OllamaProvider(model_type, api_key, base_url)
             elif provider_type == "lmstudio":
                 logger.info("创建LM STUDIO服务提供商")
-                return LMStudioProvider(model_type, api_key, base_url, proxy)
+                return LMStudioProvider(model_type, api_key, base_url)
             elif provider_type == "gemini":
                 logger.info("创建Gemini服务提供商")
-                return GeminiProvider(model_type, api_key, base_url, proxy)
+                return GeminiProvider(model_type, api_key, base_url)
             elif provider_type == "kimi-code":
                 logger.info("创建 Kimi Code 服务提供商")
                 return KimiCodeProvider(model_type, api_key, base_url)

--- a/ling_chat/core/llm_providers/qwen_translate.py
+++ b/ling_chat/core/llm_providers/qwen_translate.py
@@ -5,6 +5,7 @@ import httpx
 from openai import AsyncOpenAI, OpenAI
 
 from ling_chat.configs.llm_config import llm_config
+from ling_chat.core.llm_providers._http import build_httpx_client
 from ling_chat.core.logger import logger
 
 from .base import BaseLLMProvider
@@ -33,9 +34,15 @@ class QwenTranslateProvider(BaseLLMProvider):
             return
 
         self._timeout = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
-        self.client = OpenAI(api_key=api_key, base_url=base_url, timeout=self._timeout)
+        http_client = build_httpx_client(timeout=self._timeout, base_url=base_url)
+        async_http_client = build_httpx_client(
+            async_client=True, timeout=self._timeout, base_url=base_url
+        )
+        self.client = OpenAI(
+            api_key=api_key, base_url=base_url, timeout=self._timeout, http_client=http_client
+        )
         self.async_client = AsyncOpenAI(
-            api_key=api_key, base_url=base_url, timeout=self._timeout
+            api_key=api_key, base_url=base_url, timeout=self._timeout, http_client=async_http_client
         )
         self.model_type = cfg.get("model", "qwen-mt-plus")
 

--- a/ling_chat/core/llm_providers/web_llm.py
+++ b/ling_chat/core/llm_providers/web_llm.py
@@ -4,12 +4,13 @@ import httpx
 from openai import AsyncOpenAI, OpenAI
 
 from ling_chat.configs.llm_config import llm_config
+from ling_chat.core.llm_providers._http import build_httpx_client
 from ling_chat.core.llm_providers.base import BaseLLMProvider
 from ling_chat.core.logger import logger
 
 
 class WebLLMProvider(BaseLLMProvider):
-    def __init__(self, model_type: str, api_key: str, base_url: str, proxy: str = ""):
+    def __init__(self, model_type: str, api_key: str, base_url: str):
         super().__init__()
         self.api_key = api_key
         self.base_url = base_url
@@ -38,8 +39,10 @@ class WebLLMProvider(BaseLLMProvider):
             return
 
         self._timeout = httpx.Timeout(connect=20.0, read=60.0, write=20.0, pool=20.0)
-        http_client = httpx.Client(proxy=proxy, timeout=self._timeout) if proxy else None
-        async_http_client = httpx.AsyncClient(proxy=proxy, timeout=self._timeout) if proxy else None
+        http_client = build_httpx_client(timeout=self._timeout, base_url=base_url)
+        async_http_client = build_httpx_client(
+            async_client=True, timeout=self._timeout, base_url=base_url
+        )
         self.client = OpenAI(api_key=api_key, base_url=base_url, http_client=http_client, timeout=self._timeout)
         self.async_client = AsyncOpenAI(
             api_key=api_key, base_url=base_url, http_client=async_http_client, timeout=self._timeout


### PR DESCRIPTION
重做 #422——基于配置大迁移后的新 LLM TOML 配置系统，按 @shadow01a 的三点反馈重新实现。旧 PR #422 是基于 .env 的，已经和现在的架构完全对不上，所以开了这个新的。

## 按反馈做的三件事

**1. 统一成单一全局代理**

新增 `[network]` 配置段，只有一个 `proxy` 字段。删掉了 `[main].proxy` 和各 provider 的独立 proxy 形参。机场代理确实不像 API URL 需要分供应商策略，一个全局配置最直观。

**2. 留空走系统代理**

新增 `build_httpx_client()` 工厂统一构造所有 provider 的 httpx 客户端：
- 配了代理 → `proxy=值, trust_env=False`（强制走配的）
- 留空 → httpx 默认 `trust_env=True`（识别系统 `HTTP_PROXY/HTTPS_PROXY`）

**3. 测试连接按钮没碰**（按反馈第 3 点，之后统一做）。factory 用 `kwargs.pop("proxy", None)` 兼容了 `llm_test_api` 还在传的旧 proxy 参数，不影响现有测试连接功能。

## 一个额外处理：本地地址自动绕过

有个不在反馈里但我觉得必须处理的点：如果用户配了机场代理（比如 `http://127.0.0.1:7890`），而 Ollama/LM Studio 是本地服务（`http://localhost:11434`），全局代理会让本地连接也走代理 → 直接连不上。

所以 `build_httpx_client` 检测 base_url 指向 `localhost / 127.0.0.1 / ::1 / 0.0.0.0` 时，即使配了全局代理也不走。这样本地模型用户不会因为开了代理就用不了。如果你们觉得这个行为不合适可以讨论。

## 迁移

新增 `_migrate_legacy_proxy()`：老用户配置里 `main.proxy` 非空时自动搬到 `network.proxy` 并落盘，升级无感。

## 覆盖范围

所有 provider 都接入了统一工厂：webllm / gemini / ollama / lmstudio / kimi-code / qwen-translate。前端配置界面加了"全局网络"段。

## 验证

本地跑了核心逻辑的单元测试：
- `_is_local_url`：localhost / 127.0.0.1 / IPv6 `::1` / 0.0.0.0 / 大小写 / 空值，全部正确
- `build_httpx_client`：无代理→默认 client、配代理+远程→走代理、配代理+本地→绕过、async、空白代理视为未配置
- 配置迁移：旧 `main.proxy` 正确迁移到 `network.proxy` 并落盘，已有 network.proxy 时不覆盖
- 11 个改动的 .py 文件 `py_compile` 全部通过

Closes #422