### PR TITLE
fix: 修复在场景编辑界面鼠标特效被毛玻璃样式挡住的问题

### DIFF
--- a/src/components/settings/scene/SceneEditModal.vue
+++ b/src/components/settings/scene/SceneEditModal.vue
@@ -3,7 +3,7 @@
     <Transition name="modal">
       <div
         v-if="show"
-        class="fixed inset-0 z-9999 flex items-center justify-center p-4 backdrop-blur-md bg-black/40"
+        class="fixed inset-0 z-9998 flex items-center justify-center p-4 backdrop-blur-md bg-black/40"
         @click="$emit('close')"
       >
         <div


### PR DESCRIPTION
# 修改/src/components/settings/scene/SceneEditModal.vue中外层盒子的z-index，防止在场景编辑界面鼠标特效被模糊特效遮住

## 修改前：鼠标流星特效被毛玻璃效果挡住
<img width="761" height="244" alt="屏幕截图 2026-06-21 221158" src="https://github.com/user-attachments/assets/893a9ea3-ff7d-4464-a9d6-27315af29d13" />

## 修改后：流星特效渲染正常，三角形特效正常
<img width="796" height="386" alt="屏幕截图 2026-06-21 221323" src="https://github.com/user-attachments/assets/fef5fac6-1f15-4804-8df9-427fb0335c68" />

## 备注：
该问题发现于分支tauri-refactor的最近一次提交 77f52bc56705ce0c6cfd8dc040975840c414395a 中，且至少从0.4.5relese版本就已经存在
在修改之前已经确认过其他类似界面（如角色编辑）的鼠标特效确实是在最上层
z-index=9998可以解决问题，且没有发现其他冲突现象

第一次pr，改的很少，请见谅 ^_+