### PR TITLE
fix: 修复触摸/番茄钟发送对话的两处 bug

### DIFF
--- a/src/components/game/standard/TouchAreas.vue
+++ b/src/components/game/standard/TouchAreas.vue
@@ -36,9 +36,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useGameStore } from '@/stores/modules/game'
-import { scriptHandler } from '@/api/websocket/handlers/script-handler'
-import { eventQueue } from '@/core/events/event-queue'
 import { invoke } from '@tauri-apps/api/core'
+import { eventQueue } from '@/core/events/event-queue'
 
 interface BodyPart {
   X: number[]
@@ -248,13 +247,15 @@ const handlePolygonClick = (event: MouseEvent) => {
           message = defaultMessage
         }
 
-        // scriptHandler.sendMessage(message)
-        invoke('send_chat_message', {
-          message,
-        }).catch((error) => {
-          console.error('发送消息失败:', error)
-          gameStore.currentStatus = 'input'
-        })
+        invoke('send_chat_message', { text: message })
+          .then(() => {
+            // 发送成功，状态由后端事件驱动更新
+          })
+          .catch((error) => {
+            console.error('发送消息失败:', error)
+            gameStore.currentStatus = 'input'
+            sent.value = false
+          })
         sent.value = true
       } else {
         const needWait = eventQueue.continue()

--- a/src/components/pomodoro/PomodoroPanel.vue
+++ b/src/components/pomodoro/PomodoroPanel.vue
@@ -223,7 +223,7 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import Button from '../base/widget/Button.vue'
 import { useGameStore } from '../../stores/modules/game'
 import { useUIStore } from '@/stores/modules/ui/ui'
-import { scriptHandler } from '../../api/websocket/handlers/script-handler'
+import { invoke } from '@tauri-apps/api/core'
 
 const gameStore = useGameStore()
 const uiStore = useUIStore()
@@ -319,12 +319,27 @@ function sendUserPrompt(text: string) {
   }
 
   gameStore.currentStatus = 'thinking'
+  // 记录用户消息的插入位置，失败时回退要把它从聊天里撤掉
+  const userMessageIndex = gameStore.dialogHistory.length
   gameStore.appendGameMessage({
     type: 'message',
     displayName: gameStore.userName,
     content,
   })
-  scriptHandler.sendMessage(content)
+  invoke('send_chat_message', { text: content })
+    .then(() => {
+      // 发送成功，状态由后端事件驱动更新
+    })
+    .catch((error) => {
+      console.error('发送消息失败:', error)
+      // 移除孤立的用户消息，避免在聊天里留下无回复的尾巴
+      // 仅当那条消息仍是用户发出的原内容时才删除，防止误删后端并发写入
+      const last = gameStore.dialogHistory[userMessageIndex]
+      if (last && last.type === 'message' && last.content === content) {
+        gameStore.dialogHistory.splice(userMessageIndex, 1)
+      }
+      gameStore.currentStatus = 'input'
+    })
 }
 
 function flushPendingPrompts() {


### PR DESCRIPTION
- TouchAreas.vue: invoke 参数 `message` 改为 `text`，匹配 Rust 端 send_chat_message 签名； 失败时 `sent.value = false` 允许重置并重试；恢复中文错误日志。
- PomodoroPanel.vue: 把 `scriptHandler.sendMessage` 替换为 `invoke('send_chat_message')`； 失败时回退 currentStatus 到 input，并 splice 移除孤立的用户消息，避免无回复尾巴。