### PR TITLE
pref: 优化主动对话触发逻辑

### DIFF
--- a/src-tauri/src/ai_service/proactive_system/delivery_evaluator.rs
+++ b/src-tauri/src/ai_service/proactive_system/delivery_evaluator.rs
@@ -18,37 +18,9 @@ impl DeliveryEvaluator {
             tracing::debug!("[DeliveryEval] can_deliver=false (frontend report)");
             return false;
         }
-
-        if perception.state == UserState::GAME {
-            // Alarm 例外：日程闹钟连游戏时也允许投放
-            if intent_type != IntentType::Alarm {
-                tracing::debug!("[DeliveryEval] User is GAME -> deny {:?}", intent_type);
-                return false;
-            }
-        }
-
-        // 各意图类型允许的 UserState
-        let allowed = match intent_type {
-            // Alarm：任何时候都可以
-            IntentType::Alarm => true,
-            // 重要提醒：除 GAME（上面已拦截）外均可
-            IntentType::ImportantDay | IntentType::Todo => true,
-            // 屏幕感知：直接允许
-            IntentType::Screen => true,
-            // 闲聊：仅真正空闲时
-            IntentType::Topic => matches!(
-                perception.state,
-                UserState::IDLE | UserState::CASUAL
-            ),
-        };
-
-            if !allowed {
-            tracing::debug!(
-                "[DeliveryEval] State={:?} denies intent {:?}",
-                perception.state,
-                intent_type
-            );
-        }
-        allowed
+        /*
+        Tips: 此处可以添加更多判断逻辑，比如过滤掉无意义对话等
+         */
+        true
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/delivery_evaluator.rs
+++ b/src-tauri/src/ai_service/proactive_system/delivery_evaluator.rs
@@ -1,0 +1,54 @@
+//! 投放时机评估器。
+//!
+//! 唯一闸门：所有意图（新生成/暂存）投放前必经此处。
+
+use super::types::{IntentType, PerceptionResult, UserState};
+
+pub struct DeliveryEvaluator;
+
+impl DeliveryEvaluator {
+    /// 判断是否可投放。`can_deliver` 由前端上报（在聊天界面 + 无设置面板 + 输入为空）。
+    /// 软条件根据意图类型进一步过滤用户活动状态。
+    pub fn can_deliver(
+        intent_type: IntentType,
+        perception: &PerceptionResult,
+        can_deliver: bool,
+    ) -> bool {
+        if !can_deliver {
+            tracing::debug!("[DeliveryEval] can_deliver=false (frontend report)");
+            return false;
+        }
+
+        if perception.state == UserState::GAME {
+            // Alarm 例外：日程闹钟连游戏时也允许投放
+            if intent_type != IntentType::Alarm {
+                tracing::debug!("[DeliveryEval] User is GAME -> deny {:?}", intent_type);
+                return false;
+            }
+        }
+
+        // 各意图类型允许的 UserState
+        let allowed = match intent_type {
+            // Alarm：任何时候都可以
+            IntentType::Alarm => true,
+            // 重要提醒：除 GAME（上面已拦截）外均可
+            IntentType::ImportantDay | IntentType::Todo => true,
+            // 屏幕感知：直接允许
+            IntentType::Screen => true,
+            // 闲聊：仅真正空闲时
+            IntentType::Topic => matches!(
+                perception.state,
+                UserState::IDLE | UserState::CASUAL
+            ),
+        };
+
+            if !allowed {
+            tracing::debug!(
+                "[DeliveryEval] State={:?} denies intent {:?}",
+                perception.state,
+                intent_type
+            );
+        }
+        allowed
+    }
+}

--- a/src-tauri/src/ai_service/proactive_system/interest_manager.rs
+++ b/src-tauri/src/ai_service/proactive_system/interest_manager.rs
@@ -18,7 +18,7 @@ impl InterestManager {
             initial_max_cap: 100.0,
             status_mod: 0,
             max_proactive_count,
-            decay_step: 50.0,
+            decay_step: 20.0,
             proactive_times: 0,
         }
     }
@@ -70,7 +70,7 @@ impl InterestManager {
     }
 
     pub fn decay_max_interest_cap(&mut self) {
-        self.max_interest_cap = (self.max_interest_cap - self.decay_step).max(0.0);
+        self.max_interest_cap = (self.max_interest_cap - self.decay_step).max(50.0);
         tracing::info!("[Engagement] Cap decayed to {:.2}", self.max_interest_cap);
     }
 

--- a/src-tauri/src/ai_service/proactive_system/mod.rs
+++ b/src-tauri/src/ai_service/proactive_system/mod.rs
@@ -46,6 +46,10 @@ pub struct ProactiveSystem {
 
     loop_handle: Option<JoinHandle<()>>,
     is_running: bool,
+
+    /// 前端上报的“当前是否适合投放主动对话”。
+    /// 条件：用户在聊天界面(/chat 或 /pet) 且 设置面板未打开 且 输入框为空。
+    can_deliver: bool,
 }
 
 impl ProactiveSystem {
@@ -78,6 +82,7 @@ impl ProactiveSystem {
             strategy_dispatcher,
             loop_handle: None,
             is_running: false,
+            can_deliver: false,
         };
 
         system
@@ -192,16 +197,31 @@ impl ProactiveSystem {
         self.interest_manager.restore_max_interest_cap();
     }
 
+    /// 前端通知后端当前是否具备投放条件。
+    /// 前端仅在最终布尔值翻转时调用（不会反复上报）。
+    pub fn set_can_deliver(&mut self, val: bool) {
+        if self.can_deliver == val {
+            return; // 未变化，忽略
+        }
+        tracing::info!(
+            "[ProactiveSystem] can_deliver changed: {} -> {}",
+            self.can_deliver,
+            val
+        );
+        self.can_deliver = val;
+    }
+
     /// 执行单次主动对话检查周期。
     async fn run_cycle(system_arc: Arc<Mutex<Self>>) -> anyhow::Result<()> {
         let mut sys = system_arc.lock().await;
 
         tracing::info!(
-            "[ProactiveSystem] Cycle start. Interest: {:.2}/{:.2}, count today: {}/{}",
+            "[ProactiveSystem] Cycle start. Interest: {:.2}/{:.2}, count today: {}/{}, can_deliver={}",
             sys.interest_manager.interest,
             sys.interest_manager.max_interest_cap,
             sys.interest_manager.proactive_times,
-            sys.interest_manager.max_proactive_count
+            sys.interest_manager.max_proactive_count,
+            sys.can_deliver,
         );
 
         // 1. 获取日程设置快照以供后续分析使用

--- a/src-tauri/src/ai_service/proactive_system/mod.rs
+++ b/src-tauri/src/ai_service/proactive_system/mod.rs
@@ -412,7 +412,8 @@ impl ProactiveSystem {
             return Ok(());
         }
 
-        // ─── 生成 prompt ───
+        // ─── 生成 prompt（SCREEN 调用视觉模型可能耗时，先禁用前端输入）───
+        events::emit_thinking(&sys.app, true);
         let prompt_result = {
             let svc = sys.ai_service.lock().await;
             let gs = svc.game_status.lock().await;
@@ -422,6 +423,7 @@ impl ProactiveSystem {
         };
 
         let Some((raw_prompt, intent_type)) = prompt_result else {
+            events::emit_thinking(&sys.app, false);
             return Ok(());
         };
 

--- a/src-tauri/src/ai_service/proactive_system/mod.rs
+++ b/src-tauri/src/ai_service/proactive_system/mod.rs
@@ -1,5 +1,6 @@
 pub mod activity_monitor;
 pub mod config;
+pub mod delivery_evaluator;
 pub mod interest_manager;
 pub mod schedule_manager;
 pub mod strategy_dispatcher;
@@ -23,10 +24,11 @@ use crate::ChatComponents;
 
 use activity_monitor::UserActivityMonitor;
 use config::ProactiveConfig;
+use delivery_evaluator::DeliveryEvaluator;
 use interest_manager::InterestManager;
 use schedule_manager::ScheduleManager;
 use strategy_dispatcher::StrategyDispatcher;
-use types::UserScheduleSettings;
+use types::{IntentType, PendingIntent, UserScheduleSettings};
 use visual_monitor::VisualMonitor;
 
 pub struct ProactiveSystem {
@@ -50,7 +52,8 @@ pub struct ProactiveSystem {
     /// 前端上报的“当前是否适合投放主动对话”。
     /// 条件：用户在聊天界面(/chat 或 /pet) 且 设置面板未打开 且 输入框为空。
     can_deliver: bool,
-}
+    /// 暂存的主动对话意图（"小本本"）。每轮 cycle 开头尝试投放。
+    pending_intents: Vec<PendingIntent>,}
 
 impl ProactiveSystem {
     pub fn new(
@@ -83,6 +86,7 @@ impl ProactiveSystem {
             loop_handle: None,
             is_running: false,
             can_deliver: false,
+            pending_intents: Vec::new(),
         };
 
         system
@@ -104,7 +108,7 @@ impl ProactiveSystem {
             tracing::info!("[ProactiveSystem] Loop task started.");
 
             // Loop runs every 30 seconds
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
+            let mut interval = tokio::time::interval(Duration::from_secs(5));
             loop {
                 interval.tick().await;
 
@@ -201,7 +205,7 @@ impl ProactiveSystem {
     /// 前端仅在最终布尔值翻转时调用（不会反复上报）。
     pub fn set_can_deliver(&mut self, val: bool) {
         if self.can_deliver == val {
-            return; // 未变化，忽略
+            return;
         }
         tracing::info!(
             "[ProactiveSystem] can_deliver changed: {} -> {}",
@@ -211,144 +215,19 @@ impl ProactiveSystem {
         self.can_deliver = val;
     }
 
-    /// 执行单次主动对话检查周期。
-    async fn run_cycle(system_arc: Arc<Mutex<Self>>) -> anyhow::Result<()> {
-        let mut sys = system_arc.lock().await;
+    // ============================================================
+    // 核心投放方法
+    // ============================================================
 
-        tracing::info!(
-            "[ProactiveSystem] Cycle start. Interest: {:.2}/{:.2}, count today: {}/{}, can_deliver={}",
-            sys.interest_manager.interest,
-            sys.interest_manager.max_interest_cap,
-            sys.interest_manager.proactive_times,
-            sys.interest_manager.max_proactive_count,
-            sys.can_deliver,
-        );
+    /// 统一的主动对话投放入口。持有锁不放，直到 LLM 流式生成完毕。
+    /// 已侵入 game_status 的副作用（add_line），调用者需确保：
+    /// - generation_lock 未被持有
+    /// - prompt 已完整生成（含截图分析结果）
+    async fn deliver(&mut self, prompt: String) -> anyhow::Result<()> {
+        tracing::info!("[ProactiveSystem] Delivering proactive dialogue...");
 
-        // 1. 获取日程设置快照以供后续分析使用
-        let settings_snap = {
-            let snap = sys.settings.read().await;
-            snap.clone()
-        };
-
-        // 2. 检查日程强提醒 (Alarm)
-        if sys.config.enable_schedule_reminder {
-            let reminder_prompt = {
-                let user_name = {
-                    let svc = sys.ai_service.lock().await;
-                    let gs = svc.game_status.lock().await;
-                    gs.player.user_name.clone()
-                };
-                sys.schedule_manager
-                    .check_schedule_reminder(&user_name, &settings_snap)
-            };
-
-            if let Some(prompt) = reminder_prompt {
-                // 日程时间到了直接强制触发对话
-                sys.trigger_proactive_dialogue(prompt).await?;
-                return Ok(());
-            }
-        }
-
-        // 3. 执行键盘鼠标与视觉变更感知
-        let perception = sys.activity_monitor.get_user_status();
-
-        // 视觉变化监测 TODO: 视觉模块将会在后面优化为更智能的模块，目前先不启用
-        // if sys.config.enable_visual_perception {
-        //     let change = sys.visual_monitor.check_visual_change();
-        //     perception.visual_change_detected = change;
-        // }
-
-        // 4. 更新好感度/兴趣度
-        sys.interest_manager.update_interest();
-        sys.interest_manager
-            .set_status_mod(perception.interest_modifier);
-
-        // 5. 检查是否满足主动出击触发阈值
-        if sys.interest_manager.should_trigger_talk() {
-            tracing::info!(
-                "[ProactiveSystem] Trigger fired! Interest: {:.2}, preparing proactive dialogue...",
-                sys.interest_manager.interest
-            );
-
-            // 确保没有正在进行的 LLM 对话
-            let lock_clone = sys.generation_lock.clone();
-            if lock_clone.try_lock().is_err() {
-                tracing::debug!(
-                    "[ProactiveSystem] Chat generation is locked. Postponing proactive talk..."
-                );
-                return Ok(());
-            }
-
-            // 获取锁，准备触发主动对话
-            let _lock = lock_clone.lock().await;
-
-            // 发送思考状态，防止前端输入
-            events::emit_thinking(&sys.app, true);
-
-            let prompt_opt = {
-                let svc = sys.ai_service.lock().await;
-                let gs = svc.game_status.lock().await;
-                sys.strategy_dispatcher
-                    .get_proactive_prompt(&gs, &settings_snap, &perception, &sys.config)
-                    .await
-            };
-
-            if let Some(prompt) = prompt_opt {
-                sys.interest_manager.reset_interest();
-
-                // 必须在持有 generation_lock 期间进行消息处理，防止与用户回复混淆
-                let generator = {
-                    let game_status = {
-                        let svc = sys.ai_service.lock().await;
-                        svc.game_status.clone()
-                    };
-                    let deps = GeneratorDeps {
-                        app: sys.app.clone(),
-                        db: sys.db.clone(),
-                        game_status,
-                        processor: sys.chat.processor.clone(),
-                        translator: sys.chat.translator.clone(),
-                        llm: sys
-                            .chat
-                            .llm
-                            .clone()
-                            .ok_or_else(|| anyhow::anyhow!("LLM is not configured"))?,
-                        concurrency: 1,
-                        god_agent: None,
-                    };
-                    MessageGenerator::new(deps)
-                };
-
-                // 往 game_status 追加系统级的主动 prompt 作为隐形触发台词
-                {
-                    let svc = sys.ai_service.lock().await;
-                    let mut gs = svc.game_status.lock().await;
-                    gs.add_line(
-                        &sys.db,
-                        LineBase {
-                            attribute: LineAttributeExt(LineAttribute::User),
-                            content: PromptRole::System.build_prompt(&prompt),
-                            sender_role_id: None,
-                            display_name: None,
-                            ..Default::default()
-                        },
-                    )
-                    .await?;
-                }
-
-                // 派发流式生成任务并等待其处理完毕 (包括 TTS 音频分段输出)
-                let _ = generator.process_message(None).await;
-            } else {
-                events::emit_thinking(&sys.app, false);
-            }
-        }
-
-        Ok(())
-    }
-
-    /// 强行触发日程警报对话 (忽略兴趣好感阈值)
-    async fn trigger_proactive_dialogue(&mut self, prompt: String) -> anyhow::Result<()> {
         let _lock = self.generation_lock.lock().await;
+        events::emit_thinking(&self.app, true);
 
         let generator = {
             let game_status = {
@@ -361,10 +240,7 @@ impl ProactiveSystem {
                 game_status,
                 processor: self.chat.processor.clone(),
                 translator: self.chat.translator.clone(),
-                llm: self
-                    .chat
-                    .llm
-                    .clone()
+                llm: self.chat.llm.clone()
                     .ok_or_else(|| anyhow::anyhow!("LLM is not configured"))?,
                 concurrency: 1,
                 god_agent: None,
@@ -379,7 +255,7 @@ impl ProactiveSystem {
                 &self.db,
                 LineBase {
                     attribute: LineAttributeExt(LineAttribute::User),
-                    content: PromptRole::System.build_prompt(&prompt),
+                    content: prompt,
                     sender_role_id: None,
                     display_name: None,
                     ..Default::default()
@@ -389,6 +265,192 @@ impl ProactiveSystem {
         }
 
         let _ = generator.process_message(None).await;
+        Ok(())
+    }
+
+    /// 遍历暂存队列，尝试投放一个合适的意图。
+    /// 返回 `true` 表示本轮已投放（调用方应 return）。
+    async fn try_flush_pending_intent(&mut self) -> anyhow::Result<bool> {
+        if self.pending_intents.is_empty() {
+            return Ok(false);
+        }
+
+        if self.generation_lock.try_lock().is_err() {
+            tracing::debug!("[ProactiveSystem] gen_lock busy, skip flush");
+            return Ok(false);
+        }
+
+        let perception = self.activity_monitor.get_user_status();
+        let now = std::time::Instant::now();
+
+        // 按优先级降序：Alarm(4) > ImportantDay(3) > Todo(2) > Screen(1) > Topic(0)
+        self.pending_intents
+            .sort_by_key(|i| std::cmp::Reverse(i.intent_type));
+
+        // 第一步：清理过期意图
+        let before = self.pending_intents.len();
+        self.pending_intents.retain(|intent| {
+            let elapsed = now.duration_since(intent.triggered_at).as_secs();
+            if elapsed > intent.intent_type.ttl_secs() {
+                tracing::info!(
+                    "[ProactiveSystem] Intent {:?} expired after {}s, discarding",
+                    intent.intent_type, elapsed
+                );
+                false
+            } else {
+                true
+            }
+        });
+        if before != self.pending_intents.len() {
+            tracing::info!(
+                "[ProactiveSystem] Expired discard: {} -> {}",
+                before,
+                self.pending_intents.len()
+            );
+        }
+
+        // 第二步：找第一个可投放的（索引有效，因为不在遍历中收集）
+        for (i, intent) in self.pending_intents.iter().enumerate() {
+            if DeliveryEvaluator::can_deliver(
+                intent.intent_type,
+                &perception,
+                self.can_deliver,
+            ) {
+                let intent = self.pending_intents.remove(i);
+                let waited = now.duration_since(intent.triggered_at);
+                tracing::info!(
+                    "[ProactiveSystem] Flushing deferred {:?} intent (waited {:.0}s, {} remaining in queue)",
+                    intent.intent_type,
+                    waited.as_secs(),
+                    self.pending_intents.len()
+                );
+                self.deliver(intent.prompt).await?;
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    // ============================================================
+    // run_cycle（核心流程）
+    // ============================================================
+
+    /// 执行单次主动对话检查周期。
+    async fn run_cycle(system_arc: Arc<Mutex<Self>>) -> anyhow::Result<()> {
+        let mut sys = system_arc.lock().await;
+
+        tracing::info!(
+            "[ProactiveSystem] Cycle start. Interest: {:.2}/{:.2}, count today: {}/{}, can_deliver={}, pending={}",
+            sys.interest_manager.interest,
+            sys.interest_manager.max_interest_cap,
+            sys.interest_manager.proactive_times,
+            sys.interest_manager.max_proactive_count,
+            sys.can_deliver,
+            sys.pending_intents.len(),
+        );
+
+        // ─── 0. 优先清暂存队列 ───
+        if sys.try_flush_pending_intent().await? {
+            return Ok(());
+        }
+
+        // ─── 1. 快照 ───
+        let settings_snap = {
+            let snap = sys.settings.read().await;
+            snap.clone()
+        };
+
+        // ─── 2. 感知（提前到这里，供 Alarm 的 evaluate 使用）───
+        let perception = sys.activity_monitor.get_user_status();
+
+        // ─── 3. 日程警报（跳过兴趣累积，但走 evaluate 闸门）───
+        if sys.config.enable_schedule_reminder {
+            let user_name = {
+                let svc = sys.ai_service.lock().await;
+                let gs = svc.game_status.lock().await;
+                gs.player.user_name.clone()
+            };
+            if let Some(raw_prompt) = sys
+                .schedule_manager
+                .check_schedule_reminder(&user_name, &settings_snap)
+            {
+                let formatted = PromptRole::System.build_prompt(&raw_prompt);
+                if DeliveryEvaluator::can_deliver(IntentType::Alarm, &perception, sys.can_deliver) {
+                    tracing::info!("[ProactiveSystem] Alarm triggered, evaluate passed, delivering");
+                    sys.deliver(formatted).await?;
+                } else {
+                    tracing::info!("[ProactiveSystem] Alarm triggered, evaluate failed, stashing");
+                    sys.pending_intents.push(PendingIntent {
+                        prompt: formatted,
+                        intent_type: IntentType::Alarm,
+                        triggered_at: std::time::Instant::now(),
+                    });
+                }
+                return Ok(());
+            }
+        }
+
+        // ─── 4. 兴趣累积 ───
+        sys.interest_manager.update_interest();
+        sys.interest_manager
+            .set_status_mod(perception.interest_modifier);
+
+        // ─── 5. 触发检查 ───
+        if !sys.interest_manager.should_trigger_talk() {
+            return Ok(());
+        }
+
+        tracing::info!(
+            "[ProactiveSystem] Trigger fired! Interest={:.2}",
+            sys.interest_manager.interest
+        );
+
+        // gen_lock 快检
+        if sys.generation_lock.try_lock().is_err() {
+            tracing::debug!("[ProactiveSystem] gen_lock busy, aborting this trigger");
+            return Ok(());
+        }
+
+        // ─── 生成 prompt ───
+        let prompt_result = {
+            let svc = sys.ai_service.lock().await;
+            let gs = svc.game_status.lock().await;
+            sys.strategy_dispatcher
+                .get_proactive_prompt(&gs, &settings_snap, &perception, &sys.config)
+                .await
+        };
+
+        let Some((raw_prompt, intent_type)) = prompt_result else {
+            return Ok(());
+        };
+
+        // 兴趣立刻消耗（"已经想说话了"）
+        sys.interest_manager.reset_interest();
+
+        // ─── 投放闸门 ───
+        if DeliveryEvaluator::can_deliver(intent_type, &perception, sys.can_deliver) {
+            tracing::info!(
+                "[ProactiveSystem] Evaluate passed for {:?}, delivering immediately",
+                intent_type
+            );
+            let formatted = PromptRole::System.build_prompt(&raw_prompt);
+            sys.deliver(formatted).await?;
+        } else {
+            let formatted = PromptRole::System.build_prompt(&raw_prompt);
+            tracing::info!(
+                "[ProactiveSystem] Evaluate failed for {:?}, stashing (queue size: {} -> {})",
+                intent_type,
+                sys.pending_intents.len(),
+                sys.pending_intents.len() + 1,
+            );
+            sys.pending_intents.push(PendingIntent {
+                prompt: formatted,
+                intent_type,
+                triggered_at: std::time::Instant::now(),
+            });
+        }
+
         Ok(())
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/mod.rs
+++ b/src-tauri/src/ai_service/proactive_system/mod.rs
@@ -108,7 +108,7 @@ impl ProactiveSystem {
             tracing::info!("[ProactiveSystem] Loop task started.");
 
             // Loop runs every 30 seconds
-            let mut interval = tokio::time::interval(Duration::from_secs(5));
+            let mut interval = tokio::time::interval(Duration::from_secs(30));
             loop {
                 interval.tick().await;
 
@@ -421,7 +421,6 @@ impl ProactiveSystem {
                 .get_proactive_prompt(&gs, &settings_snap, &perception, &sys.config)
                 .await
         };
-
         let Some((raw_prompt, intent_type)) = prompt_result else {
             events::emit_thinking(&sys.app, false);
             return Ok(());
@@ -451,6 +450,7 @@ impl ProactiveSystem {
                 intent_type,
                 triggered_at: std::time::Instant::now(),
             });
+            events::emit_thinking(&sys.app, false);
         }
 
         Ok(())

--- a/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
+++ b/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
@@ -1,7 +1,7 @@
 use crate::ai_service::game_system::game_status::GameStatus;
 use crate::ai_service::proactive_system::config::ProactiveConfig;
 use crate::ai_service::proactive_system::types::{
-    PerceptionResult, UserScheduleSettings, UserState,
+    IntentType, PerceptionResult, UserScheduleSettings, UserState,
 };
 use crate::ai_service::screen_analyzer::{ScreenAnalyzer, ScreenAnalyzerConfig};
 use chrono::Local;
@@ -46,7 +46,7 @@ impl StrategyDispatcher {
         settings: &UserScheduleSettings,
         perception: &PerceptionResult,
         config: &ProactiveConfig,
-    ) -> Option<String> {
+    ) -> Option<(String, IntentType)> {
         let now = Local::now();
         let today_str = now.format("%m-%d").to_string();
 
@@ -72,9 +72,12 @@ impl StrategyDispatcher {
                                 "[StrategyDispatcher] Triggered important day reminder: {}",
                                 day.title
                             );
-                            return Some(format!(
-                                "{{今天是特殊的一天：{}，{}。可以和{}聊聊哦}}",
-                                day.title, desc, char_name
+                            return Some((
+                                format!(
+                                    "{{今天是特殊的一天：{}，{}。可以和{}聊聊哦}}",
+                                    day.title, desc, char_name
+                                ),
+                                IntentType::ImportantDay,
                             ));
                         }
                     }
@@ -154,25 +157,25 @@ impl StrategyDispatcher {
         match selected_mode {
             "TODO" => {
                 if let Some(prompt) = self.get_todo_prompt(game_status, settings) {
-                    return Some(prompt);
+                    return Some((prompt, IntentType::Todo));
                 }
                 // 没有 Todo 时降级到 TOPIC
                 if config.enable_topic_creator {
-                    return Some(self.get_topic_prompt(game_status));
+                    return Some((self.get_topic_prompt(game_status), IntentType::Topic));
                 }
                 None
             }
             "SCREEN" => {
                 if let Some(prompt) = self.get_screen_prompt(game_status).await {
-                    return Some(prompt);
+                    return Some((prompt, IntentType::Screen));
                 }
                 // SCREEN 抓取失败或接口失败时降级到 TOPIC
                 if config.enable_topic_creator {
-                    return Some(self.get_topic_prompt(game_status));
+                    return Some((self.get_topic_prompt(game_status), IntentType::Topic));
                 }
                 None
             }
-            _ => Some(self.get_topic_prompt(game_status)),
+            _ => Some((self.get_topic_prompt(game_status), IntentType::Topic)),
         }
     }
 

--- a/src-tauri/src/ai_service/proactive_system/types.rs
+++ b/src-tauri/src/ai_service/proactive_system/types.rs
@@ -88,3 +88,43 @@ pub struct UserScheduleSettings {
     pub todo_groups: Option<HashMap<String, TodoGroup>>,
     pub important_days: Option<Vec<ImportantDay>>,
 }
+
+// ==========================================
+// 主动对话意图暂存（"小本本"）
+// ==========================================
+
+use std::time::Instant;
+
+/// 意图类型，带 TTL 和投放优先级。
+/// `Ord` 派生顺序 = 投放优先级（高值优先投放）。
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IntentType {
+    Topic = 0,        // 闲聊 — 最低优先级
+    Screen = 1,       // 屏幕感知 — 时效短（2min TTL）
+    Todo = 2,         // 待办提醒
+    ImportantDay = 3, // 重要日子
+    Alarm = 4,        // 日程闹钟 — 最高优先级，长 TTL（不应过期）
+}
+
+impl IntentType {
+    /// 意图存活时间（秒）。超时自动作废，不再投放。
+    pub fn ttl_secs(self) -> u64 {
+        match self {
+            Self::Topic => 900,
+            Self::Screen => 120,
+            Self::Todo => 600,
+            Self::ImportantDay => 600,
+            Self::Alarm => 1800, // 30 分钟，确保不会被轻易丢弃
+        }
+    }
+}
+
+/// 暂存的主动对话意图。prompt 已完整生成，不可变。
+#[derive(Clone, Debug)]
+pub struct PendingIntent {
+    /// 已格式化的系统旁白（PromptRole::System.build_prompt 的结果）
+    pub prompt: String,
+    pub intent_type: IntentType,
+    /// 生成时间，用于 TTL 过期判断
+    pub triggered_at: Instant,
+}

--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -17,6 +17,9 @@ pub mod workshop;
 
 use std::path::PathBuf;
 
+use tauri::Manager;
+use crate::AppState;
+
 // ========== 共享路径辅助函数 ==========
 
 pub(crate) fn data_dir() -> PathBuf {
@@ -66,6 +69,22 @@ pub(crate) fn validate_path_in_base(resolved: &PathBuf, base: &PathBuf) -> Resul
              规范基础目录: {:?}",
             resolved, canon_resolved, base, canon_base
         ));
+    }
+    Ok(())
+}
+
+// ========== 主动对话系统指令 ==========
+
+/// 前端通知后端当前是否具备主动对话投放条件。
+/// 仅在最终布尔值翻转时调用。
+#[tauri::command]
+pub async fn proactive_set_can_deliver(
+    app: tauri::AppHandle,
+    can_deliver: bool,
+) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    if let Some(ref ps) = state.proactive_system {
+        ps.lock().await.set_can_deliver(can_deliver);
     }
     Ok(())
 }

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -614,7 +614,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                     ConfigSetting {
                         key: proactive::keys::MAX_PROACTIVE_TIMES.to_string(),
                         value: read_setting(app, proactive::keys::MAX_PROACTIVE_TIMES, "3"),
-                        description: "MAX_PROACTIVE_TIMES — 每日主动出击上限次数".to_string(),
+                        description: "MAX_PROACTIVE_TIMES — 在用户响应之前，能主动对话的次数".to_string(),
                         setting_type: "text".to_string(),
                     },
                 ],

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -353,6 +353,7 @@ pub fn run() {
             api::schedule::get_schedules,
             api::schedule::save_schedules,
             api::schedule::reload_proactive_system,
+            api::proactive_set_can_deliver,
             api::achievement::get_achievement_list,
             api::achievement::unlock_achievement,
             api::adventure::list_character_adventures,

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,11 @@ import AppDialog from './components/ui/AppDialog.vue'
 import { initUIStore } from './stores/modules/ui/ui'
 import { useAchievementStore } from './stores/modules/ui/achievement'
 import { useSedentaryReminder } from './composables/useSedentaryReminder'
+import { useUpdater } from './composables/useUpdater'
+import { useCanDeliver } from './composables/useCanDeliver'
+
+// 激活主动对话投放条件上报（仅在此处挂载一次）
+useCanDeliver()
 
 // ─── 久坐提醒 ────────────────────────────────────────────────
 useSedentaryReminder()

--- a/src/components/game/standard/GameDialog.vue
+++ b/src/components/game/standard/GameDialog.vue
@@ -149,8 +149,11 @@ import { escapeHtml } from '../../../utils/escapeHtml'
 import { eventQueue } from '../../../core/events/event-queue'
 import { invoke } from '@tauri-apps/api/core'
 import { listen } from '@tauri-apps/api/event'
+import { setInputHasText } from '../../../composables/useCanDeliver'
 
 const inputMessage = ref('')
+// 输入框内容变化 → 通知 can_deliver 追踪
+watch(inputMessage, (val) => setInputHasText(Boolean(val.trim())), { immediate: true })
 const isShowingMotionText = ref(false)
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 const inlineDisplayRef = ref<HTMLDivElement | null>(null)

--- a/src/components/pet/ChatInput.vue
+++ b/src/components/pet/ChatInput.vue
@@ -38,6 +38,7 @@ import { useGameStore } from '@/stores/modules/game'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import { useSettingsStore } from '@/stores/modules/settings'
 import { useScreenshot } from '@/composables/useScreenshot'
+import { setInputHasText } from '@/composables/useCanDeliver'
 import { Forward } from 'lucide-vue-next'
 
 const gameStore = useGameStore()
@@ -105,6 +106,8 @@ const props = defineProps({
 const emit = defineEmits(['message-sent'])
 
 const messageText = ref('')
+// 输入框内容变化 → 通知 can_deliver 追踪
+watch(messageText, (val) => setInputHasText(Boolean(val.trim())), { immediate: true })
 
 const sendMessage = () => {
   const text = messageText.value.trim()

--- a/src/composables/useCanDeliver.ts
+++ b/src/composables/useCanDeliver.ts
@@ -1,0 +1,63 @@
+import { ref, watch, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { invoke } from '@tauri-apps/api/core'
+import { useUIStore } from '@/stores/modules/ui/ui'
+
+/**
+ * 前端上报的“当前是否适合投放主动对话”。
+ * 条件：用户在聊天界面 且 设置面板未打开 且 输入框为空。
+ *
+ * 仅在最终布尔值翻转时调用 invoke（不会反复上报）。
+ */
+
+// ===== 可投放的路由名（聊天主界面 + 桌宠） =====
+const CHAT_ROUTES = ['LingChat', 'PetMode']
+
+// ===== 全局输入状态（由 GameDialog / ChatInput 组件上报） =====
+let _inputHasText = false
+const _inputListeners = new Set<() => void>()
+
+/** 各输入组件在 watch 中调用此函数来更新输入状态 */
+export function setInputHasText(val: boolean) {
+  if (_inputHasText === val) return
+  _inputHasText = val
+  _inputListeners.forEach((fn) => fn())
+}
+
+export function useCanDeliver() {
+  const router = useRouter()
+  const uiStore = useUIStore()
+
+  const canDeliver = ref(false)
+  let lastInvoked: boolean | null = null
+
+  function recompute() {
+    const onChatRoute = CHAT_ROUTES.includes(router.currentRoute.value.name as string)
+    canDeliver.value = onChatRoute && !uiStore.showSettings && !_inputHasText
+  }
+
+  // 监听变更
+  watch(
+    () => router.currentRoute.value.name,
+    recompute,
+    { immediate: true },
+  )
+  watch(
+    () => uiStore.showSettings,
+    recompute,
+  )
+
+  // 输入状态变化时重新计算
+  _inputListeners.add(recompute)
+
+  // 值翻转时通知后端
+  watch(canDeliver, (val) => {
+    if (val !== lastInvoked) {
+      lastInvoked = val
+      invoke('proactive_set_can_deliver', { canDeliver: val })
+        .catch((e) => console.error('[CanDeliver] invoke failed:', e))
+    }
+  })
+
+  return { canDeliver }
+}


### PR DESCRIPTION
解决#465 提到的问题

## 改动声明
后端主要改动集中在proactive_system/mod.rs中，其余改动较为零散，主要是为了新逻辑而做的适配
前端则新建src/composables/useCanDeliver.ts用来通知后端

## 已经实现的内容

1. 用户状态持续收集
2. 不满足发起条件（主界面、设置界面、输入框有字）时主动对话事件自动暂存
3. 实现暂存事件的管理（过期清除、按优先级发起）

**也就是说，在不可对话场景触发的主动对话可以延迟到再次进入可对话场景时再触发，日程提醒不会错过啦**
> ps：稍微改动了原本的interest_manager逻辑（原本的会在第一次触发后卡死）

## 仍需注意的地方
预期功能已经设计完善，但是代码总体不太优雅……还是先确定一下功能是否大体符合，之后细节还得再慢慢打磨