### PR TITLE
build: add local desktop build profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vue-tsc --noEmit --skipLibCheck && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
+    "desktop:build:local": "tauri build --config src-tauri/tauri.local.conf.json",
     "android:prepare": "node scripts/prepare-bundled-resources.mjs",
     "android:build": "node scripts/prepare-bundled-resources.mjs && tauri android build --target aarch64"
   },

--- a/src-tauri/tauri.local.conf.json
+++ b/src-tauri/tauri.local.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": false
+  }
+}


### PR DESCRIPTION
## 范围

这个 PR 只补充本地桌面打包配置，不改变正式发布配置。

- 保留正式 `tauri.conf.json` 的 updater artifacts 和多平台 bundle 配置
- 增加 `src-tauri/tauri.local.conf.json`，本地打包时关闭 updater artifacts
- 增加 `pnpm desktop:build:local`，避免本地没有 updater 私钥时打包失败

## 使用方式

```bash
pnpm desktop:build:local
```

## 验证

- JSON 配置解析通过
- `pnpm run desktop:build:local --help` 能正确加载覆盖配置
- 2 个文件，7 行改动
