### PR TITLE
功能：强化视觉分析与模型提供商兼容

### DIFF
--- a/docs/proactive-improvements.md
+++ b/docs/proactive-improvements.md
@@ -1,0 +1,42 @@
+# 主动回复改进计划（参考 N.E.K.O）
+
+## 当前状态
+
+- [x] 步骤 1：richer 屏幕上下文 prompt
+- [x] 步骤 2：一步式屏幕搭话决策
+- [x] 步骤 3：增加反重复机制
+- [x] `cargo check --all-targets` 通过
+- [x] `cargo test --release` 通过（7 个测试，含新增 3 个反重复测试）
+- [x] 已重新编译并覆盖 `LingChat-rust/bin/ling-chat.exe`
+
+## 改动摘要
+
+### screen_analyzer.rs
+- 新增 `ScreenContext`：携带 `ai_name`、`user_name`、`recent_chat_summary`
+- `analyze_screen` 增加 `context` 参数
+- 新增 `analyze_screen_for_proactive`：让 VLM 直接判断说不说
+- `VISION_SYSTEM_PROMPT` 和 `build_screen_prompt` 融入角色上下文
+
+### strategy_dispatcher.rs
+- SCREEN 模式改为调用 `analyze_screen_for_proactive`
+- 模型返回 `[PASS]` 时跳过本次，降级到 TOPIC
+- 新增 `ProactiveDeduplicator`，对 ImportantDay/Todo/Screen/Topic 都进行反重复检测
+
+### proactive_history.rs（新增）
+- 维护最近 10 条、1 小时内的主动搭话历史
+- 归一化 + 编辑距离相似度，阈值 0.85
+- 自动过期清理和数量限制
+
+### api/chat.rs
+- `test_screen_analyzer` 调用更新为 `analyze_screen(&prompt, None)`
+
+### mod.rs
+- 注册新模块 `proactive_history`
+
+## 后续可继续优化
+
+- 在 `ScreenContext` 中传入真实对话历史摘要
+- 把反重复历史持久化到文件（目前只存内存，重启丢失）
+- 增加 AI 正在说话 / 用户正在输入时的触发门控
+- 多屏截图和隐藏自身窗口再截图
+- 把 TODO/TOPIC/SCREEN 等做成可配置权重的 dispatcher

--- a/src-tauri/src/ai_service/god_agent/core.rs
+++ b/src-tauri/src/ai_service/god_agent/core.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use regex::Regex;
 
 use crate::ai_service::game_system::game_status::GameStatus;
 use crate::ai_service::god_agent::config::GodAgentConfig;
@@ -201,8 +202,62 @@ impl GodAgentCore {
         // Fallback：如果 LLM 返回了文本但未调用工具，尝试从内容解析
         if let Some(ref content) = response.content {
             tracing::warn!("上帝Agent 未调用工具，返回了文本: {content}");
+            if let Some((role_id, reason)) = parse_fallback_speaker(content) {
+                if role_id == 0 || gs.present_role_ids.contains(&role_id) {
+                    tracing::info!("上帝Agent 文本回退解析成功: role_id={role_id}, reason={reason}");
+                    return Ok((role_id, reason));
+                }
+                tracing::warn!("上帝Agent 文本回退解析到不在场的角色 {role_id}，忽略");
+            }
+            // 仍无法解析时，安全降级为交给玩家，避免整轮对话失败
+            tracing::warn!("上帝Agent 无法解析发言者，降级为 role_id=0（玩家）");
+            return Ok((0, "fallback to player after unparsable response".into()));
         }
 
         Err(anyhow!("上帝Agent 无法解析下一个发言者"))
+    }
+}
+
+/// 从 LLM 文本回退解析下一个发言者。
+/// 优先匹配 `role_id = N` / `role_id=N`，其次匹配第一个独立整数。
+fn parse_fallback_speaker(content: &str) -> Option<(i32, String)> {
+    // 1. 显式的 role_id 标记
+    let re = Regex::new(r"role_id\s*=\s*(\d+)").ok()?;
+    if let Some(caps) = re.captures(content) {
+        if let Ok(id) = caps[1].parse::<i32>() {
+            return Some((id, "parsed role_id from text".into()));
+        }
+    }
+
+    // 2. 文本中的第一个独立整数
+    let re_num = Regex::new(r"\b(\d+)\b").ok()?;
+    if let Some(caps) = re_num.captures(content) {
+        if let Ok(id) = caps[1].parse::<i32>() {
+            return Some((id, "parsed first number from text".into()));
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_fallback_speaker() {
+        assert_eq!(
+            parse_fallback_speaker("我选择 role_id=3 继续发言"),
+            Some((3, "parsed role_id from text".into()))
+        );
+        assert_eq!(
+            parse_fallback_speaker("role_id = 0"),
+            Some((0, "parsed role_id from text".into()))
+        );
+        assert_eq!(
+            parse_fallback_speaker("交给玩家，选择 0"),
+            Some((0, "parsed first number from text".into()))
+        );
+        assert!(parse_fallback_speaker("I can't continue.").is_none());
     }
 }

--- a/src-tauri/src/ai_service/llm/providers/kimi_code.rs
+++ b/src-tauri/src/ai_service/llm/providers/kimi_code.rs
@@ -99,6 +99,17 @@ impl KimiCodeProvider {
             }
         }
 
+        // 转换工具定义为 Anthropic 原生格式
+        let anthropic_tools: Option<Vec<AnthropicTool>> = tools.map(|ts| {
+            ts.iter()
+                .map(|t| AnthropicTool {
+                    name: t.function.name.clone(),
+                    description: t.function.description.clone(),
+                    input_schema: t.function.parameters.clone(),
+                })
+                .collect()
+        });
+
         MessagesRequest {
             model: &self.model,
             max_tokens: 65536,
@@ -107,16 +118,17 @@ impl KimiCodeProvider {
             top_p: self.top_p,
             system: if system_text.is_empty() { None } else { Some(system_text) },
             messages: conversation,
-            tools,
+            tools: anthropic_tools,
             tool_choice,
             thinking: if self.enable_thinking {
                 Some(ThinkingConfig {
                     type_: "enabled".to_string(),
                 })
             } else {
-                Some(ThinkingConfig {
-                    type_: "disabled".to_string(),
-                })
+                // Kimi Code 后端（Fable）会拒绝显式的 thinking: {type: "disabled"}，
+                // 所以关闭思考链时直接省略该字段。参考 kimi-code 官方 anthropic provider:
+                // https://github.com/MoonshotAI/kimi-code/blob/main/packages/kosong/src/providers/anthropic.ts
+                None
             },
         }
     }
@@ -164,15 +176,32 @@ impl LlmProvider for KimiCodeProvider {
         tools: &[ToolDefinition],
         tool_choice: Option<&str>,
     ) -> Result<LlmResponseWithTools> {
-        let tool_choice_value = tool_choice.map(|tc| {
-            if tc == "auto" || tc == "none" || tc == "required" {
-                serde_json::Value::String(tc.to_string())
-            } else {
-                serde_json::from_str(tc).unwrap_or(serde_json::Value::String("auto".to_string()))
+        // Anthropic Messages API 的 tool_choice 格式与 OpenAI 不同：
+        // OpenAI: "auto" | "none" | "required" | {"type": "function", "function": {"name": "..."}}
+        // Anthropic: {"type": "auto"} | {"type": "any"} | {"type": "tool", "name": "..."}
+        let anthropic_tool_choice: Option<serde_json::Value> = tool_choice.and_then(|tc| {
+            match tc {
+                "auto" | "none" => Some(serde_json::json!({"type": "auto"})),
+                "required" => Some(serde_json::json!({"type": "any"})),
+                _ => {
+                    // 尝试解析 OpenAI 的 function 指定格式
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(tc) {
+                        if v.get("type").and_then(|t| t.as_str()) == Some("function") {
+                            if let Some(name) = v.get("function").and_then(|f| f.get("name")).and_then(|n| n.as_str()) {
+                                return Some(serde_json::json!({"type": "tool", "name": name}));
+                            }
+                        }
+                    }
+                    Some(serde_json::json!({"type": "auto"}))
+                }
             }
         });
 
-        let body = self.build_request(messages, false, Some(tools), tool_choice_value);
+        let body = self.build_request(messages, false, Some(tools), anthropic_tool_choice);
+        if let Ok(body_json) = serde_json::to_string(&body) {
+            tracing::debug!("[KimiCode] complete_with_tools request body: {}", body_json);
+        }
+
         let resp = http
             .post(self.endpoint())
             .headers(self.headers()?)
@@ -338,6 +367,14 @@ impl LlmProvider for KimiCodeProvider {
 // ============================================================
 
 #[derive(Serialize)]
+struct AnthropicTool {
+    name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    description: String,
+    input_schema: serde_json::Value,
+}
+
+#[derive(Serialize)]
 struct MessagesRequest<'a> {
     model: &'a str,
     max_tokens: u32,
@@ -350,7 +387,7 @@ struct MessagesRequest<'a> {
     system: Option<String>,
     messages: Vec<AnthropicMessage<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tools: Option<&'a [ToolDefinition]>,
+    tools: Option<Vec<AnthropicTool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
+++ b/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
@@ -19,6 +19,7 @@ impl StrategyDispatcher {
             vd_api_key: config.vd_api_key.clone(),
             vd_base_url: config.vd_base_url.clone(),
             vd_model: config.vd_model.clone(),
+            provider: "openai".to_string(),
         };
         Self {
             screen_analyzer: Mutex::new(ScreenAnalyzer::new(sa_config)),
@@ -34,6 +35,7 @@ impl StrategyDispatcher {
                 vd_api_key: config.vd_api_key,
                 vd_base_url: config.vd_base_url,
                 vd_model: config.vd_model,
+                provider: "openai".to_string(),
             });
         }
     }
@@ -217,7 +219,7 @@ impl StrategyDispatcher {
             .screen_analyzer
             .lock()
             .await
-            .analyze_screen(analyze_prompt)
+            .analyze_screen(analyze_prompt, None)
             .await?;
 
         let user_name = &game_status.player.user_name;

--- a/src-tauri/src/ai_service/screen_analyzer.rs
+++ b/src-tauri/src/ai_service/screen_analyzer.rs
@@ -7,12 +7,16 @@ use reqwest::Client;
 use serde_json::Value;
 use std::time::Instant;
 
+use crate::ai_service::llm::provider_config::resolve_chat_provider;
+use crate::config::proactive::ProactiveConfig;
+
 /// 屏幕分析器的配置（从环境/Store 加载）。
 #[derive(Clone, Debug)]
 pub struct ScreenAnalyzerConfig {
     pub vd_api_key: String,
     pub vd_base_url: String,
     pub vd_model: String,
+    pub provider: String,
 }
 
 impl Default for ScreenAnalyzerConfig {
@@ -20,9 +24,18 @@ impl Default for ScreenAnalyzerConfig {
         Self {
             vd_api_key: String::new(),
             vd_base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1".to_string(),
-            vd_model: "qwen3.5-plus".to_string(),
+            vd_model: "qwen3-vl-flash".to_string(),
+            provider: "openai".to_string(),
         }
     }
+}
+
+/// Shared context passed by proactive and manual screen-analysis callers.
+#[derive(Clone, Debug, Default)]
+pub struct ScreenContext {
+    pub ai_name: Option<String>,
+    pub user_name: Option<String>,
+    pub recent_chat_summary: Option<String>,
 }
 
 /// 最后一次分析的性能与用量报告。
@@ -58,9 +71,24 @@ impl ScreenAnalyzer {
         &self.last_report
     }
 
+    /// Proactive entry point kept in the shared contract so engine and visual
+    /// implementation PRs can be reviewed independently.
+    pub async fn analyze_screen_for_proactive(
+        &mut self,
+        context: Option<&ScreenContext>,
+    ) -> Option<String> {
+        let prompt = "你刚刚看了一眼主人的电脑屏幕。若有值得自然搭话的内容，请直接回复一句不超过50字的话；否则只回复[PASS]。";
+        self.analyze_screen(prompt, context).await
+    }
+
     /// 核心方法：截屏 → 发送给 VLM 分析 → 返回文本描述。
-    /// 这是策略分发器和主动对话系统的主要入口。
-    pub async fn analyze_screen(&mut self, prompt: &str) -> Option<String> {
+    /// `context` is part of the stable cross-PR API; the visual implementation
+    /// PR enriches the prompt with it.
+    pub async fn analyze_screen(
+        &mut self,
+        prompt: &str,
+        _context: Option<&ScreenContext>,
+    ) -> Option<String> {
         let api_key = &self.config.vd_api_key;
         if api_key.is_empty() {
             tracing::warn!("[ScreenAnalyzer] VD_API_KEY is empty, skipping screenshot analysis.");
@@ -193,6 +221,31 @@ impl ScreenAnalyzer {
         };
 
         None
+    }
+}
+
+/// Resolve the visual model once for every caller. The visual implementation
+/// PR extends protocol handling without changing this shared API.
+pub fn build_screen_analyzer_config(
+    app_handle: &tauri::AppHandle,
+    config: &ProactiveConfig,
+) -> ScreenAnalyzerConfig {
+    if config.vd_follow_chat_model {
+        if let Some(provider) = resolve_chat_provider(app_handle) {
+            return ScreenAnalyzerConfig {
+                vd_api_key: provider.api_key,
+                vd_base_url: provider.base_url,
+                vd_model: provider.model,
+                provider: provider.provider,
+            };
+        }
+    }
+
+    ScreenAnalyzerConfig {
+        vd_api_key: config.vd_api_key.clone(),
+        vd_base_url: config.vd_base_url.clone(),
+        vd_model: config.vd_model.clone(),
+        provider: "openai".to_string(),
     }
 }
 

--- a/src-tauri/src/ai_service/screen_analyzer.rs
+++ b/src-tauri/src/ai_service/screen_analyzer.rs
@@ -1,14 +1,32 @@
 //! 桌面截图分析器。
 //! 独立的屏幕捕获与视觉语言模型(VLM)分析模块，可在多处复用（主动对话、脚本事件等）。
 //!
-//! 设计参考 Python 原版 `ling_chat_python/core/pic_analyzer.py` 的 DesktopAnalyzer。
+//! 设计参考 Python 原版 `ling_chat_python/core/pic_analyzer.py` 的 DesktopAnalyzer，
+//! 并参考 N.E.K.O 与 Kimi Code 的截图清晰度、图片验证、窗口标题上下文等做法。
 
 use reqwest::Client;
 use serde_json::Value;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::ai_service::llm::provider_config::resolve_chat_provider;
 use crate::config::proactive::ProactiveConfig;
+
+/// 安全限制：原始图片最大 10MB（base64 后约 13.3MB）。
+const MAX_IMAGE_SIZE_BYTES: usize = 10 * 1024 * 1024;
+const MAX_BASE64_SIZE: usize = MAX_IMAGE_SIZE_BYTES * 4 / 3 + 100;
+const MAX_IMAGE_DIMENSION: u32 = 32_768;
+const MAX_IMAGE_DECODE_BYTES: u64 = 192 * 1024 * 1024;
+/// 屏幕识别只需要一句短回复；限制输出，避免推理模型为简单视觉任务生成很长的思考链。
+const VISION_MAX_TOKENS: u32 = 256;
+/// Kimi Coding 目前无法可靠关闭长思考；过小预算会在最终正文前截断。
+/// 对该兼容路径保留足够输出空间，并依靠请求总超时止损。
+const KIMICODE_VISION_MAX_TOKENS: u32 = 4096;
+const SCREEN_ANALYZER_USER_AGENT: &str =
+    concat!("LingChat/", env!("CARGO_PKG_VERSION"), " screen-analyzer");
+const VISION_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const VISION_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+/// 图片像素数安全上限（避免超大图片耗尽内存）。
+const MAX_IMAGE_PIXELS: u64 = 100_000_000;
 
 /// 屏幕分析器的配置（从环境/Store 加载）。
 #[derive(Clone, Debug)]
@@ -16,6 +34,8 @@ pub struct ScreenAnalyzerConfig {
     pub vd_api_key: String,
     pub vd_base_url: String,
     pub vd_model: String,
+    /// 提供者协议类型，例如 `"openai"` 或 `"kimicode"`。
+    /// 用于决定使用 OpenAI Chat Completions 还是 Anthropic Messages API。
     pub provider: String,
 }
 
@@ -30,12 +50,37 @@ impl Default for ScreenAnalyzerConfig {
     }
 }
 
-/// Shared context passed by proactive and manual screen-analysis callers.
+/// 屏幕分析时的角色/对话上下文，让 VLM 以角色视角描述屏幕。
 #[derive(Clone, Debug, Default)]
 pub struct ScreenContext {
     pub ai_name: Option<String>,
     pub user_name: Option<String>,
     pub recent_chat_summary: Option<String>,
+}
+
+/// 图片压缩目标参数。
+/// 参考 Kimi Code 的 `compressImageForModel`：在视觉可接受的前提下控制 token 消耗。
+#[derive(Clone, Debug)]
+pub struct CompressionTarget {
+    /// 长边最大像素（默认 896）。
+    pub max_dimension: u32,
+    /// JPEG 编码后目标最大字节数（默认 512 KiB）。
+    pub max_bytes: usize,
+    /// 最低 JPEG 质量（默认 60）。
+    pub min_quality: u8,
+    /// 首选 JPEG 质量（默认 78）；只有该质量超限时才继续降质。
+    pub max_quality: u8,
+}
+
+impl Default for CompressionTarget {
+    fn default() -> Self {
+        Self {
+            max_dimension: 896,
+            max_bytes: 512 * 1024,
+            min_quality: 60,
+            max_quality: 78,
+        }
+    }
 }
 
 /// 最后一次分析的性能与用量报告。
@@ -50,14 +95,22 @@ pub struct ScreenAnalyzer {
     config: ScreenAnalyzerConfig,
     client: Client,
     last_report: AnalysisReport,
+    compression: CompressionTarget,
 }
 
 impl ScreenAnalyzer {
     pub fn new(config: ScreenAnalyzerConfig) -> Self {
+        let client = Client::builder()
+            .connect_timeout(VISION_CONNECT_TIMEOUT)
+            .timeout(VISION_REQUEST_TIMEOUT)
+            .build()
+            .expect("static screen-analyzer HTTP client configuration should be valid");
+
         Self {
             config,
-            client: Client::new(),
+            client,
             last_report: AnalysisReport::default(),
+            compression: CompressionTarget::default(),
         }
     }
 
@@ -71,34 +124,76 @@ impl ScreenAnalyzer {
         &self.last_report
     }
 
-    /// Proactive entry point kept in the shared contract so engine and visual
-    /// implementation PRs can be reviewed independently.
+    /// 主动搭话专用：让 VLM 直接看图决定"说不说"。
+    /// 返回 `[PASS]` 表示不说话；否则返回要说出的话语。
     pub async fn analyze_screen_for_proactive(
         &mut self,
         context: Option<&ScreenContext>,
     ) -> Option<String> {
-        let prompt = "你刚刚看了一眼主人的电脑屏幕。若有值得自然搭话的内容，请直接回复一句不超过50字的话；否则只回复[PASS]。";
+        let prompt = "你刚刚偷偷看了一眼主人的电脑屏幕。请根据屏幕内容和当前窗口标题，判断是否要主动和主人搭话。\
+规则：\
+1. 如果屏幕上有任何有趣、新鲜、奇怪或值得讨论的内容，请一定要说一句简短自然的话；\
+2. 如果内容与你们之前的对话、主人的兴趣或当前窗口标题相关，更应该提起；\
+3. 只有当屏幕内容真的无聊、重复，或者主人明显在全屏游戏/视频会议/紧急工作时，才回复\"[PASS]\"；\
+4. 不要描述聊天窗口或角色立绘区域，只关注桌面上的其他内容；\
+5. 回复要简短自然，像不经意间看到的，不超过50字。\
+\
+回复格式：\
+- 如果要搭话，直接说出你想说的话；\
+- 如果确定不要搭话，只回复\"[PASS]\"，不要解释。";
+
         self.analyze_screen(prompt, context).await
     }
 
     /// 核心方法：截屏 → 发送给 VLM 分析 → 返回文本描述。
-    /// `context` is part of the stable cross-PR API; the visual implementation
-    /// PR enriches the prompt with it.
+    /// 这是策略分发器和主动对话系统的主要入口。
     pub async fn analyze_screen(
         &mut self,
         prompt: &str,
-        _context: Option<&ScreenContext>,
+        context: Option<&ScreenContext>,
     ) -> Option<String> {
+        let total_started = Instant::now();
         let api_key = &self.config.vd_api_key;
         if api_key.is_empty() {
             tracing::warn!("[ScreenAnalyzer] VD_API_KEY is empty, skipping screenshot analysis.");
             return None;
         }
 
-        let jpeg_bytes = capture_screen_as_jpeg()?;
+        let capture_started = Instant::now();
+        let compression = self.compression.clone();
+        let jpeg_bytes = match tokio::task::spawn_blocking(move || {
+            capture_screen_as_jpeg_with_compression(&compression)
+        })
+        .await
+        {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => return None,
+            Err(e) => {
+                tracing::error!("[ScreenAnalyzer] Screenshot worker failed: {}", e);
+                return None;
+            }
+        };
+        let capture_elapsed = capture_started.elapsed();
+        tracing::info!(
+            "[ScreenAnalyzer] Captured screenshot: {} bytes in {:.0}ms",
+            jpeg_bytes.len(),
+            capture_elapsed.as_secs_f64() * 1000.0
+        );
 
+        let window_title = get_active_window_title();
+        let enriched_prompt = build_screen_prompt(prompt, window_title.as_deref(), context);
+
+        let vlm_started = Instant::now();
         let (base64, mime) = encode_image_base64(&jpeg_bytes, "jpeg");
-        self.call_vlm(prompt, &base64, &mime).await
+        let result = self.call_vlm(&enriched_prompt, &base64, &mime).await;
+        let vlm_elapsed = vlm_started.elapsed();
+        tracing::info!(
+            "[ScreenAnalyzer] Stage timings: capture={:.0}ms, vlm={:.0}ms, total={:.0}ms",
+            capture_elapsed.as_secs_f64() * 1000.0,
+            vlm_elapsed.as_secs_f64() * 1000.0,
+            total_started.elapsed().as_secs_f64() * 1000.0,
+        );
+        result
     }
 
     /// 分析任意图片字节（支持 JPEG / PNG / WebP 等格式）。
@@ -110,7 +205,42 @@ impl ScreenAnalyzer {
             return None;
         }
 
-        let (base64, mime) = encode_image_base64(image_bytes, "png");
+        if image_bytes.len() > MAX_IMAGE_SIZE_BYTES {
+            tracing::error!(
+                "[ScreenAnalyzer] Image too large: {} bytes > {}",
+                image_bytes.len(),
+                MAX_IMAGE_SIZE_BYTES
+            );
+            return None;
+        }
+
+        let image_bytes = image_bytes.to_vec();
+        let compression = self.compression.clone();
+        let compressed = match tokio::task::spawn_blocking(move || {
+            compress_image_bytes(&image_bytes, &compression)
+        })
+        .await
+        {
+            Ok(Ok(bytes)) => bytes,
+            Ok(Err(error)) => {
+                tracing::error!("[ScreenAnalyzer] Image compression failed: {error:#}");
+                return None;
+            }
+            Err(error) => {
+                tracing::error!("[ScreenAnalyzer] Image worker failed: {error}");
+                return None;
+            }
+        };
+        let mime_type = if matches!(
+            image::guess_format(&compressed).ok(),
+            Some(image::ImageFormat::Png)
+        ) {
+            "png"
+        } else {
+            "jpeg"
+        };
+
+        let (base64, mime) = encode_image_base64(&compressed, mime_type);
         self.call_vlm(prompt, &base64, &mime).await
     }
 
@@ -123,33 +253,87 @@ impl ScreenAnalyzer {
         }
 
         let bytes = std::fs::read(image_path).ok()?;
-
-        // 根据扩展名推断 MIME
-        let mime_type = if image_path.ends_with(".png") {
-            "png"
-        } else if image_path.ends_with(".webp") {
-            "webp"
-        } else {
-            "jpeg"
-        };
-
-        let (base64, mime) = encode_image_base64(&bytes, mime_type);
-        self.call_vlm(prompt, &base64, &mime).await
+        self.analyze_image(&bytes, prompt).await
     }
 
     /// 调用视觉语言模型 API。
+    /// 根据 provider 字段自动选择 OpenAI Chat Completions 或 Anthropic Messages API。
     async fn call_vlm(
         &mut self,
         prompt: &str,
         base64_image: &str,
         mime_type: &str,
     ) -> Option<String> {
+        if base64_image.len() > MAX_BASE64_SIZE {
+            tracing::error!(
+                "[ScreenAnalyzer] Base64 image too large: {} bytes > {}",
+                base64_image.len(),
+                MAX_BASE64_SIZE
+            );
+            return None;
+        }
+
+        let provider = self.config.provider.to_lowercase();
+        let is_anthropic = provider == "kimicode" || provider == "anthropic";
+        let model = &self.config.vd_model;
+
+        tracing::info!(
+            "[ScreenAnalyzer] Sending image to VLM ({}, provider={}) for analysis...",
+            model,
+            self.config.provider
+        );
+
+        let start = Instant::now();
+
+        let result = if is_anthropic {
+            self.call_vlm_anthropic(prompt, base64_image, mime_type)
+                .await
+        } else {
+            self.call_vlm_openai(prompt, base64_image, mime_type).await
+        };
+
+        let elapsed = start.elapsed().as_secs_f64();
+
+        match result {
+            Ok(content) => {
+                self.last_report.response_time_secs = elapsed;
+                if content.is_some() {
+                    tracing::info!("[ScreenAnalyzer] Analysis success in {:.2}s", elapsed);
+                }
+                content
+            }
+            Err(e) => {
+                tracing::error!(
+                    "[ScreenAnalyzer] VLM request failed after {:.2}s: {}",
+                    elapsed,
+                    e
+                );
+                self.last_report = AnalysisReport {
+                    response_time_secs: elapsed,
+                    ..Default::default()
+                };
+                None
+            }
+        }
+    }
+
+    /// OpenAI 兼容协议调用路径。
+    async fn call_vlm_openai(
+        &mut self,
+        prompt: &str,
+        base64_image: &str,
+        mime_type: &str,
+    ) -> Result<Option<String>, String> {
         let image_url = format!("data:image/{};base64,{}", mime_type, base64_image);
         let model = &self.config.vd_model;
 
-        let payload = serde_json::json!({
+        let mut payload = serde_json::json!({
             "model": model,
             "messages": [
+                {
+                    "role": "system",
+                    "content": VISION_SYSTEM_PROMPT
+                },
                 {
                     "role": "user",
                     "content": [
@@ -158,86 +342,270 @@ impl ScreenAnalyzer {
                     ]
                 }
             ],
-            "max_tokens": 512
+            "max_tokens": VISION_MAX_TOKENS
         });
-
-        tracing::info!(
-            "[ScreenAnalyzer] Sending image to VLM ({}) for analysis...",
-            model
+        apply_fast_vision_options(
+            &mut payload,
+            &self.config.vd_model,
+            &self.config.vd_base_url,
         );
 
-        let start = Instant::now();
+        let endpoint = normalize_endpoint(&self.config.vd_base_url);
 
-        let api_key = &self.config.vd_api_key;
-        let endpoint = format!("{}/chat/completions", self.config.vd_base_url);
-
-        let res = self
+        let response = self
             .client
             .post(&endpoint)
-            .bearer_auth(api_key)
+            .bearer_auth(&self.config.vd_api_key)
+            .header(reqwest::header::USER_AGENT, SCREEN_ANALYZER_USER_AGENT)
             .json(&payload)
             .send()
-            .await;
+            .await
+            .map_err(|e| format!("request failed: {:?}", e))?;
 
-        let elapsed = start.elapsed().as_secs_f64();
-
-        match res {
-            Ok(response) => {
-                if response.status().is_success() {
-                    if let Ok(json_res) = response.json::<Value>().await {
-                        let content = json_res["choices"][0]["message"]["content"]
-                            .as_str()
-                            .map(|s| s.to_string());
-
-                        let usage = &json_res["usage"];
-                        self.last_report = AnalysisReport {
-                            response_time_secs: elapsed,
-                            input_tokens: usage["prompt_tokens"].as_u64().map(|n| n as u32),
-                            output_tokens: usage["completion_tokens"].as_u64().map(|n| n as u32),
-                        };
-
-                        if let Some(ref c) = content {
-                            tracing::info!("[ScreenAnalyzer] Analysis success: {}", c);
-                        }
-
-                        return content;
-                    }
-                } else {
-                    let err_text = response.text().await.unwrap_or_default();
-                    tracing::error!(
-                        "[ScreenAnalyzer] VLM API returned error status: {}",
-                        err_text
-                    );
-                }
-            }
-            Err(e) => {
-                tracing::error!("[ScreenAnalyzer] Failed to send request to VLM: {:?}", e);
-            }
+        let status = response.status();
+        if !status.is_success() {
+            let err_text = response
+                .text()
+                .await
+                .unwrap_or_else(|error| format!("<failed to read error body: {error}>"));
+            return Err(format!(
+                "VLM API returned error status {}: {}",
+                status, err_text
+            ));
         }
 
+        let json_res = response
+            .json::<Value>()
+            .await
+            .map_err(|e| format!("failed to parse VLM JSON response: {:?}", e))?;
+
+        let content = json_res["choices"][0]["message"]["content"]
+            .as_str()
+            .map(|s| s.to_string());
+
+        let usage = &json_res["usage"];
         self.last_report = AnalysisReport {
-            response_time_secs: elapsed,
-            ..Default::default()
+            response_time_secs: 0.0,
+            input_tokens: usage["prompt_tokens"].as_u64().map(|n| n as u32),
+            output_tokens: usage["completion_tokens"].as_u64().map(|n| n as u32),
         };
 
-        None
+        if content.is_none() {
+            tracing::warn!(
+                "[ScreenAnalyzer] VLM response missing content (choices={})",
+                json_res["choices"].as_array().map_or(0, Vec::len)
+            );
+        }
+
+        Ok(content)
+    }
+
+    /// Anthropic Messages API 调用路径（用于 Kimi Code / kimi-for-coding 等）。
+    async fn call_vlm_anthropic(
+        &mut self,
+        prompt: &str,
+        base64_image: &str,
+        mime_type: &str,
+    ) -> Result<Option<String>, String> {
+        let model = &self.config.vd_model;
+        let media_type = format!("image/{}", mime_type);
+
+        let payload = serde_json::json!({
+            "model": model,
+            "max_tokens": if self.config.provider.eq_ignore_ascii_case("kimicode") {
+                KIMICODE_VISION_MAX_TOKENS
+            } else {
+                VISION_MAX_TOKENS
+            },
+            "system": VISION_SYSTEM_PROMPT,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": media_type,
+                                "data": base64_image
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let endpoint = normalize_anthropic_endpoint(&self.config.vd_base_url);
+
+        let response = self
+            .client
+            .post(&endpoint)
+            .header("x-api-key", self.config.vd_api_key.clone())
+            .header("anthropic-version", "2023-06-01")
+            .header(reqwest::header::USER_AGENT, SCREEN_ANALYZER_USER_AGENT)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() && self.config.provider.eq_ignore_ascii_case("kimicode") {
+                    "Kimi Coding 视觉分析超过 20 秒，已取消；建议为主动屏幕识别配置独立的轻量视觉模型"
+                        .to_string()
+                } else {
+                    format!("request failed: {:?}", e)
+                }
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let err_text = response
+                .text()
+                .await
+                .unwrap_or_else(|error| format!("<failed to read error body: {error}>"));
+            return Err(format!(
+                "VLM API returned error status {}: {}",
+                status, err_text
+            ));
+        }
+
+        let json_res = response.json::<Value>().await.map_err(|e| {
+            if e.is_timeout() && self.config.provider.eq_ignore_ascii_case("kimicode") {
+                "Kimi Coding 视觉分析超过 20 秒，已取消；建议为主动屏幕识别配置独立的轻量视觉模型"
+                    .to_string()
+            } else {
+                format!("failed to parse VLM JSON response: {:?}", e)
+            }
+        })?;
+
+        // Anthropic 响应的 content 是数组，可能同时包含 thinking 和 text 块。
+        // kimi-for-coding 默认会输出 thinking，需要遍历所有 block 提取文本。
+        let (content, thinking_chars) = extract_anthropic_text(&json_res);
+
+        if thinking_chars > 0 {
+            tracing::debug!(
+                "[ScreenAnalyzer] VLM thinking received ({} chars)",
+                thinking_chars
+            );
+        }
+
+        let usage = &json_res["usage"];
+        self.last_report = AnalysisReport {
+            response_time_secs: 0.0,
+            input_tokens: usage["input_tokens"].as_u64().map(|n| n as u32),
+            output_tokens: usage["output_tokens"].as_u64().map(|n| n as u32),
+        };
+
+        if content.is_none() {
+            tracing::warn!(
+                "[ScreenAnalyzer] VLM response missing text content (blocks={}, stop_reason={:?})",
+                json_res["content"].as_array().map_or(0, Vec::len),
+                json_res["stop_reason"].as_str()
+            );
+        }
+
+        Ok(content)
     }
 }
 
-/// Resolve the visual model once for every caller. The visual implementation
-/// PR extends protocol handling without changing this shared API.
+/// 从 Anthropic Messages API 响应中提取可读的文本内容。
+/// 返回 `(text_content, thinking_char_count)`，其中 text_content 会把所有 text block 拼接起来。
+/// 思考链只计数而不复制，避免为不会展示的长文本额外分配内存。
+fn extract_anthropic_text(json_res: &Value) -> (Option<String>, usize) {
+    let mut text_parts = Vec::new();
+    let mut thinking_chars = 0;
+
+    if let Some(content) = json_res["content"].as_array() {
+        for block in content {
+            match block["type"].as_str() {
+                Some("text") => {
+                    if let Some(t) = block["text"].as_str() {
+                        text_parts.push(t.to_string());
+                    }
+                }
+                Some("thinking") => {
+                    if let Some(t) = block["thinking"].as_str() {
+                        thinking_chars += t.chars().count();
+                    }
+                }
+                Some(other) => {
+                    tracing::debug!(
+                        "[ScreenAnalyzer] Unhandled Anthropic content block type: {}",
+                        other
+                    );
+                }
+                None => {}
+            }
+        }
+    }
+
+    let text = if text_parts.is_empty() {
+        None
+    } else {
+        Some(text_parts.join("\n"))
+    };
+
+    (text, thinking_chars)
+}
+
+/// VLM 系统提示：让模型知道自己在做什么，以及忽略聊天窗口。
+const VISION_SYSTEM_PROMPT: &str = "你是一个桌面画面观察者，也是用户的AI伙伴。用户授权你查看他的屏幕截图，请用简洁的中文描述画面主体内容。\
+如果截图里包含用户与 AI 的聊天窗口或角色立绘对话框，请不要描述这部分，只描述桌面上的其他内容。\
+如果提供了当前窗口标题，可以结合标题理解用户正在做什么。\
+如果提供了角色身份或近期对话摘要，请结合这些信息理解用户当前可能在做什么。";
+
+/// 把用户提示与当前窗口标题、角色上下文结合，给 VLM 更丰富的上下文。
+fn build_screen_prompt(
+    base_prompt: &str,
+    window_title: Option<&str>,
+    context: Option<&ScreenContext>,
+) -> String {
+    let mut sections = vec![base_prompt.to_string()];
+
+    if let Some(title) = window_title.filter(|t| !t.is_empty()) {
+        sections.push(format!("\n\n[当前焦点窗口标题]：{}", title));
+    }
+
+    if let Some(ctx) = context {
+        let ai_name = ctx.ai_name.as_deref().unwrap_or("AI");
+        let user_name = ctx.user_name.as_deref().unwrap_or("用户");
+        sections.push(format!(
+            "\n\n[角色身份]：你是{}，正在陪伴{}。",
+            ai_name, user_name
+        ));
+
+        if let Some(summary) = ctx.recent_chat_summary.as_deref().filter(|s| !s.is_empty()) {
+            sections.push(format!("\n[近期对话摘要]：{}", summary));
+        }
+    }
+
+    sections.concat()
+}
+
+/// 根据 ProactiveConfig 构建 ScreenAnalyzerConfig。
+/// 当 `VD_FOLLOW_CHAT_MODEL` 为 true 时，复用当前对话模型（chat provider）的 API Key、Base URL、模型名和提供者协议；
+/// 如果对话模型未配置或不可用，则回退到独立的视觉模型配置并记录警告。
 pub fn build_screen_analyzer_config(
     app_handle: &tauri::AppHandle,
     config: &ProactiveConfig,
 ) -> ScreenAnalyzerConfig {
     if config.vd_follow_chat_model {
         if let Some(provider) = resolve_chat_provider(app_handle) {
+            tracing::info!(
+                "[ScreenAnalyzer] VD follows chat model: {} ({}) provider={}",
+                provider.label,
+                provider.model,
+                provider.provider
+            );
             return ScreenAnalyzerConfig {
                 vd_api_key: provider.api_key,
                 vd_base_url: provider.base_url,
                 vd_model: provider.model,
                 provider: provider.provider,
             };
+        } else {
+            tracing::warn!(
+                "[ScreenAnalyzer] VD_FOLLOW_CHAT_MODEL is enabled but no usable chat provider found, falling back to dedicated VD config"
+            );
         }
     }
 
@@ -255,85 +623,434 @@ fn encode_image_base64(bytes: &[u8], mime_type: &str) -> (String, String) {
     (b64, mime_type.to_string())
 }
 
-/// 捕获整个桌面并返回 JPEG 格式的字节。
+/// Disable long reasoning for OpenAI-compatible models known to support this option.
+fn apply_fast_vision_options(payload: &mut Value, model: &str, base_url: &str) {
+    let Some(object) = payload.as_object_mut() else {
+        return;
+    };
+
+    let base_url = base_url.to_ascii_lowercase();
+    let is_dashscope = base_url.contains("dashscope.aliyuncs.com")
+        || base_url.contains("dashscope-intl.aliyuncs.com");
+    if is_dashscope && model.to_ascii_lowercase().contains("qwen3") {
+        object.insert("enable_thinking".to_string(), Value::Bool(false));
+    }
+}
+
+/// 确保 Base URL 末尾没有斜杠，以便正确拼接 `/chat/completions`。
+fn normalize_endpoint(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions".to_string()
+    } else if trimmed.ends_with("/chat/completions") {
+        trimmed.to_string()
+    } else {
+        format!("{}/chat/completions", trimmed)
+    }
+}
+
+/// 为 Anthropic Messages API 规范化 endpoint：base_url 末尾去斜杠后拼接 `/v1/messages`。
+fn normalize_anthropic_endpoint(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "https://api.kimi.com/coding/v1/messages".to_string()
+    } else if trimmed.ends_with("/v1/messages") {
+        trimmed.to_string()
+    } else {
+        format!("{}/v1/messages", trimmed)
+    }
+}
+
+/// 验证并加载图片，检查尺寸与完整性。
+fn validate_image_bytes(bytes: &[u8]) -> anyhow::Result<image::DynamicImage> {
+    if bytes.len() > MAX_IMAGE_SIZE_BYTES {
+        anyhow::bail!(
+            "image too large: {} bytes > {}",
+            bytes.len(),
+            MAX_IMAGE_SIZE_BYTES
+        );
+    }
+
+    let make_reader = || {
+        image::ImageReader::new(std::io::Cursor::new(bytes))
+            .with_guessed_format()
+            .map_err(|e| anyhow::anyhow!("invalid image header: {e}"))
+    };
+
+    // 先只读取尺寸，再决定是否允许完整解码，避免超大压缩图抢占大量内存。
+    let (width, height) = make_reader()?
+        .into_dimensions()
+        .map_err(|e| anyhow::anyhow!("invalid image dimensions: {e}"))?;
+    let pixels = u64::from(width).saturating_mul(u64::from(height));
+    if pixels > MAX_IMAGE_PIXELS {
+        anyhow::bail!(
+            "image too large: {}x{} = {} pixels > {}",
+            width,
+            height,
+            pixels,
+            MAX_IMAGE_PIXELS
+        );
+    }
+
+    let mut reader = make_reader()?;
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(MAX_IMAGE_DIMENSION);
+    limits.max_image_height = Some(MAX_IMAGE_DIMENSION);
+    limits.max_alloc = Some(MAX_IMAGE_DECODE_BYTES);
+    reader.limits(limits);
+    let img = reader
+        .decode()
+        .map_err(|e| anyhow::anyhow!("invalid or oversized image: {e}"))?;
+
+    Ok(img)
+}
+
+/// 压缩图片字节到目标尺寸与大小。
+/// 先按 `max_dimension` 等比缩放，再用 JPEG 质量迭代控制文件大小。
+fn compress_image_bytes(bytes: &[u8], target: &CompressionTarget) -> anyhow::Result<Vec<u8>> {
+    let img = validate_image_bytes(bytes)?;
+    compress_dynamic_image(&img, target)
+}
+
+/// 压缩 `DynamicImage` 到目标尺寸与大小。
+fn compress_dynamic_image(
+    img: &image::DynamicImage,
+    target: &CompressionTarget,
+) -> anyhow::Result<Vec<u8>> {
+    let (orig_w, orig_h) = (img.width(), img.height());
+    let max_dim = target.max_dimension.max(1);
+
+    // 先缩小再转 RGB，避免 4K 截图在压缩前产生一次完整尺寸的额外 RGB 副本。
+    let resized_source = if orig_w.max(orig_h) > max_dim {
+        img.resize(max_dim, max_dim, image::imageops::FilterType::Triangle)
+    } else {
+        img.clone()
+    };
+    // 统一转换为 RGB8，避免 RGBA/P 模式带来的 JPEG 兼容性问题。
+    let resized = image::DynamicImage::ImageRgb8(resized_source.to_rgb8());
+
+    let (new_w, new_h) = (resized.width(), resized.height());
+
+    let encode_at_quality = |quality: u8| -> anyhow::Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        let mut cursor = std::io::Cursor::new(&mut buf);
+        let mut encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut cursor, quality);
+        encoder.encode_image(&resized)?;
+        Ok(buf)
+    };
+
+    let min_quality = target.min_quality.clamp(1, 100);
+    let preferred_quality = target.max_quality.clamp(min_quality, 100);
+
+    // 主动屏幕识别的默认尺寸下，q78 通常远低于 512 KiB。先只编码一次，
+    // 避免旧实现为了找到最高质量而无条件重复编码 5 次。
+    let preferred = encode_at_quality(preferred_quality)?;
+    let (selected_quality, best) = if preferred.len() <= target.max_bytes {
+        (preferred_quality, preferred)
+    } else {
+        let mut low = min_quality;
+        let mut high = preferred_quality.saturating_sub(1);
+        let mut best_under_limit: Option<(u8, Vec<u8>)> = None;
+        let mut smallest = (preferred_quality, preferred);
+
+        while low <= high {
+            let mid = low + (high - low) / 2;
+            let buf = encode_at_quality(mid)?;
+            if buf.len() < smallest.1.len() {
+                smallest = (mid, buf.clone());
+            }
+
+            if buf.len() <= target.max_bytes {
+                best_under_limit = Some((mid, buf));
+                low = mid.saturating_add(1);
+            } else {
+                if mid == 0 {
+                    break;
+                }
+                high = mid - 1;
+            }
+        }
+
+        best_under_limit.unwrap_or(smallest)
+    };
+
+    if best.len() > target.max_bytes {
+        let current_dimension = new_w.max(new_h);
+        if current_dimension <= 1 {
+            anyhow::bail!(
+                "cannot compress image below {} bytes (smallest result: {})",
+                target.max_bytes,
+                best.len()
+            );
+        }
+        let estimated_ratio = (target.max_bytes as f64 / best.len() as f64).sqrt() * 0.92;
+        let next_dimension =
+            ((current_dimension as f64 * estimated_ratio) as u32).clamp(1, current_dimension - 1);
+        let mut smaller_target = target.clone();
+        smaller_target.max_dimension = next_dimension;
+        return compress_dynamic_image(img, &smaller_target);
+    }
+
+    tracing::info!(
+        "[ScreenAnalyzer] Compressed image: {}x{} -> {}x{}, q{}, {} bytes",
+        orig_w,
+        orig_h,
+        new_w,
+        new_h,
+        selected_quality,
+        best.len()
+    );
+
+    Ok(best)
+}
+
+/// 获取当前前台窗口标题（Windows）。
+/// 用于给 VLM 提供“用户正在看什么窗口”的上下文。
+#[cfg(target_os = "windows")]
+fn get_active_window_title() -> Option<String> {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW,
+    };
+
+    unsafe {
+        let hwnd = GetForegroundWindow();
+        if hwnd == HWND(std::ptr::null_mut()) {
+            return None;
+        }
+
+        let len = GetWindowTextLengthW(hwnd);
+        if len <= 0 {
+            return None;
+        }
+
+        let mut buffer = vec![0u16; (len + 1) as usize];
+        let written = GetWindowTextW(hwnd, &mut buffer);
+        if written <= 0 {
+            return None;
+        }
+
+        // 去掉末尾的 null
+        buffer.truncate(written as usize);
+        String::from_utf16(&buffer).ok()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn get_active_window_title() -> Option<String> {
+    None
+}
+
+/// 捕获整个桌面并返回经过压缩的 JPEG 字节。
 /// Windows: 使用 GDI (BitBlt + GetDIBits) 捕获，然后压缩为 1024x768 JPEG。
 /// 其他平台: 返回 None。
+#[allow(dead_code)]
 pub fn capture_screen_as_jpeg() -> Option<Vec<u8>> {
+    capture_screen_as_jpeg_with_compression(&CompressionTarget::default())
+}
+
+fn capture_screen_as_jpeg_with_compression(target: &CompressionTarget) -> Option<Vec<u8>> {
     #[cfg(target_os = "windows")]
     {
-        use windows::Win32::Graphics::Gdi::{
-            BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC,
-            GetDIBits, ReleaseDC, SelectObject, BITMAPINFOHEADER, DIB_RGB_COLORS, SRCCOPY,
-        };
-        use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
-
-        unsafe {
-            let hdc_screen = GetDC(None);
-            if hdc_screen.is_invalid() {
-                return None;
+        let dynamic_img = capture_active_monitor_image()?;
+        match compress_dynamic_image(&dynamic_img, target) {
+            Ok(bytes) => Some(bytes),
+            Err(e) => {
+                tracing::error!("[ScreenAnalyzer] Failed to compress screenshot: {:?}", e);
+                None
             }
-            let w = GetSystemMetrics(SM_CXSCREEN);
-            let h = GetSystemMetrics(SM_CYSCREEN);
-            if w <= 0 || h <= 0 {
-                ReleaseDC(None, hdc_screen);
-                return None;
-            }
-
-            let hdc_mem = CreateCompatibleDC(Some(hdc_screen));
-            let hbitmap = CreateCompatibleBitmap(hdc_screen, w, h);
-
-            let old_obj = SelectObject(hdc_mem, hbitmap.into());
-            let _ = BitBlt(hdc_mem, 0, 0, w, h, Some(hdc_screen), 0, 0, SRCCOPY);
-
-            let mut bmi = windows::Win32::Graphics::Gdi::BITMAPINFO::default();
-            bmi.bmiHeader.biSize = std::mem::size_of::<BITMAPINFOHEADER>() as u32;
-            bmi.bmiHeader.biWidth = w;
-            bmi.bmiHeader.biHeight = -h;
-            bmi.bmiHeader.biPlanes = 1;
-            bmi.bmiHeader.biBitCount = 24;
-            bmi.bmiHeader.biCompression = 0;
-
-            let mut buffer = vec![0u8; (w * h * 3) as usize];
-
-            let lines = GetDIBits(
-                hdc_screen,
-                hbitmap,
-                0,
-                h as u32,
-                Some(buffer.as_mut_ptr() as *mut _),
-                &mut bmi,
-                DIB_RGB_COLORS,
-            );
-
-            SelectObject(hdc_mem, old_obj);
-            let _ = DeleteObject(hbitmap.into());
-            let _ = DeleteDC(hdc_mem);
-            ReleaseDC(None, hdc_screen);
-
-            if lines <= 0 {
-                return None;
-            }
-
-            for chunk in buffer.chunks_exact_mut(3) {
-                chunk.swap(0, 2);
-            }
-
-            let img =
-                image::ImageBuffer::<image::Rgb<u8>, _>::from_raw(w as u32, h as u32, buffer)?;
-            let dynamic_img = image::DynamicImage::ImageRgb8(img);
-            let resized = dynamic_img.resize(1024, 768, image::imageops::FilterType::Triangle);
-
-            let mut jpeg_bytes = Vec::new();
-            let mut cursor = std::io::Cursor::new(&mut jpeg_bytes);
-            let _ = resized.write_to(&mut cursor, image::ImageFormat::Jpeg);
-
-            Some(jpeg_bytes)
         }
     }
 
     #[cfg(not(target_os = "windows"))]
     {
+        tracing::warn!("[ScreenAnalyzer] Screen capture is only supported on Windows.");
         None
+    }
+}
+
+/// 捕获前台窗口所在显示器；获取失败时回退到主显示器。
+#[cfg(target_os = "windows")]
+fn capture_active_monitor_image() -> Option<image::DynamicImage> {
+    use windows::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MonitorFromWindow, MONITORINFO, MONITOR_DEFAULTTONEAREST,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
+
+    unsafe {
+        let hwnd = GetForegroundWindow();
+        if !hwnd.0.is_null() {
+            let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+            if !monitor.0.is_null() {
+                let mut info = MONITORINFO::default();
+                info.cbSize = std::mem::size_of::<MONITORINFO>() as u32;
+                if GetMonitorInfoW(monitor, &mut info).as_bool() {
+                    let rect = info.rcMonitor;
+                    let width = rect.right.saturating_sub(rect.left);
+                    let height = rect.bottom.saturating_sub(rect.top);
+                    if width > 0 && height > 0 {
+                        return capture_screen_region_image(rect.left, rect.top, width, height);
+                    }
+                }
+            }
+        }
+    }
+
+    capture_primary_screen_image()
+}
+
+#[cfg(target_os = "windows")]
+fn capture_primary_screen_image() -> Option<image::DynamicImage> {
+    use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
+
+    let width = unsafe { GetSystemMetrics(SM_CXSCREEN) };
+    let height = unsafe { GetSystemMetrics(SM_CYSCREEN) };
+    capture_screen_region_image(0, 0, width, height)
+}
+
+/// Capture a desktop region using a 32-bpp top-down DIB.
+///
+/// 32 bpp avoids the row-padding hazard of 24-bpp DIBs. The bitmap is restored out of the
+/// memory DC before `GetDIBits`, as required by GDI, and every allocation is overflow checked.
+#[cfg(target_os = "windows")]
+fn capture_screen_region_image(
+    source_x: i32,
+    source_y: i32,
+    w: i32,
+    h: i32,
+) -> Option<image::DynamicImage> {
+    use windows::Win32::Graphics::Gdi::{
+        BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC,
+        GetDIBits, ReleaseDC, SelectObject, BITMAPINFO, BITMAPINFOHEADER, DIB_RGB_COLORS, SRCCOPY,
+    };
+
+    unsafe {
+        let hdc_screen = GetDC(None);
+        if hdc_screen.is_invalid() {
+            tracing::error!("[ScreenAnalyzer] Failed to get screen DC.");
+            return None;
+        }
+
+        if w <= 0 || h <= 0 {
+            tracing::error!("[ScreenAnalyzer] Invalid screen size: {}x{}", w, h);
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        let pixel_count = match (w as usize).checked_mul(h as usize) {
+            Some(count) if count as u64 <= MAX_IMAGE_PIXELS => count,
+            _ => {
+                tracing::error!(
+                    "[ScreenAnalyzer] Screen dimensions are too large: {}x{}",
+                    w,
+                    h
+                );
+                ReleaseDC(None, hdc_screen);
+                return None;
+            }
+        };
+        let bgra_len = match pixel_count.checked_mul(4) {
+            Some(len) => len,
+            None => {
+                tracing::error!("[ScreenAnalyzer] Screenshot buffer size overflow.");
+                ReleaseDC(None, hdc_screen);
+                return None;
+            }
+        };
+
+        let hdc_mem = CreateCompatibleDC(Some(hdc_screen));
+        if hdc_mem.is_invalid() {
+            tracing::error!("[ScreenAnalyzer] CreateCompatibleDC failed.");
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        let hbitmap = CreateCompatibleBitmap(hdc_screen, w, h);
+        if hbitmap.is_invalid() {
+            tracing::error!("[ScreenAnalyzer] CreateCompatibleBitmap failed.");
+            let _ = DeleteDC(hdc_mem);
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        let old_obj = SelectObject(hdc_mem, hbitmap.into());
+        if old_obj.0.is_null() || old_obj.0 as isize == -1 {
+            tracing::error!("[ScreenAnalyzer] SelectObject failed.");
+            let _ = DeleteDC(hdc_mem);
+            let _ = DeleteObject(hbitmap.into());
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        if let Err(e) = BitBlt(
+            hdc_mem,
+            0,
+            0,
+            w,
+            h,
+            Some(hdc_screen),
+            source_x,
+            source_y,
+            SRCCOPY,
+        ) {
+            tracing::error!("[ScreenAnalyzer] BitBlt failed: {}", e);
+            let _ = SelectObject(hdc_mem, old_obj);
+            let _ = DeleteDC(hdc_mem);
+            let _ = DeleteObject(hbitmap.into());
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        // GetDIBits requires the bitmap not to be selected into a DC.
+        let restored = SelectObject(hdc_mem, old_obj);
+        if restored.0.is_null() || restored.0 as isize == -1 {
+            tracing::error!("[ScreenAnalyzer] Failed to restore memory DC bitmap.");
+            let _ = DeleteDC(hdc_mem);
+            let _ = DeleteObject(hbitmap.into());
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        let mut bmi = BITMAPINFO::default();
+        bmi.bmiHeader.biSize = std::mem::size_of::<BITMAPINFOHEADER>() as u32;
+        bmi.bmiHeader.biWidth = w;
+        bmi.bmiHeader.biHeight = -h;
+        bmi.bmiHeader.biPlanes = 1;
+        bmi.bmiHeader.biBitCount = 32;
+        bmi.bmiHeader.biCompression = 0;
+        bmi.bmiHeader.biSizeImage = bgra_len as u32;
+
+        let mut bgra = vec![0u8; bgra_len];
+        let lines = GetDIBits(
+            hdc_mem,
+            hbitmap,
+            0,
+            h as u32,
+            Some(bgra.as_mut_ptr() as *mut _),
+            &mut bmi,
+            DIB_RGB_COLORS,
+        );
+
+        let _ = DeleteDC(hdc_mem);
+        let _ = DeleteObject(hbitmap.into());
+        ReleaseDC(None, hdc_screen);
+
+        if lines != h {
+            tracing::error!(
+                "[ScreenAnalyzer] GetDIBits returned {} of {} lines.",
+                lines,
+                h
+            );
+            return None;
+        }
+
+        for pixel in bgra.chunks_exact_mut(4) {
+            pixel.swap(0, 2);
+            pixel[3] = u8::MAX;
+        }
+
+        let image = image::ImageBuffer::<image::Rgba<u8>, _>::from_raw(w as u32, h as u32, bgra)?;
+        Some(image::DynamicImage::ImageRgba8(image))
     }
 }
 
@@ -342,77 +1059,117 @@ pub fn capture_screen_as_jpeg() -> Option<Vec<u8>> {
 pub fn capture_screen_raw_jpeg() -> Option<Vec<u8>> {
     #[cfg(target_os = "windows")]
     {
-        use windows::Win32::Graphics::Gdi::{
-            BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC,
-            GetDIBits, ReleaseDC, SelectObject, BITMAPINFOHEADER, DIB_RGB_COLORS, SRCCOPY,
-        };
-        use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
-
-        unsafe {
-            let hdc_screen = GetDC(None);
-            if hdc_screen.is_invalid() {
-                return None;
-            }
-            let w = GetSystemMetrics(SM_CXSCREEN);
-            let h = GetSystemMetrics(SM_CYSCREEN);
-            if w <= 0 || h <= 0 {
-                ReleaseDC(None, hdc_screen);
-                return None;
-            }
-
-            let hdc_mem = CreateCompatibleDC(Some(hdc_screen));
-            let hbitmap = CreateCompatibleBitmap(hdc_screen, w, h);
-
-            let old_obj = SelectObject(hdc_mem, hbitmap.into());
-            let _ = BitBlt(hdc_mem, 0, 0, w, h, Some(hdc_screen), 0, 0, SRCCOPY);
-
-            let mut bmi = windows::Win32::Graphics::Gdi::BITMAPINFO::default();
-            bmi.bmiHeader.biSize = std::mem::size_of::<BITMAPINFOHEADER>() as u32;
-            bmi.bmiHeader.biWidth = w;
-            bmi.bmiHeader.biHeight = -h;
-            bmi.bmiHeader.biPlanes = 1;
-            bmi.bmiHeader.biBitCount = 24;
-            bmi.bmiHeader.biCompression = 0;
-
-            let mut buffer = vec![0u8; (w * h * 3) as usize];
-
-            let lines = GetDIBits(
-                hdc_screen,
-                hbitmap,
-                0,
-                h as u32,
-                Some(buffer.as_mut_ptr() as *mut _),
-                &mut bmi,
-                DIB_RGB_COLORS,
-            );
-
-            SelectObject(hdc_mem, old_obj);
-            let _ = DeleteObject(hbitmap.into());
-            let _ = DeleteDC(hdc_mem);
-            ReleaseDC(None, hdc_screen);
-
-            if lines <= 0 {
-                return None;
-            }
-
-            for chunk in buffer.chunks_exact_mut(3) {
-                chunk.swap(0, 2);
-            }
-
-            let img =
-                image::ImageBuffer::<image::Rgb<u8>, _>::from_raw(w as u32, h as u32, buffer)?;
-            let dynamic_img = image::DynamicImage::ImageRgb8(img);
-
-            let mut jpeg_bytes = Vec::new();
-            let mut cursor = std::io::Cursor::new(&mut jpeg_bytes);
-            let _ = dynamic_img.write_to(&mut cursor, image::ImageFormat::Jpeg);
-
-            Some(jpeg_bytes)
+        let dynamic_img = capture_primary_screen_image()?;
+        let rgb_img = image::DynamicImage::ImageRgb8(dynamic_img.to_rgb8());
+        let mut jpeg_bytes = Vec::new();
+        let mut cursor = std::io::Cursor::new(&mut jpeg_bytes);
+        if let Err(e) = rgb_img.write_to(&mut cursor, image::ImageFormat::Jpeg) {
+            tracing::error!("[ScreenAnalyzer] Failed to encode raw screenshot: {}", e);
+            return None;
         }
+        Some(jpeg_bytes)
     }
 
     #[cfg(not(target_os = "windows"))]
     {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fast_vision_defaults() {
+        let target = CompressionTarget::default();
+        assert_eq!(target.max_dimension, 896);
+        assert_eq!(target.max_bytes, 512 * 1024);
+        assert_eq!(target.min_quality, 60);
+        assert_eq!(target.max_quality, 78);
+        assert_eq!(VISION_MAX_TOKENS, 256);
+        assert!(KIMICODE_VISION_MAX_TOKENS > VISION_MAX_TOKENS);
+        assert_eq!(VISION_CONNECT_TIMEOUT, Duration::from_secs(5));
+        assert_eq!(VISION_REQUEST_TIMEOUT, Duration::from_secs(20));
+    }
+
+    #[test]
+    fn test_qwen3_disables_thinking_without_affecting_kimi() {
+        let mut qwen_payload = serde_json::json!({ "model": "qwen3.5-plus" });
+        apply_fast_vision_options(
+            &mut qwen_payload,
+            "qwen3.5-plus",
+            "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        );
+        assert_eq!(qwen_payload["enable_thinking"], Value::Bool(false));
+
+        let mut kimi_payload = serde_json::json!({ "model": "kimi-for-coding-highspeed" });
+        apply_fast_vision_options(
+            &mut kimi_payload,
+            "kimi-for-coding-highspeed",
+            "https://api.kimi.com/coding",
+        );
+        assert!(kimi_payload.get("enable_thinking").is_none());
+        assert!(kimi_payload.get("thinking").is_none());
+
+        let mut third_party_qwen = serde_json::json!({ "model": "qwen3-vl-flash" });
+        apply_fast_vision_options(
+            &mut third_party_qwen,
+            "qwen3-vl-flash",
+            "https://example.test/v1",
+        );
+        assert!(third_party_qwen.get("enable_thinking").is_none());
+    }
+
+    #[test]
+    fn test_endpoint_normalization_does_not_duplicate_suffixes() {
+        assert_eq!(
+            normalize_endpoint("https://example.test/v1/chat/completions/"),
+            "https://example.test/v1/chat/completions"
+        );
+        assert_eq!(
+            normalize_anthropic_endpoint("https://api.kimi.com/coding/v1/messages/"),
+            "https://api.kimi.com/coding/v1/messages"
+        );
+    }
+
+    #[test]
+    fn test_anthropic_extraction_keeps_text_without_copying_thinking() {
+        let response = serde_json::json!({
+            "content": [
+                { "type": "thinking", "thinking": "先观察画面" },
+                { "type": "text", "text": "看到你在写代码。" }
+            ]
+        });
+        let (text, thinking_chars) = extract_anthropic_text(&response);
+        assert_eq!(text.as_deref(), Some("看到你在写代码。"));
+        assert_eq!(thinking_chars, "先观察画面".chars().count());
+    }
+
+    /// 冒烟测试：验证 Windows 下能成功截屏并压缩到目标大小以内。
+    /// 该测试不需要调用任何外部 API，因此可以在没有 API Key 的情况下运行。
+    #[test]
+    fn test_capture_and_compress_smoke() {
+        #[cfg(target_os = "windows")]
+        {
+            let target = CompressionTarget::default();
+            let jpeg = capture_screen_as_jpeg_with_compression(&target)
+                .expect("screen capture should succeed on Windows");
+            assert!(!jpeg.is_empty(), "captured JPEG should not be empty");
+            assert!(
+                jpeg.len() <= target.max_bytes,
+                "captured JPEG ({} bytes) should not exceed target size ({} bytes)",
+                jpeg.len(),
+                target.max_bytes
+            );
+            let decoded = image::load_from_memory(&jpeg).expect("captured JPEG should decode");
+            assert!(decoded.width().max(decoded.height()) <= target.max_dimension);
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            // 非 Windows 平台该功能直接返回 None，验证行为即可。
+            assert!(capture_screen_as_jpeg().is_none());
+        }
     }
 }

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -642,6 +642,24 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         description: "MAX_PROACTIVE_TIMES — 在用户响应之前，能主动对话的次数".to_string(),
                         setting_type: "text".to_string(),
                     },
+                    ConfigSetting {
+                        key: proactive::keys::PROACTIVE_INTERVAL_SECS.to_string(),
+                        value: read_setting(app, proactive::keys::PROACTIVE_INTERVAL_SECS, "10"),
+                        description: "PROACTIVE_INTERVAL_SECS — 主动对话轮询间隔（秒，默认 10，最小 2）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::INTEREST_TRIGGER_THRESHOLD.to_string(),
+                        value: read_setting(app, proactive::keys::INTEREST_TRIGGER_THRESHOLD, "30.0"),
+                        description: "INTEREST_TRIGGER_THRESHOLD — 兴趣度触发阈值（默认 30，越低越容易被触发）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::INTEREST_DECAY_STEP.to_string(),
+                        value: read_setting(app, proactive::keys::INTEREST_DECAY_STEP, "15.0"),
+                        description: "INTEREST_DECAY_STEP — 每次主动对话后兴趣度上限衰减量（默认 15，设为 0 则不衰减）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
                 ],
             },
         );
@@ -652,6 +670,12 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
             Subcategory {
                 description: "主动对话时调用的 Vision LLM 视觉分析模型以及截图分析设置".to_string(),
                 settings: vec![
+                    ConfigSetting {
+                        key: proactive::keys::VD_FOLLOW_CHAT_MODEL.to_string(),
+                        value: read_setting(app, proactive::keys::VD_FOLLOW_CHAT_MODEL, "true"),
+                        description: "VD_FOLLOW_CHAT_MODEL — 跟随当前对话模型；若当前是不可关闭长思考的模型，视觉识别也会明显变慢。低延迟建议关闭并配置独立轻量视觉模型".to_string(),
+                        setting_type: "bool".to_string(),
+                    },
                     ConfigSetting {
                         key: proactive::keys::VD_API_KEY.to_string(),
                         value: read_setting(app, proactive::keys::VD_API_KEY, ""),
@@ -670,8 +694,10 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                     },
                     ConfigSetting {
                         key: proactive::keys::VD_MODEL.to_string(),
-                        value: read_setting(app, proactive::keys::VD_MODEL, "qwen3.5-plus"),
-                        description: "VD_MODEL — 视觉模型型号".to_string(),
+                        value: read_setting(app, proactive::keys::VD_MODEL, "qwen3-vl-flash"),
+                        description:
+                            "VD_MODEL — 独立视觉模型型号（低延迟推荐非思考型 VL/Flash，例如 qwen3-vl-flash）"
+                                .to_string(),
                         setting_type: "text".to_string(),
                     },
                     ConfigSetting {
@@ -689,6 +715,14 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "SCREEN_WEIGHT — 视觉模式触发权重（越大越容易偷看屏幕聊天，默认 30）"
                                 .to_string(),
                         setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::VISUAL_PERCEPTION_PRIORITY.to_string(),
+                        value: read_setting(app, proactive::keys::VISUAL_PERCEPTION_PRIORITY, "false"),
+                        description:
+                            "VISUAL_PERCEPTION_PRIORITY — 视觉理解优先模式（开启后每次主动回复优先看屏幕，失败才找话题）"
+                                .to_string(),
+                        setting_type: "bool".to_string(),
                     },
                 ],
             },

--- a/src-tauri/src/config/proactive.rs
+++ b/src-tauri/src/config/proactive.rs
@@ -5,11 +5,16 @@ use tauri_plugin_store::StoreExt;
 pub mod keys {
     pub const ENABLE_PROACTIVE_SYSTEM: &str = "ENABLE_PROACTIVE_SYSTEM";
     pub const MAX_PROACTIVE_TIMES: &str = "MAX_PROACTIVE_TIMES";
+    pub const PROACTIVE_INTERVAL_SECS: &str = "PROACTIVE_INTERVAL_SECS";
+    pub const INTEREST_TRIGGER_THRESHOLD: &str = "INTEREST_TRIGGER_THRESHOLD";
+    pub const INTEREST_DECAY_STEP: &str = "INTEREST_DECAY_STEP";
+    pub const VD_FOLLOW_CHAT_MODEL: &str = "VD_FOLLOW_CHAT_MODEL";
     pub const VD_API_KEY: &str = "VD_API_KEY";
     pub const VD_BASE_URL: &str = "VD_BASE_URL";
     pub const VD_MODEL: &str = "VD_MODEL";
     pub const ENABLE_VISUAL_PRECEPTION: &str = "ENABLE_VISUAL_PRECEPTION";
     pub const SCREEN_WEIGHT: &str = "SCREEN_WEIGHT";
+    pub const VISUAL_PERCEPTION_PRIORITY: &str = "VISUAL_PERCEPTION_PRIORITY";
     pub const ENABLE_TOPIC_CREATER: &str = "ENABLE_TOPIC_CREATER";
     pub const TOPIC_WEIGHT: &str = "TOPIC_WEIGHT";
     pub const ENABLE_TODO_PRECEPTION: &str = "ENABLE_TODO_PRECEPTION";
@@ -22,11 +27,16 @@ pub mod keys {
 pub struct ProactiveConfig {
     pub enable_proactive_system: bool,
     pub max_proactive_times: i32,
+    pub proactive_interval_secs: u64,
+    pub interest_trigger_threshold: f64,
+    pub interest_decay_step: f64,
+    pub vd_follow_chat_model: bool,
     pub vd_api_key: String,
     pub vd_base_url: String,
     pub vd_model: String,
     pub enable_visual_perception: bool,
     pub screen_weight: f64,
+    pub visual_perception_priority: bool,
     pub enable_topic_creator: bool,
     pub topic_weight: f64,
     pub enable_todo_perception: bool,
@@ -86,21 +96,46 @@ impl ProactiveConfig {
                 .unwrap_or(default)
         };
 
+        let get_bounded_f64 = |key: &str, default: f64, min: f64, max: f64| -> f64 {
+            let value = get_f64(key, default);
+            if value.is_finite() {
+                value.clamp(min, max)
+            } else {
+                tracing::warn!(
+                    "[ProactiveConfig] {} is not finite, falling back to {}",
+                    key,
+                    default
+                );
+                default
+            }
+        };
+
         Self {
             enable_proactive_system: get_bool(keys::ENABLE_PROACTIVE_SYSTEM, false),
-            max_proactive_times: get_i32(keys::MAX_PROACTIVE_TIMES, 3),
+            max_proactive_times: get_i32(keys::MAX_PROACTIVE_TIMES, 3).clamp(0, 1_000),
+            proactive_interval_secs: get_i32(keys::PROACTIVE_INTERVAL_SECS, 10).clamp(2, 3_600)
+                as u64,
+            interest_trigger_threshold: get_bounded_f64(
+                keys::INTEREST_TRIGGER_THRESHOLD,
+                30.0,
+                0.0,
+                95.0,
+            ),
+            interest_decay_step: get_bounded_f64(keys::INTEREST_DECAY_STEP, 15.0, 0.0, 100.0),
+            vd_follow_chat_model: get_bool(keys::VD_FOLLOW_CHAT_MODEL, true),
             vd_api_key: get_string(keys::VD_API_KEY, ""),
             vd_base_url: get_string(
                 keys::VD_BASE_URL,
                 "https://dashscope.aliyuncs.com/compatible-mode/v1",
             ),
-            vd_model: get_string(keys::VD_MODEL, "qwen3.5-plus"),
+            vd_model: get_string(keys::VD_MODEL, "qwen3-vl-flash"),
             enable_visual_perception: get_bool(keys::ENABLE_VISUAL_PRECEPTION, true),
-            screen_weight: get_f64(keys::SCREEN_WEIGHT, 30.0),
+            screen_weight: get_bounded_f64(keys::SCREEN_WEIGHT, 30.0, 0.0, 10_000.0),
+            visual_perception_priority: get_bool(keys::VISUAL_PERCEPTION_PRIORITY, false),
             enable_topic_creator: get_bool(keys::ENABLE_TOPIC_CREATER, true),
-            topic_weight: get_f64(keys::TOPIC_WEIGHT, 60.0),
+            topic_weight: get_bounded_f64(keys::TOPIC_WEIGHT, 60.0, 0.0, 10_000.0),
             enable_todo_perception: get_bool(keys::ENABLE_TODO_PRECEPTION, true),
-            todo_weight: get_f64(keys::TODO_WEIGHT, 10.0),
+            todo_weight: get_bounded_f64(keys::TODO_WEIGHT, 10.0, 0.0, 10_000.0),
             enable_schedule_reminder: get_bool(keys::ENABLE_SCHEDULE_REMINDER, true),
             enable_important_day_reminder: get_bool(keys::ENABLE_IMPORTANT_DAY_REMINDER, true),
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ pub fn run() {
                     vd_api_key: pconfig.vd_api_key,
                     vd_base_url: pconfig.vd_base_url,
                     vd_model: pconfig.vd_model,
+                    provider: "openai".to_string(),
                 };
                 std::sync::Arc::new(tokio::sync::Mutex::new(ScreenAnalyzer::new(sa_config)))
             };


### PR DESCRIPTION
## 范围

本 PR 只处理视觉模型协议、截图分析和 provider 兼容，不包含主动调度循环或前端设置。

- 支持 Kimi Code / Anthropic Messages API 与多内容块提取
- 增加截图压缩、大小校验、超时和窗口上下文
- 优化视觉 prompt、token 限制和耗时日志
- 补充视觉 provider 与屏幕分析相关测试

## 规模与依赖

- 依赖先合并 #489
- GitHub 页面累计：8 个文件，1214 行新增、198 行删除
- 相对 #489 的本层增量：4 个文件，1088 行新增、197 行删除
- 页面累计新增严格低于 2000 行

## 验证

- `node scripts/prepare-desktop-resources.mjs`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- 最终组合分支中的视觉测试全部通过
- `git diff --check`