### PR TITLE
fix: 退出游戏时彻底终止进程而非仅销毁窗口

### DIFF
--- a/src-tauri/src/ai_service/game_system/auto_save.rs
+++ b/src-tauri/src/ai_service/game_system/auto_save.rs
@@ -62,14 +62,18 @@ impl AutoSaveManager {
 
     /// Register a close-requested handler on the main window that performs a
     /// final auto-save before allowing the window to actually close.
-    pub fn setup_close_handler(window: WebviewWindow, manager: Arc<Mutex<Self>>) {
+    pub fn setup_close_handler(
+        app: AppHandle,
+        window: WebviewWindow,
+        manager: Arc<Mutex<Self>>,
+    ) {
         window.clone().on_window_event(move |event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 // Prevent the window from closing immediately
                 api.prevent_close();
 
                 let mgr = manager.clone();
-                let w = window.clone();
+                let ah = app.clone();
 
                 tauri::async_runtime::spawn(async move {
                     tracing::info!("[AutoSave] 正在执行退出前自动存档...");
@@ -89,11 +93,11 @@ impl AutoSaveManager {
                         Err(_) => tracing::warn!("[AutoSave] 退出前存档超时（{} 秒），放弃等待", EXIT_SAVE_TIMEOUT_SECS),
                     }
 
-                    // Drop the manager lock before destroying the window
+                    // Drop the manager lock before exiting
                     drop(save_result);
 
-                    // Actually close the window
-                    let _ = w.destroy();
+                    // 退出整个应用程序（destroy 只会销毁窗口，不会结束进程）
+                    let _ = ah.exit(0);
                 });
             }
         });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -171,6 +171,7 @@ pub fn run() {
 
             // Set up close handler for exit auto-save
             ai_service::game_system::auto_save::AutoSaveManager::setup_close_handler(
+                app.handle().clone(),
                 window.clone(),
                 auto_save_manager.clone(),
             );


### PR DESCRIPTION
﻿## 描述

点击主菜单"退出游戏"按钮或关闭窗口时，Tauri 的 close handler 仅调用 WebviewWindow::destroy() 销毁窗口，
但 Tauri 进程并未终止，导致残留透明/不可见的窗口进程在后台运行。

## 修改内容

- **auto_save.rs**: 退出前存档完成后，改用 AppHandle::exit(0) 替代 WebviewWindow::destroy()，彻底终止 Tauri 进程
- **lib.rs**: 调用 setup_close_handler 时传入 AppHandle

## 检查清单

- [x] 编译通过（cargo check 成功）
- [x] 仅修改了相关文件
- [x] Closes #437
