### PR TITLE
fix(db): 显式指定 migration name + 让 migration error 进 logcat

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -31,6 +31,11 @@ pub async fn init_db(data_dir: &Path) -> Result<DatabaseConnection> {
 
     Migrator::up(&db, None)
         .await
+        .map_err(|e: sea_orm::DbErr| {
+            // Tauri only prints the outermost context, so log the full chain here.
+            tracing::error!("migration error: {e}");
+            e
+        })
         .context("Failed to run database migrations")?;
 
     tracing::info!("Database initialized at {:?}", db_path);

--- a/src-tauri/src/migration/m20240101_000001_create_tables.rs
+++ b/src-tauri/src/migration/m20240101_000001_create_tables.rs
@@ -1,7 +1,18 @@
 use sea_orm_migration::prelude::*;
 
-#[derive(DeriveMigrationName)]
 pub struct Migration;
+
+// sea-orm 工具链在某些版本会自动用文件路径当作 migration name 写进
+// `seaql_migrations.version`（这条 db 里就是这个值）。为了保持跟旧
+// app 生成的 db 互通，name 必须跟 db 里实际记录的字符串完全一致。
+// 不要换成 "Migration" 或其他派生值，否则覆盖 db 后 migrator 找不到
+// 匹配项，会重新跑一次 CREATE TABLE IF NOT EXISTS（no-op），但 schema
+// 错位不会被发现，后续查询 panic。
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "src\\migration\\m20240101_000001_create_tables"
+    }
+}
 
 #[async_trait::async_trait]
 impl MigrationTrait for Migration {


### PR DESCRIPTION
历史 db 的 seaql_migrations.version 被旧版 sea-orm 工具链
写成 file path 形式 (src\\migration\\m20240101_000001_create_tables), 但 derive 派生的 Migration::name() 返回的是 file stem 形式
(m20240101_000001_create_tables), 两边字符串不一致 ->
migrator 报 'applied but missing' -> init 失败 -> 启动 panic。

- 显式 impl MigrationName, 硬编码 file path 形式, 匹配历史 db
- 在 Migrator::up 后加 .map_err 把完整 error 链打 tracing, 避免以后同类问题被 outermost context 吞掉看不到根因