### PR TITLE
fix/pomodoro-invoke

### DIFF
--- a/src/components/pomodoro/PomodoroPanel.vue
+++ b/src/components/pomodoro/PomodoroPanel.vue
@@ -223,7 +223,7 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import Button from '../base/widget/Button.vue'
 import { useGameStore } from '../../stores/modules/game'
 import { useUIStore } from '@/stores/modules/ui/ui'
-import { scriptHandler } from '../../api/websocket/handlers/script-handler'
+import { invoke } from '@tauri-apps/api/core'
 
 const gameStore = useGameStore()
 const uiStore = useUIStore()
@@ -324,7 +324,10 @@ function sendUserPrompt(text: string) {
     displayName: gameStore.userName,
     content,
   })
-  scriptHandler.sendMessage(content)
+  invoke('send_chat_message', { text: content }).catch((err) => {
+    console.error('番茄钟消息发送失败:', err)
+    gameStore.currentStatus = 'input'
+  })
 }
 
 function flushPendingPrompts() {


### PR DESCRIPTION
修复：番茄钟发送消息失败
症状：点击番茄钟「开始」/ 阶段切换时，前端调 scriptHandler.sendMessage() → sendWebSocketChatMessage()，但 Rust 后端没有 WebSocket 服务（旧的 Python 后端已被 Tauri 替换），消息从未送达 LLM。 修复：PomodoroPanel.vue 直接走 invoke('send_chat_message', { text })，与 ChatInput.vue:120,129 一致。.catch 把 gameStore.currentStatus 回滚到 input，避免 LLM 失败时界面卡在 thinking。

改动：仅 1 个文件，5 行新增 / 2 行删除。后端零改动。