### PR TITLE
feat: 前端添加LM Studio本地推理选项（后端复用openai逻辑）

### DIFF
--- a/src-tauri/src/ai_service/llm/factory.rs
+++ b/src-tauri/src/ai_service/llm/factory.rs
@@ -9,7 +9,7 @@ use super::{LlmClient, LlmConfig};
 /// 对标 Python `LLMProviderFactory.create_provider()`。
 pub fn create_llm_client(cfg: LlmConfig) -> Result<LlmClient> {
     let provider: Box<dyn LlmProvider> = match cfg.provider.to_lowercase().as_str() {
-        "" | "openai" | "webllm" => Box::new(OpenAiProvider::from_config(&cfg)?),
+        "" | "openai" | "webllm" | "lmstudio" => Box::new(OpenAiProvider::from_config(&cfg)?),
         "gemini" => Box::new(GeminiProvider::from_config(&cfg)?),
         other => return Err(anyhow!("不支持的 LLM 提供商: {other}")),
     };

--- a/src-tauri/src/ai_service/llm/factory.rs
+++ b/src-tauri/src/ai_service/llm/factory.rs
@@ -9,6 +9,7 @@ use super::{LlmClient, LlmConfig};
 /// 对标 Python `LLMProviderFactory.create_provider()`。
 pub fn create_llm_client(cfg: LlmConfig) -> Result<LlmClient> {
     let provider: Box<dyn LlmProvider> = match cfg.provider.to_lowercase().as_str() {
+        // LM Studio 走 OpenAI 兼容协议，复用 OpenAiProvider
         "" | "openai" | "webllm" | "lmstudio" => Box::new(OpenAiProvider::from_config(&cfg)?),
         "gemini" => Box::new(GeminiProvider::from_config(&cfg)?),
         other => return Err(anyhow!("不支持的 LLM 提供商: {other}")),

--- a/src/components/settings/pages/SettingsLlmProviders.vue
+++ b/src/components/settings/pages/SettingsLlmProviders.vue
@@ -280,10 +280,14 @@
               <div class="relative">
                 <select
                   v-model="editing.provider"
+                  @change="onProviderChange"
                   class="w-full appearance-none pl-3 pr-8 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm outline-none focus:border-brand transition-colors cursor-pointer"
                 >
                   <option value="openai" class="bg-gray-800 text-white">
                     OpenAI 兼容 (DeepSeek / 通义千问 / Ollama)
+                  </option>
+                  <option value="lmstudio" class="bg-gray-800 text-white">
+                    LM Studio（本地）
                   </option>
                   <option value="gemini" class="bg-gray-800 text-white">Gemini</option>
                 </select>
@@ -313,7 +317,7 @@
               <input
                 v-model="editing.model"
                 type="text"
-                placeholder="例如: deepseek-chat"
+                :placeholder="editing.provider === 'lmstudio' ? '如: llama-3.2-3b-instruct' : '如: deepseek-chat'"
                 class="px-3 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm outline-none focus:border-brand transition-colors placeholder:text-white/20"
               />
             </div>
@@ -493,6 +497,21 @@ function emptyProvider(): LlmProviderConfig {
 function closePanel() {
   sidePanel.value = null
   saveMessage.value = ''
+}
+
+function onProviderChange() {
+  if (editing.provider === 'lmstudio') {
+    editing.base_url = 'http://localhost:1234/v1'
+    editing.api_key = 'sk-lingchat70'
+  } else {
+    // 切回其他供应商时清除 LM Studio 的默认值
+    if (editing.base_url === 'http://localhost:1234/v1') {
+      editing.base_url = ''
+    }
+    if (editing.api_key === 'sk-lingchat70') {
+      editing.api_key = ''
+    }
+  }
 }
 
 function startAdd() {

--- a/src/components/settings/pages/SettingsLlmProviders.vue
+++ b/src/components/settings/pages/SettingsLlmProviders.vue
@@ -472,6 +472,7 @@ const sidePanel = ref<'edit' | 'test' | null>(null)
 const editing = reactive<LlmProviderConfig>(emptyProvider())
 const saveMessage = ref('')
 const saveError = ref(false)
+const lmstudioAutoFilled = ref(false)
 
 // Test state
 const testProvider = ref<LlmProviderConfig | null>(null)
@@ -499,17 +500,22 @@ function closePanel() {
   saveMessage.value = ''
 }
 
+// LM Studio 兼容：本质是 OpenAI 协议，这里只帮用户预填默认地址和假 key
 function onProviderChange() {
   if (editing.provider === 'lmstudio') {
     editing.base_url = 'http://localhost:1234/v1'
     editing.api_key = 'sk-lingchat70'
+    lmstudioAutoFilled.value = true
   } else {
-    // 切回其他供应商时清除 LM Studio 的默认值
-    if (editing.base_url === 'http://localhost:1234/v1') {
-      editing.base_url = ''
-    }
-    if (editing.api_key === 'sk-lingchat70') {
-      editing.api_key = ''
+    // 仅清除由 LM Studio 自动填入的默认值，不误伤用户手写的相同值
+    if (lmstudioAutoFilled.value) {
+      if (editing.base_url === 'http://localhost:1234/v1') {
+        editing.base_url = ''
+      }
+      if (editing.api_key === 'sk-lingchat70') {
+        editing.api_key = ''
+      }
+      lmstudioAutoFilled.value = false
     }
   }
 }


### PR DESCRIPTION
## 概述
LM Studio 暴露标准的 OpenAI 兼容 API，修改前端即可实现支持
~~这个功能有点鸡肋因为原有的openai选项也能调用~~ **方便起见，在前端添加LM Studio选项**
## 改动明细
后端 factory.rs将lmstudio映射到OpenAiProvider
提供商下拉菜单新增LM Studio（本地）选项（value="lmstudio"）
选择 LM Studio 时自动填入：base_url、api_key

## 运行截图
<img width="1031" height="286" alt="屏幕截图 2026-07-02 232557" src="https://github.com/user-attachments/assets/4a9e397c-39ad-48d8-a97b-ab43485ef271" />
<img width="1568" height="785" alt="屏幕截图 2026-07-02 225126" src="https://github.com/user-attachments/assets/88304af9-246b-4ef3-9915-8ceafbfa9811" />

## 其他
如有需要改进的地方请在开发者群揪我！o(><；)oo