### PR TITLE
fix: 修复了实际文字速度与设置值不对应的问题

### DIFF
--- a/src/utils/typewriter/TypeWriter.ts
+++ b/src/utils/typewriter/TypeWriter.ts
@@ -166,11 +166,13 @@ export class TypeWriter {
 
           this.playRandomSound()
 
-          // Calculate delay with random variation for natural feel
-          // Effective range: speed * 0.8 to speed * 1.2
-          const baseDelay = this.speed * 0.8
-          const randomVariation = this.speed * 0.4
-          const delay = baseDelay + Math.random() * randomVariation
+          //timer接收delay的是延迟（越大越慢），而传入的speed是速度（越大越快）
+          //此处按照Text.vue（速度演示文本）中的方式重新计算延迟值
+          //并保留了原本的微量随机偏移设计
+          const maxDelay = 200
+          const minDelay = 10
+          const randomVariation = this.speed * 0.2
+          const delay = maxDelay - ((this.speed - 1) / 99) * (maxDelay - minDelay) + Math.random() * randomVariation
 
           this.timer = setTimeout(typing, delay)
         } else {


### PR DESCRIPTION
## 问题描述
游玩过程中出现设置中文字显示速度调的越快，实际对话框中文字速度反而越慢的问题——但是设置页面的测试文本速度响应正常
且在0.4.1release、0.4.5release、0.4.6（ e87bceca5da586ef9994a894a573510025214cf9 ）中均存在相同问题 ~~疑似陈年bug~~
经排查，确定是“速度”（设置拖动条的对应值）与“延迟”（打字机中文字刷新间隔）混淆了
## 改动
遵循“最小改动”的原则，仅修改了/src/utils/typewriter/TypeWriter.ts
且按照测试文本组件Text.vue中的写法，重新计算了TypeWriter.ts的延迟值（确保示例文本和游戏文本速度一致）
保留了原本“随机间隔”的逻辑，但是略微降低了系数（0.4 -> 0.2）
## 相关录屏（v0.4.6）
修改前（我慢它快，我快它慢）：

https://github.com/user-attachments/assets/164a8f45-14bd-49e6-9518-39b8c2016802

修改后，一切正常：

https://github.com/user-attachments/assets/b23fe67b-0a24-474c-a0e8-1ecc20bf9111

## Checklist / 检查清单
- [x] 此更改没有影响LingChat的其他功能，如桌宠
- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“运行截图”或“测试日志”**。/ My changes have been well-tested, **and "Screenshots" or "Test Logs" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

### 备注

这是我的第二次PR，十分感谢LingChat项目对我的包容和支持！ヾ(≧▽≦*)o
如果我的更改有任何问题，请提醒我，我愿意学习改正~
