### PR TITLE
重构：稳定主动回复与视觉分析共享契约

### DIFF
--- a/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
+++ b/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
@@ -19,6 +19,7 @@ impl StrategyDispatcher {
             vd_api_key: config.vd_api_key.clone(),
             vd_base_url: config.vd_base_url.clone(),
             vd_model: config.vd_model.clone(),
+            provider: "openai".to_string(),
         };
         Self {
             screen_analyzer: Mutex::new(ScreenAnalyzer::new(sa_config)),
@@ -34,6 +35,7 @@ impl StrategyDispatcher {
                 vd_api_key: config.vd_api_key,
                 vd_base_url: config.vd_base_url,
                 vd_model: config.vd_model,
+                provider: "openai".to_string(),
             });
         }
     }
@@ -217,7 +219,7 @@ impl StrategyDispatcher {
             .screen_analyzer
             .lock()
             .await
-            .analyze_screen(analyze_prompt)
+            .analyze_screen(analyze_prompt, None)
             .await?;
 
         let user_name = &game_status.player.user_name;

--- a/src-tauri/src/ai_service/screen_analyzer.rs
+++ b/src-tauri/src/ai_service/screen_analyzer.rs
@@ -7,12 +7,16 @@ use reqwest::Client;
 use serde_json::Value;
 use std::time::Instant;
 
+use crate::ai_service::llm::provider_config::resolve_chat_provider;
+use crate::config::proactive::ProactiveConfig;
+
 /// 屏幕分析器的配置（从环境/Store 加载）。
 #[derive(Clone, Debug)]
 pub struct ScreenAnalyzerConfig {
     pub vd_api_key: String,
     pub vd_base_url: String,
     pub vd_model: String,
+    pub provider: String,
 }
 
 impl Default for ScreenAnalyzerConfig {
@@ -20,9 +24,18 @@ impl Default for ScreenAnalyzerConfig {
         Self {
             vd_api_key: String::new(),
             vd_base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1".to_string(),
-            vd_model: "qwen3.5-plus".to_string(),
+            vd_model: "qwen3-vl-flash".to_string(),
+            provider: "openai".to_string(),
         }
     }
+}
+
+/// Shared context passed by proactive and manual screen-analysis callers.
+#[derive(Clone, Debug, Default)]
+pub struct ScreenContext {
+    pub ai_name: Option<String>,
+    pub user_name: Option<String>,
+    pub recent_chat_summary: Option<String>,
 }
 
 /// 最后一次分析的性能与用量报告。
@@ -58,9 +71,24 @@ impl ScreenAnalyzer {
         &self.last_report
     }
 
+    /// Proactive entry point kept in the shared contract so engine and visual
+    /// implementation PRs can be reviewed independently.
+    pub async fn analyze_screen_for_proactive(
+        &mut self,
+        context: Option<&ScreenContext>,
+    ) -> Option<String> {
+        let prompt = "你刚刚看了一眼主人的电脑屏幕。若有值得自然搭话的内容，请直接回复一句不超过50字的话；否则只回复[PASS]。";
+        self.analyze_screen(prompt, context).await
+    }
+
     /// 核心方法：截屏 → 发送给 VLM 分析 → 返回文本描述。
-    /// 这是策略分发器和主动对话系统的主要入口。
-    pub async fn analyze_screen(&mut self, prompt: &str) -> Option<String> {
+    /// `context` is part of the stable cross-PR API; the visual implementation
+    /// PR enriches the prompt with it.
+    pub async fn analyze_screen(
+        &mut self,
+        prompt: &str,
+        _context: Option<&ScreenContext>,
+    ) -> Option<String> {
         let api_key = &self.config.vd_api_key;
         if api_key.is_empty() {
             tracing::warn!("[ScreenAnalyzer] VD_API_KEY is empty, skipping screenshot analysis.");
@@ -193,6 +221,31 @@ impl ScreenAnalyzer {
         };
 
         None
+    }
+}
+
+/// Resolve the visual model once for every caller. The visual implementation
+/// PR extends protocol handling without changing this shared API.
+pub fn build_screen_analyzer_config(
+    app_handle: &tauri::AppHandle,
+    config: &ProactiveConfig,
+) -> ScreenAnalyzerConfig {
+    if config.vd_follow_chat_model {
+        if let Some(provider) = resolve_chat_provider(app_handle) {
+            return ScreenAnalyzerConfig {
+                vd_api_key: provider.api_key,
+                vd_base_url: provider.base_url,
+                vd_model: provider.model,
+                provider: provider.provider,
+            };
+        }
+    }
+
+    ScreenAnalyzerConfig {
+        vd_api_key: config.vd_api_key.clone(),
+        vd_base_url: config.vd_base_url.clone(),
+        vd_model: config.vd_model.clone(),
+        provider: "openai".to_string(),
     }
 }
 

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -642,6 +642,24 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         description: "MAX_PROACTIVE_TIMES — 在用户响应之前，能主动对话的次数".to_string(),
                         setting_type: "text".to_string(),
                     },
+                    ConfigSetting {
+                        key: proactive::keys::PROACTIVE_INTERVAL_SECS.to_string(),
+                        value: read_setting(app, proactive::keys::PROACTIVE_INTERVAL_SECS, "10"),
+                        description: "PROACTIVE_INTERVAL_SECS — 主动对话轮询间隔（秒，默认 10，最小 2）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::INTEREST_TRIGGER_THRESHOLD.to_string(),
+                        value: read_setting(app, proactive::keys::INTEREST_TRIGGER_THRESHOLD, "30.0"),
+                        description: "INTEREST_TRIGGER_THRESHOLD — 兴趣度触发阈值（默认 30，越低越容易被触发）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::INTEREST_DECAY_STEP.to_string(),
+                        value: read_setting(app, proactive::keys::INTEREST_DECAY_STEP, "15.0"),
+                        description: "INTEREST_DECAY_STEP — 每次主动对话后兴趣度上限衰减量（默认 15，设为 0 则不衰减）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
                 ],
             },
         );
@@ -652,6 +670,12 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
             Subcategory {
                 description: "主动对话时调用的 Vision LLM 视觉分析模型以及截图分析设置".to_string(),
                 settings: vec![
+                    ConfigSetting {
+                        key: proactive::keys::VD_FOLLOW_CHAT_MODEL.to_string(),
+                        value: read_setting(app, proactive::keys::VD_FOLLOW_CHAT_MODEL, "true"),
+                        description: "VD_FOLLOW_CHAT_MODEL — 跟随当前对话模型；若当前是不可关闭长思考的模型，视觉识别也会明显变慢。低延迟建议关闭并配置独立轻量视觉模型".to_string(),
+                        setting_type: "bool".to_string(),
+                    },
                     ConfigSetting {
                         key: proactive::keys::VD_API_KEY.to_string(),
                         value: read_setting(app, proactive::keys::VD_API_KEY, ""),
@@ -670,8 +694,10 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                     },
                     ConfigSetting {
                         key: proactive::keys::VD_MODEL.to_string(),
-                        value: read_setting(app, proactive::keys::VD_MODEL, "qwen3.5-plus"),
-                        description: "VD_MODEL — 视觉模型型号".to_string(),
+                        value: read_setting(app, proactive::keys::VD_MODEL, "qwen3-vl-flash"),
+                        description:
+                            "VD_MODEL — 独立视觉模型型号（低延迟推荐非思考型 VL/Flash，例如 qwen3-vl-flash）"
+                                .to_string(),
                         setting_type: "text".to_string(),
                     },
                     ConfigSetting {
@@ -689,6 +715,14 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "SCREEN_WEIGHT — 视觉模式触发权重（越大越容易偷看屏幕聊天，默认 30）"
                                 .to_string(),
                         setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::VISUAL_PERCEPTION_PRIORITY.to_string(),
+                        value: read_setting(app, proactive::keys::VISUAL_PERCEPTION_PRIORITY, "false"),
+                        description:
+                            "VISUAL_PERCEPTION_PRIORITY — 视觉理解优先模式（开启后每次主动回复优先看屏幕，失败才找话题）"
+                                .to_string(),
+                        setting_type: "bool".to_string(),
                     },
                 ],
             },

--- a/src-tauri/src/config/proactive.rs
+++ b/src-tauri/src/config/proactive.rs
@@ -5,11 +5,16 @@ use tauri_plugin_store::StoreExt;
 pub mod keys {
     pub const ENABLE_PROACTIVE_SYSTEM: &str = "ENABLE_PROACTIVE_SYSTEM";
     pub const MAX_PROACTIVE_TIMES: &str = "MAX_PROACTIVE_TIMES";
+    pub const PROACTIVE_INTERVAL_SECS: &str = "PROACTIVE_INTERVAL_SECS";
+    pub const INTEREST_TRIGGER_THRESHOLD: &str = "INTEREST_TRIGGER_THRESHOLD";
+    pub const INTEREST_DECAY_STEP: &str = "INTEREST_DECAY_STEP";
+    pub const VD_FOLLOW_CHAT_MODEL: &str = "VD_FOLLOW_CHAT_MODEL";
     pub const VD_API_KEY: &str = "VD_API_KEY";
     pub const VD_BASE_URL: &str = "VD_BASE_URL";
     pub const VD_MODEL: &str = "VD_MODEL";
     pub const ENABLE_VISUAL_PRECEPTION: &str = "ENABLE_VISUAL_PRECEPTION";
     pub const SCREEN_WEIGHT: &str = "SCREEN_WEIGHT";
+    pub const VISUAL_PERCEPTION_PRIORITY: &str = "VISUAL_PERCEPTION_PRIORITY";
     pub const ENABLE_TOPIC_CREATER: &str = "ENABLE_TOPIC_CREATER";
     pub const TOPIC_WEIGHT: &str = "TOPIC_WEIGHT";
     pub const ENABLE_TODO_PRECEPTION: &str = "ENABLE_TODO_PRECEPTION";
@@ -22,11 +27,16 @@ pub mod keys {
 pub struct ProactiveConfig {
     pub enable_proactive_system: bool,
     pub max_proactive_times: i32,
+    pub proactive_interval_secs: u64,
+    pub interest_trigger_threshold: f64,
+    pub interest_decay_step: f64,
+    pub vd_follow_chat_model: bool,
     pub vd_api_key: String,
     pub vd_base_url: String,
     pub vd_model: String,
     pub enable_visual_perception: bool,
     pub screen_weight: f64,
+    pub visual_perception_priority: bool,
     pub enable_topic_creator: bool,
     pub topic_weight: f64,
     pub enable_todo_perception: bool,
@@ -86,21 +96,46 @@ impl ProactiveConfig {
                 .unwrap_or(default)
         };
 
+        let get_bounded_f64 = |key: &str, default: f64, min: f64, max: f64| -> f64 {
+            let value = get_f64(key, default);
+            if value.is_finite() {
+                value.clamp(min, max)
+            } else {
+                tracing::warn!(
+                    "[ProactiveConfig] {} is not finite, falling back to {}",
+                    key,
+                    default
+                );
+                default
+            }
+        };
+
         Self {
             enable_proactive_system: get_bool(keys::ENABLE_PROACTIVE_SYSTEM, false),
-            max_proactive_times: get_i32(keys::MAX_PROACTIVE_TIMES, 3),
+            max_proactive_times: get_i32(keys::MAX_PROACTIVE_TIMES, 3).clamp(0, 1_000),
+            proactive_interval_secs: get_i32(keys::PROACTIVE_INTERVAL_SECS, 10).clamp(2, 3_600)
+                as u64,
+            interest_trigger_threshold: get_bounded_f64(
+                keys::INTEREST_TRIGGER_THRESHOLD,
+                30.0,
+                0.0,
+                95.0,
+            ),
+            interest_decay_step: get_bounded_f64(keys::INTEREST_DECAY_STEP, 15.0, 0.0, 100.0),
+            vd_follow_chat_model: get_bool(keys::VD_FOLLOW_CHAT_MODEL, true),
             vd_api_key: get_string(keys::VD_API_KEY, ""),
             vd_base_url: get_string(
                 keys::VD_BASE_URL,
                 "https://dashscope.aliyuncs.com/compatible-mode/v1",
             ),
-            vd_model: get_string(keys::VD_MODEL, "qwen3.5-plus"),
+            vd_model: get_string(keys::VD_MODEL, "qwen3-vl-flash"),
             enable_visual_perception: get_bool(keys::ENABLE_VISUAL_PRECEPTION, true),
-            screen_weight: get_f64(keys::SCREEN_WEIGHT, 30.0),
+            screen_weight: get_bounded_f64(keys::SCREEN_WEIGHT, 30.0, 0.0, 10_000.0),
+            visual_perception_priority: get_bool(keys::VISUAL_PERCEPTION_PRIORITY, false),
             enable_topic_creator: get_bool(keys::ENABLE_TOPIC_CREATER, true),
-            topic_weight: get_f64(keys::TOPIC_WEIGHT, 60.0),
+            topic_weight: get_bounded_f64(keys::TOPIC_WEIGHT, 60.0, 0.0, 10_000.0),
             enable_todo_perception: get_bool(keys::ENABLE_TODO_PRECEPTION, true),
-            todo_weight: get_f64(keys::TODO_WEIGHT, 10.0),
+            todo_weight: get_bounded_f64(keys::TODO_WEIGHT, 10.0, 0.0, 10_000.0),
             enable_schedule_reminder: get_bool(keys::ENABLE_SCHEDULE_REMINDER, true),
             enable_important_day_reminder: get_bool(keys::ENABLE_IMPORTANT_DAY_REMINDER, true),
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ pub fn run() {
                     vd_api_key: pconfig.vd_api_key,
                     vd_base_url: pconfig.vd_base_url,
                     vd_model: pconfig.vd_model,
+                    provider: "openai".to_string(),
                 };
                 std::sync::Arc::new(tokio::sync::Mutex::new(ScreenAnalyzer::new(sa_config)))
             };


### PR DESCRIPTION
## 范围

这是重新拆分后的共享小底座，只稳定主动对话后端和视觉实现之间的公共契约。

- 统一视觉模型配置解析与默认值
- 增加稳定的 `ScreenContext`、主动视觉入口和 provider 字段
- 增加主动轮询、兴趣阈值和视觉优先配置键
- 保留旧实现可用，使后续视觉与主动后端 PR 能独立构建、并行审查

## 规模与依赖

- 基于 `tauri-refactor`
- 5 个文件，136 行新增、11 行删除
- 后续视觉与主动后端 PR 以本 PR 为共享基础

## 验证

- `node scripts/prepare-desktop-resources.mjs`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

Windows 本地验证通过，仅保留仓库已有警告。