### PR TITLE
fix: 修复取消截图后不能再次截图的问题

### DIFF
--- a/src-tauri/src/api/screenshot.rs
+++ b/src-tauri/src/api/screenshot.rs
@@ -89,6 +89,7 @@ pub async fn confirm_screenshot(app: AppHandle, base64_cropped: String) -> Resul
 /// 覆盖窗口调用：用户取消截图。
 #[tauri::command]
 pub async fn cancel_screenshot(app: AppHandle) -> Result<(), String> {
+    let _ = app.emit("screenshot:cancelled", ());
     cleanup(&app).await;
     tracing::info!("[Screenshot] Cancelled by user.");
     Ok(())

--- a/src/components/game/standard/GameDialog.vue
+++ b/src/components/game/standard/GameDialog.vue
@@ -354,6 +354,7 @@ const toggleRecording = async () => {
 }
 
 let unlistenScreenshot: (() => void) | null = null
+let unlistenCancelled: (() => void) | null = null
 
 onMounted(async () => {
   document.addEventListener('contextmenu', handleDialogShow)
@@ -370,12 +371,19 @@ onMounted(async () => {
     hasScreenshot.value = true
     isCapturing.value = false
   })
+
+  // 监听截图取消事件
+  unlistenCancelled = await listen('screenshot:cancelled', () => {
+    isCapturing.value = false
+    hasScreenshot.value = false
+  })
 })
 
 onUnmounted(() => {
   document.removeEventListener('contextmenu', handleDialogShow)
   window.removeEventListener('resize', updateContainerWidth)
   if (unlistenScreenshot) unlistenScreenshot()
+  if (unlistenCancelled) unlistenCancelled()
 })
 
 async function startScreenshot() {

--- a/src/composables/useScreenshot.ts
+++ b/src/composables/useScreenshot.ts
@@ -7,6 +7,7 @@ const hasScreenshot = ref(false)
 const screenshotBase64 = ref<string | null>(null)
 const isCapturing = ref(false)
 let unlisten: (() => void) | null = null
+let unlistenCanceled: (() => void) | null = null
 let initCount = 0
 
 export function useScreenshot() {
@@ -19,6 +20,13 @@ export function useScreenshot() {
     }).then((fn) => {
       unlisten = fn
     })
+
+    listen('screenshot:cancelled', () => {  //监听截图取消事件
+      hasScreenshot.value = false
+      isCapturing.value = false
+    }).then((fn) => {
+      unlistenCanceled = fn
+    })
   }
 
   function destroy() {
@@ -26,6 +34,11 @@ export function useScreenshot() {
     if (unlisten) {
       unlisten()
       unlisten = null
+    }
+
+    if (unlistenCanceled) {
+      unlistenCanceled()
+      unlistenCanceled = null
     }
   }
 


### PR DESCRIPTION
## 问题描述
游玩过程中，发现在窗口模式和桌宠模式下，取消一次截图后再点击截图键无反应、无控制台输出，必须切到另外一个模式后才能再次截图

### 原因分析
后端 cancel_screenshot 执行清理后静默结束，未向前端发送任何事件通知；前端 GameDialog.vue 仅监听了 screenshot:captured（成功事件），缺少对取消状态的监听，导致 isCapturing 永远为 true

## 改动
本次改动涉及三个文件：
src/components/game/standard/GameDialog.vue    **主对话窗口，设置了取消事件的监听**
src/composables/useScreenshot.ts    **桌宠，设置了取消事件的监听**
src-tauri/src/api/screenshot.rs    **后端，在 cancel_screenshot 中 emit screenshot:cancelled 事件，通知前端流程已终止**
## 相关录屏（v0.4.6）
### 修改前：

https://github.com/user-attachments/assets/4e9efe26-6760-4907-96a7-ca39e7a3116e


（视频里貌似出现双击桌宠时**灵灵会瞬移**的bug，禁用双击最大化应该能解决，暂时没改）

### 修改后：

https://github.com/user-attachments/assets/44ca6bb2-085a-4f82-af57-f89e0229dba1


## Checklist / 检查清单
- [x] 此更改没有影响LingChat的其他功能，原本的截图功能正常运行
- [ ] ⚠对LingChat手机版的影响未知

### 备注
这是我为LingChat缝缝补补小bug的第三个PR
~~胆子比较肥~~ 动了后端代码，整体改动不太多
如果我的更改有任何问题，请提醒我( •̀ ω •́ )✧

