### PR TITLE
修复：强化主动回复后端生命周期与消息投放

### DIFF
--- a/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
@@ -39,6 +39,8 @@ impl AIDialogueEvent {
 #[async_trait]
 impl ScriptEvent for AIDialogueEvent {
     async fn execute(&mut self, ctx: &mut ScriptContext<'_>) -> Result<Option<String>> {
+        let _generation_guard = ctx.generation_lock.clone().lock_owned().await;
+
         let script_status = ctx
             .game_status
             .lock()
@@ -97,6 +99,7 @@ impl ScriptEvent for AIDialogueEvent {
             concurrency: 1,
             god_agent: None,
             suppress_thinking: false,
+            is_proactive: false,
         };
 
         let generator = MessageGenerator::new(deps);

--- a/src-tauri/src/ai_service/game_system/script_engine/events/free_dialogue_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/free_dialogue_event.rs
@@ -117,6 +117,7 @@ impl ScriptEvent for FreeDialogueEvent {
                     concurrency: 1,
                     god_agent: None,
                     suppress_thinking: false,
+                    is_proactive: false,
                 };
                 MessageGenerator::new(deps)
             })
@@ -161,6 +162,9 @@ impl ScriptEvent for FreeDialogueEvent {
             let _ = emit(ctx.app, SCRIPT_INPUT, &payload);
 
             let user_input = rx.await.map_err(|_| anyhow!("用户输入通道已关闭"))?;
+
+            // 用户输入、剧情提示与对应 AI 回复必须保持同一生成顺序。
+            let _generation_guard = ctx.generation_lock.clone().lock_owned().await;
 
             // ---- 添加用户输入台词先 ----
             {

--- a/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
@@ -72,6 +72,8 @@ pub struct ScriptContext<'a> {
     /// Owned Arc — events lock as needed. Decoupled from AIService lock
     /// so events can safely call MessageGenerator without deadlock.
     pub game_status: Arc<Mutex<GameStatus>>,
+    /// 与普通聊天、入场问候和主动回复共用的全局生成门。
+    pub generation_lock: Arc<Mutex<()>>,
     pub config: &'a AIServiceConfig,
 
     /// Optional LLM client for `ai_dialogue`, `free_dialogue`, `chapter_end` (ai_judged).

--- a/src-tauri/src/ai_service/game_system/script_engine/script_manager.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/script_manager.rs
@@ -205,18 +205,11 @@ impl ScriptManager {
             .ok_or_else(|| anyhow!("剧本不存在: '{}'", name))?
             .clone();
 
-        self.is_running.store(true, Ordering::SeqCst);
+        self.is_running
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .map_err(|_| anyhow!("已有剧本正在运行"))?;
 
-        // Initialize: register roles, set script_status, load player
-        Self::init_script(&script, ctx).await?;
-
-        // Run the chapter loop
-        Self::run_script(ctx).await?;
-
-        // Cleanup
-        Self::on_script_end(ctx, &self.is_running).await?;
-
-        Ok(())
+        Self::execute_reserved_script(&script, ctx, &self.is_running).await
     }
 
     /// Execute a script from start to finish without needing `&self`.
@@ -227,11 +220,31 @@ impl ScriptManager {
         ctx: &mut ScriptContext<'_>,
         is_running: &AtomicBool,
     ) -> Result<()> {
-        is_running.store(true, Ordering::SeqCst);
-        Self::init_script(script, ctx).await?;
-        Self::run_script(ctx).await?;
-        Self::on_script_end(ctx, is_running).await?;
-        Ok(())
+        debug_assert!(is_running.load(Ordering::SeqCst));
+        Self::execute_reserved_script(script, ctx, is_running).await
+    }
+
+    async fn execute_reserved_script(
+        script: &ScriptStatus,
+        ctx: &mut ScriptContext<'_>,
+        is_running: &AtomicBool,
+    ) -> Result<()> {
+        let execution = async {
+            {
+                let _generation_guard = ctx.generation_lock.clone().lock_owned().await;
+                Self::init_script(script, ctx).await?;
+            }
+            Self::run_script(ctx).await
+        }
+        .await;
+
+        match execution {
+            Ok(()) => Self::on_script_end(ctx, is_running).await,
+            Err(error) => {
+                Self::abort_script(ctx, is_running).await;
+                Err(error)
+            }
+        }
     }
 
     /// Initialize a script: register its roles, set script_status, load player info.
@@ -461,6 +474,20 @@ impl ScriptManager {
         tracing::info!("[ScriptManager] 剧本状态已清除");
 
         Ok(())
+    }
+
+    /// 异常结束只清理运行态，不把失败的剧本记入 completed_scripts。
+    async fn abort_script(ctx: &mut ScriptContext<'_>, is_running: &AtomicBool) {
+        tracing::warn!("[ScriptManager] 剧本异常终止，正在清理状态");
+        let _ = emit(ctx.app, SCRIPT_END, &ScriptEndPayload {});
+
+        {
+            let mut channels = ctx.channels.lock().await;
+            channels.input_tx = None;
+            channels.choice_tx = None;
+        }
+        ctx.game_status.lock().await.script_status = None;
+        is_running.store(false, Ordering::SeqCst);
     }
 
     // ============================================================

--- a/src-tauri/src/ai_service/message_system/events.rs
+++ b/src-tauri/src/ai_service/message_system/events.rs
@@ -39,8 +39,9 @@ pub fn emit<T: Serialize + Clone>(app: &AppHandle, event: &str, payload: &T) -> 
 }
 
 /// 通知前端 AI 正在思考或结束思考。
-pub fn emit_thinking(app: &AppHandle, is_thinking: bool) {
-    let payload = super::responses::ThinkingResponse::new(is_thinking);
+/// `is_proactive` 为 true 时表示这是主动回复触发的前置思考，前端可据此显示"主动回复中"。
+pub fn emit_thinking(app: &AppHandle, is_thinking: bool, is_proactive: bool) {
+    let payload = super::responses::ThinkingResponse::new(is_thinking, is_proactive);
     if let Err(e) = app.emit(super::responses::event_names::AI_THINKING, &payload) {
         tracing::warn!("emit thinking 失败: {e}");
     }
@@ -51,6 +52,14 @@ pub fn emit_thinking_progress(app: &AppHandle, thinking_length: usize) {
     let payload = super::responses::ThinkingProgressResponse::new(thinking_length);
     if let Err(e) = app.emit(super::responses::event_names::AI_THINKING_PROGRESS, &payload) {
         tracing::warn!("emit thinking_progress 失败: {e}");
+    }
+}
+
+/// 通知前端主动回复的思考状态切换。
+pub fn emit_proactive_thinking(app: &AppHandle, is_thinking: bool) {
+    let payload = super::responses::ProactiveThinkingResponse::new(is_thinking);
+    if let Err(e) = app.emit(super::responses::event_names::AI_PROACTIVE_THINKING, &payload) {
+        tracing::warn!("emit proactive_thinking 失败: {e}");
     }
 }
 

--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -45,6 +45,8 @@ pub struct GeneratorDeps {
     pub god_agent: Option<Arc<GodAgentCore>>,
     /// 抑制 ai:thinking 事件。用于系统触发的后台生成（如入场问候）。
     pub suppress_thinking: bool,
+    /// 标记本次生成是否由主动回复触发，用于前端区分思考状态文案。
+    pub is_proactive: bool,
 }
 
 /// `process_message` 各步骤间传递的用户消息上下文。
@@ -225,7 +227,7 @@ impl MessageGenerator {
         user_msg_seq: Option<u32>,
     ) -> Result<String> {
         if !self.deps.suppress_thinking {
-            events::emit_thinking(&self.deps.app, true);
+            events::emit_thinking(&self.deps.app, true, self.deps.is_proactive);
         }
 
         match self
@@ -234,14 +236,14 @@ impl MessageGenerator {
         {
             Ok(acc) => {
                 if !self.deps.suppress_thinking {
-                    events::emit_thinking(&self.deps.app, false);
+                    events::emit_thinking(&self.deps.app, false, self.deps.is_proactive);
                 }
                 Ok(acc)
             }
             Err(e) => {
                 events::emit_error(&self.deps.app, &e);
                 if !self.deps.suppress_thinking {
-                    events::emit_thinking(&self.deps.app, false);
+                    events::emit_thinking(&self.deps.app, false, self.deps.is_proactive);
                 }
                 Err(e)
             }

--- a/src-tauri/src/ai_service/message_system/responses.rs
+++ b/src-tauri/src/ai_service/message_system/responses.rs
@@ -16,6 +16,8 @@ pub mod event_names {
     pub const AI_THINKING: &str = "ai:thinking";
     /// AI 思考链字数进度（流式统计，仅在启用思考链时触发）。
     pub const AI_THINKING_PROGRESS: &str = "ai:thinking_progress";
+    /// 主动回复思考状态切换。
+    pub const AI_PROACTIVE_THINKING: &str = "ai:proactive_thinking";
     /// TTS 语音缓存（孤立文件）清理结果。
     pub const TTS_CLEANUP: &str = "tts:cleanup";
     /// AI 侧错误（鉴权失败 / 网络错误等）。
@@ -85,14 +87,17 @@ pub struct ThinkingResponse {
     pub type_: String,
     pub is_thinking: bool,
     pub duration: f64,
+    /// 标记这次思考是否来自主动回复触发，用于前端区分 placeholder 文案。
+    pub is_proactive: bool,
 }
 
 impl ThinkingResponse {
-    pub fn new(is_thinking: bool) -> Self {
+    pub fn new(is_thinking: bool, is_proactive: bool) -> Self {
         Self {
             type_: "thinking".to_string(),
             is_thinking,
             duration: 0.0,
+            is_proactive,
         }
     }
 }
@@ -111,6 +116,23 @@ impl ThinkingProgressResponse {
         Self {
             type_: "thinking_progress".to_string(),
             thinking_length,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProactiveThinkingResponse {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub is_thinking: bool,
+}
+
+impl ProactiveThinkingResponse {
+    pub fn new(is_thinking: bool) -> Self {
+        Self {
+            type_: "proactive_thinking".to_string(),
+            is_thinking,
         }
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/activity_monitor.rs
+++ b/src-tauri/src/ai_service/proactive_system/activity_monitor.rs
@@ -1,6 +1,11 @@
 use crate::ai_service::proactive_system::types::{PerceptionResult, UserState};
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
+
+const ACTIVITY_WINDOW: Duration = Duration::from_secs(20);
+const MOVE_SAMPLE_INTERVAL: Duration = Duration::from_millis(25);
+const MAX_ACTIVITY_EVENTS: usize = 4096;
 
 #[cfg(target_os = "windows")]
 use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
@@ -34,8 +39,8 @@ struct ActivityEvent {
 }
 
 struct MonitorInner {
-    events: Vec<ActivityEvent>,
-    last_mouse_pos: Option<(i32, i32)>,
+    events: VecDeque<ActivityEvent>,
+    last_move_sample_at: Option<Instant>,
 }
 
 pub struct UserActivityMonitor {
@@ -52,8 +57,8 @@ static GLOBAL_MONITOR_INNER: OnceLock<Arc<Mutex<MonitorInner>>> = OnceLock::new(
 impl UserActivityMonitor {
     pub fn new() -> Self {
         let inner = Arc::new(Mutex::new(MonitorInner {
-            events: Vec::new(),
-            last_mouse_pos: None,
+            events: VecDeque::new(),
+            last_move_sample_at: None,
         }));
 
         GLOBAL_MONITOR_INNER.get_or_init(|| inner.clone());
@@ -117,17 +122,25 @@ impl UserActivityMonitor {
     pub fn get_user_status(&self) -> PerceptionResult {
         let mut inner = self.inner.lock().unwrap();
         let now = Instant::now();
-        let cutoff = now - Duration::from_secs(20);
+        let cutoff = now - ACTIVITY_WINDOW;
 
         // Slide window
-        inner.events.retain(|e| e.timestamp >= cutoff);
+        while inner
+            .events
+            .front()
+            .is_some_and(|event| event.timestamp < cutoff)
+        {
+            inner.events.pop_front();
+        }
 
         let mut keystrokes = 0;
         let mut game_keys = 0;
         let mut clicks = 0;
         let mut mouse_distance = 0.0;
 
-        let mut running_last_pos = inner.last_mouse_pos;
+        // 只在当前滑动窗口内部计算相邻采样点距离。不能以上一轮的最新坐标作为
+        // 起点，否则会先从“最新点”跳回本轮最旧点，凭空制造一段巨大移动距离。
+        let mut running_last_pos = None;
         for event in &inner.events {
             match &event.input_type {
                 InputType::Key { is_game } => {
@@ -149,8 +162,6 @@ impl UserActivityMonitor {
                 }
             }
         }
-        inner.last_mouse_pos = running_last_pos;
-
         let game_ratio = if keystrokes > 0 {
             game_keys as f64 / keystrokes as f64
         } else {
@@ -210,6 +221,21 @@ impl UserActivityMonitor {
     }
 }
 
+fn push_activity_event(inner: &mut MonitorInner, event: ActivityEvent) {
+    let cutoff = event.timestamp - ACTIVITY_WINDOW;
+    while inner
+        .events
+        .front()
+        .is_some_and(|old| old.timestamp < cutoff)
+    {
+        inner.events.pop_front();
+    }
+    if inner.events.len() >= MAX_ACTIVITY_EVENTS {
+        inner.events.pop_front();
+    }
+    inner.events.push_back(event);
+}
+
 #[cfg(target_os = "windows")]
 unsafe extern "system" fn keyboard_hook_callback(
     code: i32,
@@ -230,10 +256,13 @@ unsafe extern "system" fn keyboard_hook_callback(
 
             if let Some(inner_arc) = GLOBAL_MONITOR_INNER.get() {
                 if let Ok(mut inner) = inner_arc.lock() {
-                    inner.events.push(ActivityEvent {
-                        timestamp: Instant::now(),
-                        input_type: InputType::Key { is_game },
-                    });
+                    push_activity_event(
+                        &mut inner,
+                        ActivityEvent {
+                            timestamp: Instant::now(),
+                            input_type: InputType::Key { is_game },
+                        },
+                    );
                 }
             }
         }
@@ -255,15 +284,35 @@ unsafe extern "system" fn mouse_hook_callback(
         if let Some(inner_arc) = GLOBAL_MONITOR_INNER.get() {
             if let Ok(mut inner) = inner_arc.lock() {
                 if msg == WM_LBUTTONDOWN || msg == WM_RBUTTONDOWN || msg == WM_MBUTTONDOWN {
-                    inner.events.push(ActivityEvent {
-                        timestamp: Instant::now(),
-                        input_type: InputType::Click,
-                    });
+                    push_activity_event(
+                        &mut inner,
+                        ActivityEvent {
+                            timestamp: Instant::now(),
+                            input_type: InputType::Click,
+                        },
+                    );
                 } else if msg == WM_MOUSEMOVE {
-                    inner.events.push(ActivityEvent {
-                        timestamp: Instant::now(),
-                        input_type: InputType::Move { x: pt.x, y: pt.y },
-                    });
+                    let now = Instant::now();
+                    let should_append = inner
+                        .last_move_sample_at
+                        .is_none_or(|last| now.duration_since(last) >= MOVE_SAMPLE_INTERVAL);
+                    if should_append {
+                        inner.last_move_sample_at = Some(now);
+                        push_activity_event(
+                            &mut inner,
+                            ActivityEvent {
+                                timestamp: now,
+                                input_type: InputType::Move { x: pt.x, y: pt.y },
+                            },
+                        );
+                    } else if let Some(last) = inner.events.back_mut() {
+                        // 在采样间隔内只更新最后一个坐标，既保留位移终点又避免
+                        // WM_MOUSEMOVE 高频事件撑大队列、拖慢低级钩子回调。
+                        if matches!(last.input_type, InputType::Move { .. }) {
+                            last.timestamp = now;
+                            last.input_type = InputType::Move { x: pt.x, y: pt.y };
+                        }
+                    }
                 }
             }
         }

--- a/src-tauri/src/ai_service/proactive_system/delivery_evaluator.rs
+++ b/src-tauri/src/ai_service/proactive_system/delivery_evaluator.rs
@@ -18,9 +18,83 @@ impl DeliveryEvaluator {
             tracing::debug!("[DeliveryEval] can_deliver=false (frontend report)");
             return false;
         }
-        /*
-        Tips: 此处可以添加更多判断逻辑，比如过滤掉无意义对话等
-         */
-        true
+
+        let allowed = match intent_type {
+            // 明确的日程闹钟优先级最高，只要前端允许即可投递。
+            IntentType::Alarm => true,
+            // 重要日子不应在全屏游戏时打断用户。
+            IntentType::ImportantDay => perception.state != UserState::GAME,
+            // TODO 在工作状态下也可能有价值，但游戏中不应弹出。
+            IntentType::Todo => perception.state != UserState::GAME,
+            // 屏幕评论只在轻度活动/浏览时投递；工作、游戏和真正挂机时容易过时或打扰。
+            IntentType::Screen => {
+                matches!(perception.state, UserState::BROWSING | UserState::CASUAL)
+            }
+            // 无明确事项的闲聊只在用户空闲或轻度活动时发起。
+            IntentType::Topic => {
+                matches!(perception.state, UserState::IDLE | UserState::CASUAL)
+            }
+        };
+
+        if !allowed {
+            tracing::debug!(
+                "[DeliveryEval] {:?} suppressed for user state {:?}",
+                intent_type,
+                perception.state
+            );
+        }
+        allowed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn perception(state: UserState) -> PerceptionResult {
+        PerceptionResult {
+            state,
+            description: String::new(),
+            interest_modifier: 0,
+            visual_change_detected: false,
+            current_screen_text: String::new(),
+        }
+    }
+
+    #[test]
+    fn frontend_gate_always_wins() {
+        assert!(!DeliveryEvaluator::can_deliver(
+            IntentType::Alarm,
+            &perception(UserState::IDLE),
+            false,
+        ));
+    }
+
+    #[test]
+    fn topic_does_not_interrupt_work_or_game() {
+        assert!(!DeliveryEvaluator::can_deliver(
+            IntentType::Topic,
+            &perception(UserState::WORK),
+            true,
+        ));
+        assert!(!DeliveryEvaluator::can_deliver(
+            IntentType::Topic,
+            &perception(UserState::GAME),
+            true,
+        ));
+        assert!(DeliveryEvaluator::can_deliver(
+            IntentType::Topic,
+            &perception(UserState::CASUAL),
+            true,
+        ));
+    }
+
+    #[test]
+    fn alarms_are_allowed_in_busy_states() {
+        assert!(DeliveryEvaluator::can_deliver(
+            IntentType::Alarm,
+            &perception(UserState::GAME),
+            true,
+        ));
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/interest_manager.rs
+++ b/src-tauri/src/ai_service/proactive_system/interest_manager.rs
@@ -1,3 +1,4 @@
+use chrono::Local;
 use rand::Rng;
 
 pub struct InterestManager {
@@ -8,18 +9,12 @@ pub struct InterestManager {
     pub max_proactive_count: i32,
     pub decay_step: f64,
     pub proactive_times: i32,
+    pub trigger_threshold: f64,
+    pub last_reset_date: String,
 }
 
 impl InterestManager {
-    pub fn new(max_proactive_count: i32) -> Self {
-        // 计算 decay_step: 50.0 / max_proactive_count
-        // 注意：需要处理 max_proactive_count 为 0 的情况，防止除以零导致 panic 或产生 NaN/Inf
-        let decay_step = if max_proactive_count > 0 {
-            50.0 / max_proactive_count as f64
-        } else {
-            0.0 // 如果最大次数为0，则不衰减
-        };
-
+    pub fn new(max_proactive_count: i32, trigger_threshold: f64, decay_step: f64) -> Self {
         Self {
             interest: 0.0,
             max_interest_cap: 100.0,
@@ -28,22 +23,32 @@ impl InterestManager {
             max_proactive_count,
             decay_step,
             proactive_times: 0,
+            trigger_threshold,
+            last_reset_date: Local::now().format("%Y-%m-%d").to_string(),
         }
     }
 
-    pub fn update_from_config(&mut self, max_proactive_count: i32) {
+    pub fn update_from_config(
+        &mut self,
+        max_proactive_count: i32,
+        trigger_threshold: f64,
+        decay_step: f64,
+    ) {
         self.max_proactive_count = max_proactive_count;
-        // 当配置更新时，同步更新 decay_step
-        self.decay_step = if max_proactive_count > 0 {
-            50.0 / max_proactive_count as f64
-        } else {
-            0.0
-        };
+        self.trigger_threshold = trigger_threshold;
+        self.decay_step = decay_step;
     }
 
-    pub fn update_interest(&mut self) {
+    /// 根据用户状态更新兴趣度。
+    /// 用户越活跃（游戏/浏览）增长越快；工作/挂机时增长更慢。
+    pub fn update_interest(&mut self, status_mod: i32) {
+        self.status_mod = status_mod;
+
         let mut rng = rand::thread_rng();
-        let growth = rng.gen_range(5.0..10.0);
+        let base_growth = rng.gen_range(5.0..10.0);
+        // 状态修正：正 modifier 加速，负 modifier 减速，但不会让增长低于 1
+        let growth = (base_growth + status_mod as f64 * 0.3).max(1.0);
+
         self.interest = (self.interest + growth).min(self.max_interest_cap);
         tracing::info!(
             "[Engagement] Interest grown by {:.2}. Current: {:.2}/{:.2}",
@@ -58,17 +63,25 @@ impl InterestManager {
             return false;
         }
 
-        if self.interest <= 50.0 {
+        if self.interest <= self.trigger_threshold {
             return false;
         }
 
         let mut rng = rand::thread_rng();
-        let prob = (self.interest + self.status_mod as f64 - 50.0) / 50.0;
+        // prob 从 0 到 1 线性增长：刚好到阈值时为 0，达到 cap 时为 1
+        let range = self.max_interest_cap - self.trigger_threshold;
+        let prob = if range <= 0.0 {
+            1.0
+        } else {
+            (self.interest + self.status_mod as f64 - self.trigger_threshold) / range
+        };
+        let prob = prob.clamp(0.0, 1.0);
         let roll = rng.gen_range(0.0..1.0);
         let triggered = roll < prob;
 
         tracing::info!(
-            "[Engagement] Trigger check: prob={:.2}, roll={:.2}, triggered={}",
+            "[Engagement] Trigger check: threshold={:.2}, prob={:.2}, roll={:.2}, triggered={}",
+            self.trigger_threshold,
             prob,
             roll,
             triggered
@@ -84,7 +97,10 @@ impl InterestManager {
     }
 
     pub fn decay_max_interest_cap(&mut self) {
-        self.max_interest_cap = (self.max_interest_cap - self.decay_step).max(50.0);
+        // 衰减后至少保留触发阈值 + 5 或 20 分，确保上限始终高于阈值，
+        // 避免 interest 永远涨不过 threshold 导致主动回复卡死
+        let floor = (self.trigger_threshold + 5.0).max(20.0);
+        self.max_interest_cap = (self.max_interest_cap - self.decay_step).max(floor);
         tracing::info!("[Engagement] Cap decayed to {:.2}", self.max_interest_cap);
     }
 
@@ -92,9 +108,22 @@ impl InterestManager {
         self.max_interest_cap = self.initial_max_cap;
         self.proactive_times = 0;
         self.interest = 0.0;
+        self.last_reset_date = Local::now().format("%Y-%m-%d").to_string();
     }
 
-    pub fn set_status_mod(&mut self, val: i32) {
-        self.status_mod = val;
+    /// 跨天时重置每日计数与上限，确保每天最多触发 `max_proactive_count` 次。
+    pub fn check_daily_reset(&mut self) {
+        let today = Local::now().format("%Y-%m-%d").to_string();
+        if self.last_reset_date != today {
+            tracing::info!(
+                "[Engagement] New day reset: {} -> {}, restoring cap and proactive count",
+                self.last_reset_date,
+                today
+            );
+            self.max_interest_cap = self.initial_max_cap;
+            self.proactive_times = 0;
+            self.interest = 0.0;
+            self.last_reset_date = today;
+        }
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/mod.rs
+++ b/src-tauri/src/ai_service/proactive_system/mod.rs
@@ -2,6 +2,7 @@ pub mod activity_monitor;
 pub mod config;
 pub mod delivery_evaluator;
 pub mod interest_manager;
+pub mod proactive_history;
 pub mod schedule_manager;
 pub mod strategy_dispatcher;
 pub mod types;
@@ -9,14 +10,17 @@ pub mod visual_monitor;
 
 use sea_orm::DatabaseConnection;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::AppHandle;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
 use tokio::task::JoinHandle;
 
+use crate::ai_service::llm::LlmClient;
 use crate::ai_service::message_system::events;
 use crate::ai_service::message_system::generator::{GeneratorDeps, MessageGenerator};
+use crate::ai_service::message_system::processor::MessageProcessor;
 use crate::ai_service::service::SharedAIService;
+use crate::ai_service::translator::Translator;
 use crate::ai_service::types::{LineAttributeExt, LineBase};
 use crate::db::entities::line::LineAttribute;
 use crate::utils::prompt::PromptRole;
@@ -28,8 +32,12 @@ use delivery_evaluator::DeliveryEvaluator;
 use interest_manager::InterestManager;
 use schedule_manager::ScheduleManager;
 use strategy_dispatcher::StrategyDispatcher;
-use types::{IntentType, PendingIntent, UserScheduleSettings};
+use types::{IntentType, PendingIntent, PerceptionResult, ProactiveContext, UserScheduleSettings};
 use visual_monitor::VisualMonitor;
+
+const MAX_PENDING_INTENTS: usize = 5;
+const MAX_SAFE_DELIVERY_ATTEMPTS: u8 = 3;
+const DELIVERY_FAILURE_BACKOFF: Duration = Duration::from_secs(60);
 
 pub struct ProactiveSystem {
     app: AppHandle,
@@ -44,7 +52,7 @@ pub struct ProactiveSystem {
     activity_monitor: UserActivityMonitor,
     visual_monitor: VisualMonitor,
     schedule_manager: ScheduleManager,
-    strategy_dispatcher: StrategyDispatcher,
+    strategy_dispatcher: Arc<StrategyDispatcher>,
 
     loop_handle: Option<JoinHandle<()>>,
     is_running: bool,
@@ -52,8 +60,161 @@ pub struct ProactiveSystem {
     /// 前端上报的“当前是否适合投放主动对话”。
     /// 条件：用户在聊天界面(/chat 或 /pet) 且 设置面板未打开 且 输入框为空。
     can_deliver: bool,
+    /// 每次用户主动发言递增；让在途视觉/闲聊结果可被识别为过期。
+    interaction_epoch: u64,
+    /// 模型/消费者失败后的全局退避，避免每轮重新污染上下文。
+    delivery_backoff_until: Option<Instant>,
     /// 暂存的主动对话意图（"小本本"）。每轮 cycle 开头尝试投放。
-    pending_intents: Vec<PendingIntent>,}
+    pending_intents: Vec<PendingIntent>,
+}
+
+/// 可以脱离 `ProactiveSystem` 大锁执行投递的只读依赖快照。
+#[derive(Clone)]
+struct DeliveryContext {
+    app: AppHandle,
+    db: DatabaseConnection,
+    ai_service: SharedAIService,
+    generation_lock: Arc<Mutex<()>>,
+    processor: Arc<MessageProcessor>,
+    translator: Arc<Translator>,
+    llm: Option<Arc<LlmClient>>,
+}
+
+/// 确保主动生成 future 被取消或任务被 abort 时也会恢复前端思考状态。
+struct ProactiveThinkingGuard {
+    app: AppHandle,
+}
+
+impl ProactiveThinkingGuard {
+    fn new(app: &AppHandle) -> Self {
+        events::emit_thinking(app, true, true);
+        events::emit_proactive_thinking(app, true);
+        Self { app: app.clone() }
+    }
+}
+
+impl Drop for ProactiveThinkingGuard {
+    fn drop(&mut self) {
+        events::emit_proactive_thinking(&self.app, false);
+        events::emit_thinking(&self.app, false, true);
+    }
+}
+
+impl DeliveryContext {
+    fn try_generation_guard(&self) -> Option<OwnedMutexGuard<()>> {
+        self.generation_lock.clone().try_lock_owned().ok()
+    }
+
+    async fn rollback_prompt_line(
+        &self,
+        game_status: &Arc<Mutex<crate::ai_service::game_system::game_status::GameStatus>>,
+        prompt_index: usize,
+        expected_prompt: &str,
+    ) {
+        let mut gs = game_status.lock().await;
+        let is_our_prompt = gs.line_list.get(prompt_index).is_some_and(|line| {
+            matches!(line.attribute(), LineAttribute::User)
+                && line.base.sender_role_id.is_none()
+                && line.base.content == expected_prompt
+        });
+        if !is_our_prompt {
+            return;
+        }
+
+        gs.line_list.remove(prompt_index);
+        if let Err(error) = gs.refresh_memories(&self.db).await {
+            tracing::error!(
+                "[ProactiveSystem] Failed to refresh memories after prompt rollback: {error:#}"
+            );
+        }
+    }
+
+    /// 调用方必须先取得 generation guard，并在取得后重新验证投放条件。
+    async fn deliver(
+        &self,
+        prompt: String,
+        _generation_guard: OwnedMutexGuard<()>,
+    ) -> anyhow::Result<String> {
+        let llm = self
+            .llm
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("LLM is not configured"))?;
+
+        let game_status = {
+            let svc = self.ai_service.lock().await;
+            svc.game_status.clone()
+        };
+        let generator = MessageGenerator::new(GeneratorDeps {
+            app: self.app.clone(),
+            db: self.db.clone(),
+            game_status: game_status.clone(),
+            processor: self.processor.clone(),
+            translator: self.translator.clone(),
+            llm,
+            concurrency: 1,
+            god_agent: None,
+            // 由本方法统一维护 thinking 状态，确保所有错误路径都能复位。
+            suppress_thinking: true,
+            is_proactive: true,
+        });
+
+        let _thinking_guard = ProactiveThinkingGuard::new(&self.app);
+
+        let expected_prompt = prompt.clone();
+        let (prompt_index, add_result) = {
+            let mut gs = game_status.lock().await;
+            let prompt_index = gs.line_list.len();
+            let result = gs
+                .add_line(
+                    &self.db,
+                    LineBase {
+                        attribute: LineAttributeExt(LineAttribute::User),
+                        content: prompt,
+                        sender_role_id: None,
+                        display_name: None,
+                        ..Default::default()
+                    },
+                )
+                .await;
+            (prompt_index, result)
+        };
+        if let Err(error) = add_result {
+            self.rollback_prompt_line(&game_status, prompt_index, &expected_prompt)
+                .await;
+            return Err(error);
+        }
+
+        let generation_result = generator.process_message(None).await;
+        let assistant_count = {
+            let gs = game_status.lock().await;
+            gs.line_list
+                .iter()
+                .skip(prompt_index + 1)
+                .filter(|line| matches!(line.attribute(), LineAttribute::Assistant))
+                .count()
+        };
+
+        match generation_result {
+            Ok(output) if assistant_count > 0 => Ok(output),
+            Ok(_) => {
+                self.rollback_prompt_line(&game_status, prompt_index, &expected_prompt)
+                    .await;
+                anyhow::bail!("proactive generation produced no persisted assistant response")
+            }
+            Err(error) if assistant_count > 0 => {
+                tracing::warn!(
+                    "[ProactiveSystem] Generator ended with an error after persisting {assistant_count} response line(s): {error:#}"
+                );
+                Ok(String::new())
+            }
+            Err(error) => {
+                self.rollback_prompt_line(&game_status, prompt_index, &expected_prompt)
+                    .await;
+                Err(error)
+            }
+        }
+    }
+}
 
 impl ProactiveSystem {
     pub fn new(
@@ -64,11 +225,15 @@ impl ProactiveSystem {
         generation_lock: Arc<Mutex<()>>,
     ) -> Self {
         let config = ProactiveConfig::load(&app);
-        let interest_manager = InterestManager::new(config.max_proactive_times);
+        let interest_manager = InterestManager::new(
+            config.max_proactive_times,
+            config.interest_trigger_threshold,
+            config.interest_decay_step,
+        );
         let activity_monitor = UserActivityMonitor::new();
         let visual_monitor = VisualMonitor::new();
         let schedule_manager = ScheduleManager::new();
-        let strategy_dispatcher = StrategyDispatcher::new(&app);
+        let strategy_dispatcher = Arc::new(StrategyDispatcher::new(&app));
 
         let system = Self {
             app,
@@ -86,10 +251,45 @@ impl ProactiveSystem {
             loop_handle: None,
             is_running: false,
             can_deliver: false,
+            interaction_epoch: 0,
+            delivery_backoff_until: None,
             pending_intents: Vec::new(),
         };
 
         system
+    }
+
+    fn delivery_context(&self) -> DeliveryContext {
+        DeliveryContext {
+            app: self.app.clone(),
+            db: self.db.clone(),
+            ai_service: self.ai_service.clone(),
+            generation_lock: self.generation_lock.clone(),
+            processor: self.chat.processor.clone(),
+            translator: self.chat.translator.clone(),
+            llm: self.chat.llm.clone(),
+        }
+    }
+
+    /// 只复制策略需要的少量状态，绝不把 GameStatus guard 带入 VLM 网络请求。
+    async fn read_runtime_context(ai_service: &SharedAIService) -> (ProactiveContext, bool) {
+        let game_status = {
+            let svc = ai_service.lock().await;
+            svc.game_status.clone()
+        };
+        let gs = game_status.lock().await;
+        let ai_name = gs
+            .current_role_id
+            .and_then(|rid| gs.role_manager.get_loaded(rid))
+            .and_then(|role| role.display_name.clone())
+            .unwrap_or_else(|| "你".to_string());
+        (
+            ProactiveContext {
+                user_name: gs.player.user_name.clone(),
+                ai_name,
+            },
+            gs.script_status.is_some(),
+        )
     }
 
     /// 启动主动对话的后台轮询 Loop。
@@ -107,30 +307,28 @@ impl ProactiveSystem {
         let handle = tokio::spawn(async move {
             tracing::info!("[ProactiveSystem] Loop task started.");
 
-            // Loop runs every 30 seconds
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
             loop {
-                interval.tick().await;
-
-                // Grab locks safely to avoid blocking startup or chat interaction
-                let (enabled, is_script_active) = {
+                // 每次循环从配置读取最新轮询间隔，保存后无需重启即可生效
+                let interval_secs = {
                     let sys = sys_clone.lock().await;
                     if !sys.is_running {
                         break;
                     }
+                    sys.config.proactive_interval_secs.max(1)
+                };
 
-                    let svc = sys.ai_service.lock().await;
-                    let is_script_active = svc.game_status.lock().await.script_status.is_some();
-                    (sys.config.enable_proactive_system, is_script_active)
+                tokio::time::sleep(Duration::from_secs(interval_secs)).await;
+
+                let enabled = {
+                    let sys = sys_clone.lock().await;
+                    if !sys.is_running {
+                        break;
+                    }
+                    sys.config.enable_proactive_system
                 };
 
                 if !enabled {
                     // tracing::info!("[ProactiveSystem] Disabled via settings, skipping...");
-                    continue;
-                }
-
-                if is_script_active {
-                    // tracing::info!("[ProactiveSystem] Script is currently running, bypassing proactive talk to avoid collision.");
                     continue;
                 }
 
@@ -155,12 +353,94 @@ impl ProactiveSystem {
     }
 
     /// 重新载入环境配置和日程设置。
-    pub async fn reload(&mut self) {
-        self.config = ProactiveConfig::load(&self.app);
-        self.strategy_dispatcher.update_config(&self.app);
-        self.interest_manager
-            .update_from_config(self.config.max_proactive_times);
-        self.load_schedule_settings().await;
+    pub async fn reload(system_arc: Arc<Mutex<Self>>) {
+        // ScreenAnalyzer 可能被一次较慢的 VLM 请求占用。复制依赖后先释放系统锁，
+        // 避免配置重载期间阻塞 can_deliver 上报和用户消息回调。
+        let (app, strategy) = {
+            let sys = system_arc.lock().await;
+            (sys.app.clone(), sys.strategy_dispatcher.clone())
+        };
+        let config = ProactiveConfig::load(&app);
+        {
+            let mut sys = system_arc.lock().await;
+            sys.config = config.clone();
+            sys.delivery_backoff_until = None;
+            if !config.enable_proactive_system {
+                sys.pending_intents.clear();
+            } else {
+                sys.pending_intents.retain(|intent| {
+                    Self::intent_enabled(&config, intent.intent_type)
+                        && (intent.intent_type == IntentType::Alarm
+                            || config.max_proactive_times > 0)
+                });
+            }
+            sys.interest_manager.update_from_config(
+                config.max_proactive_times,
+                config.interest_trigger_threshold,
+                config.interest_decay_step,
+            );
+        }
+
+        // 这一步可能等待正在进行的 VLM，但已不再持有 ProactiveSystem 锁。
+        strategy.update_config(&app).await;
+        system_arc.lock().await.load_schedule_settings().await;
+    }
+
+    /// 手动触发一次基于屏幕的主动搭话测试，直接截屏 → VLM → 投递到前端。
+    /// 跳过兴趣累积、投放闸门和反重复检测，用于在设置页快速验证视觉主动回复链路。
+    pub async fn test_screen_proactive(
+        system_arc: Arc<Mutex<Self>>,
+    ) -> Result<Option<String>, String> {
+        let (ai_service, strategy, delivery) = {
+            let sys = system_arc.lock().await;
+            (
+                sys.ai_service.clone(),
+                sys.strategy_dispatcher.clone(),
+                sys.delivery_context(),
+            )
+        };
+
+        tracing::info!("[ProactiveSystem] Test proactive message triggered.");
+
+        let prompt_result = async {
+            let (context, script_active) = Self::read_runtime_context(&ai_service).await;
+            if script_active {
+                return Err("剧情正在运行，暂不执行主动消息测试".to_string());
+            }
+            let (raw_prompt, _intent_type) = strategy
+                .get_screen_prompt_for_test(&context)
+                .await
+                .ok_or_else(|| {
+                    "屏幕分析未返回有效内容（API Key 为空、网络超时或模型不支持视觉）".to_string()
+                })?;
+
+            tracing::info!(
+                "[ProactiveSystem] Test screen prompt generated: {}",
+                raw_prompt
+            );
+
+            let formatted = crate::utils::prompt::PromptRole::System.build_prompt(&raw_prompt);
+            let (_, script_active) = Self::read_runtime_context(&ai_service).await;
+            if script_active {
+                return Err("视觉分析期间剧情已开始，本次测试已取消".to_string());
+            }
+            let guard = delivery
+                .try_generation_guard()
+                .ok_or_else(|| "当前有其他回复正在生成，请稍后再试".to_string())?;
+            delivery
+                .deliver(formatted, guard)
+                .await
+                .map_err(|e| format!("投递主动消息失败: {}", e))?;
+
+            Ok::<String, String>(raw_prompt)
+        }
+        .await;
+
+        if let Err(ref e) = prompt_result {
+            tracing::error!("[ProactiveSystem] Test proactive message failed: {}", e);
+        }
+
+        prompt_result.map(Some)
     }
 
     /// 重新载入日程设置文件 schedules.json。
@@ -198,7 +478,11 @@ impl ProactiveSystem {
     /// 当用户主动发送消息时触发的回调，用于恢复好感度/兴趣阈值。
     pub async fn on_user_message_received(&mut self) {
         tracing::info!("[ProactiveSystem] User message received! Restoring engagement cap.");
+        self.interaction_epoch = self.interaction_epoch.wrapping_add(1);
         self.interest_manager.restore_max_interest_cap();
+        // 用户已经主动开启了一轮新对话，旧的闲聊/屏幕观察已失去时效。
+        self.pending_intents
+            .retain(|intent| !matches!(intent.intent_type, IntentType::Screen | IntentType::Topic));
     }
 
     /// 前端通知后端当前是否具备投放条件。
@@ -219,118 +503,164 @@ impl ProactiveSystem {
     // 核心投放方法
     // ============================================================
 
-    /// 统一的主动对话投放入口。持有锁不放，直到 LLM 流式生成完毕。
-    /// 已侵入 game_status 的副作用（add_line），调用者需确保：
-    /// - generation_lock 未被持有
-    /// - prompt 已完整生成（含截图分析结果）
-    async fn deliver(&mut self, prompt: String) -> anyhow::Result<()> {
-        tracing::info!("[ProactiveSystem] Delivering proactive dialogue...");
-
-        let _lock = self.generation_lock.lock().await;
-        events::emit_thinking(&self.app, true);
-
-        let generator = {
-            let game_status = {
-                let svc = self.ai_service.lock().await;
-                svc.game_status.clone()
-            };
-            let deps = GeneratorDeps {
-                app: self.app.clone(),
-                db: self.db.clone(),
-                game_status,
-                processor: self.chat.processor.clone(),
-                translator: self.chat.translator.clone(),
-                llm: self.chat.llm.clone()
-                    .ok_or_else(|| anyhow::anyhow!("LLM is not configured"))?,
-                concurrency: 1,
-                god_agent: None,
-                suppress_thinking: false,
-            };
-            MessageGenerator::new(deps)
-        };
-
+    fn stash_intent(&mut self, intent: PendingIntent) {
+        if matches!(intent.intent_type, IntentType::Screen | IntentType::Topic)
+            && intent.interaction_epoch != self.interaction_epoch
         {
-            let svc = self.ai_service.lock().await;
-            let mut gs = svc.game_status.lock().await;
-            gs.add_line(
-                &self.db,
-                LineBase {
-                    attribute: LineAttributeExt(LineAttribute::User),
-                    content: prompt,
-                    sender_role_id: None,
-                    display_name: None,
-                    ..Default::default()
-                },
-            )
-            .await?;
+            tracing::debug!(
+                "[ProactiveSystem] Dropping stale {:?} intent from epoch {} (current {})",
+                intent.intent_type,
+                intent.interaction_epoch,
+                self.interaction_epoch
+            );
+            return;
         }
 
-        let _ = generator.process_message(None).await;
-        Ok(())
+        if intent.intent_type == IntentType::Alarm {
+            // 同一分钟可能有多个日程；闹钟逐条保留，只过滤完全相同的重复项。
+            if self.pending_intents.iter().any(|queued| {
+                queued.intent_type == IntentType::Alarm && queued.prompt == intent.prompt
+            }) {
+                return;
+            }
+        } else if let Some(existing) = self
+            .pending_intents
+            .iter_mut()
+            .find(|queued| queued.intent_type == intent.intent_type)
+        {
+            if intent.triggered_at >= existing.triggered_at {
+                tracing::debug!(
+                    "[ProactiveSystem] Replacing queued {:?} intent with newer content",
+                    intent.intent_type
+                );
+                *existing = intent;
+            }
+            return;
+        }
+
+        if self.pending_intents.len() >= MAX_PENDING_INTENTS {
+            self.pending_intents
+                .sort_by_key(|queued| (queued.intent_type, queued.triggered_at));
+            self.pending_intents.remove(0);
+        }
+        self.pending_intents.push(intent);
     }
 
-    /// 遍历暂存队列，尝试投放一个合适的意图。
-    /// 返回 `true` 表示本轮已投放（调用方应 return）。
-    async fn try_flush_pending_intent(&mut self) -> anyhow::Result<bool> {
-        if self.pending_intents.is_empty() {
-            return Ok(false);
-        }
-
-        if self.generation_lock.try_lock().is_err() {
-            tracing::debug!("[ProactiveSystem] gen_lock busy, skip flush");
-            return Ok(false);
-        }
-
-        let perception = self.activity_monitor.get_user_status();
-        let now = std::time::Instant::now();
-
-        // 按优先级降序：Alarm(4) > ImportantDay(3) > Todo(2) > Screen(1) > Topic(0)
-        self.pending_intents
-            .sort_by_key(|i| std::cmp::Reverse(i.intent_type));
-
-        // 第一步：清理过期意图
-        let before = self.pending_intents.len();
+    fn take_deliverable_pending(&mut self, perception: &PerceptionResult) -> Option<PendingIntent> {
+        let now = Instant::now();
+        let interaction_epoch = self.interaction_epoch;
+        let delivery_backoff_active = self.delivery_backoff_until.is_some_and(|until| now < until);
         self.pending_intents.retain(|intent| {
-            let elapsed = now.duration_since(intent.triggered_at).as_secs();
-            if elapsed > intent.intent_type.ttl_secs() {
-                tracing::info!(
-                    "[ProactiveSystem] Intent {:?} expired after {}s, discarding",
-                    intent.intent_type, elapsed
-                );
-                false
-            } else {
-                true
-            }
+            now.duration_since(intent.triggered_at).as_secs() <= intent.intent_type.ttl_secs()
+                && (!matches!(intent.intent_type, IntentType::Screen | IntentType::Topic)
+                    || intent.interaction_epoch == interaction_epoch)
         });
-        if before != self.pending_intents.len() {
-            tracing::info!(
-                "[ProactiveSystem] Expired discard: {} -> {}",
-                before,
-                self.pending_intents.len()
-            );
+        self.pending_intents
+            .sort_by_key(|intent| std::cmp::Reverse(intent.intent_type));
+        let index = self.pending_intents.iter().position(|intent| {
+            (!delivery_backoff_active
+                || (intent.intent_type == IntentType::Alarm && intent.delivery_attempts == 0))
+                && DeliveryEvaluator::can_deliver(intent.intent_type, perception, self.can_deliver)
+        })?;
+        Some(self.pending_intents.remove(index))
+    }
+
+    fn intent_enabled(config: &ProactiveConfig, intent_type: IntentType) -> bool {
+        match intent_type {
+            IntentType::Alarm => config.enable_schedule_reminder,
+            IntentType::ImportantDay => config.enable_important_day_reminder,
+            IntentType::Todo => config.enable_todo_perception,
+            IntentType::Screen => config.enable_visual_perception,
+            IntentType::Topic => config.enable_topic_creator,
+        }
+    }
+
+    async fn attempt_delivery(
+        system_arc: Arc<Mutex<Self>>,
+        delivery: DeliveryContext,
+        strategy: Arc<StrategyDispatcher>,
+        mut intent: PendingIntent,
+    ) -> anyhow::Result<bool> {
+        let Some(guard) = delivery.try_generation_guard() else {
+            tracing::debug!("[ProactiveSystem] generation lock busy; deferring intent");
+            system_arc.lock().await.stash_intent(intent);
+            return Ok(false);
+        };
+
+        let (_, script_active) = Self::read_runtime_context(&delivery.ai_service).await;
+        let should_defer = {
+            let sys = system_arc.lock().await;
+            if !sys.is_running || !sys.config.enable_proactive_system {
+                return Ok(false);
+            }
+            if !Self::intent_enabled(&sys.config, intent.intent_type) {
+                tracing::debug!(
+                    "[ProactiveSystem] Dropping disabled {:?} intent",
+                    intent.intent_type
+                );
+                return Ok(false);
+            }
+            if matches!(intent.intent_type, IntentType::Screen | IntentType::Topic)
+                && intent.interaction_epoch != sys.interaction_epoch
+            {
+                tracing::debug!(
+                    "[ProactiveSystem] Dropping stale {:?} result from epoch {} (current {})",
+                    intent.intent_type,
+                    intent.interaction_epoch,
+                    sys.interaction_epoch
+                );
+                return Ok(false);
+            }
+            if intent.intent_type != IntentType::Alarm
+                && sys.interest_manager.proactive_times >= sys.interest_manager.max_proactive_count
+            {
+                return Ok(false);
+            }
+            let current = sys.activity_monitor.get_user_status();
+            script_active
+                || !DeliveryEvaluator::can_deliver(intent.intent_type, &current, sys.can_deliver)
+        };
+        if should_defer {
+            system_arc.lock().await.stash_intent(intent);
+            return Ok(false);
         }
 
-        // 第二步：找第一个可投放的（索引有效，因为不在遍历中收集）
-        for (i, intent) in self.pending_intents.iter().enumerate() {
-            if DeliveryEvaluator::can_deliver(
-                intent.intent_type,
-                &perception,
-                self.can_deliver,
-            ) {
-                let intent = self.pending_intents.remove(i);
-                let waited = now.duration_since(intent.triggered_at);
-                tracing::info!(
-                    "[ProactiveSystem] Flushing deferred {:?} intent (waited {:.0}s, {} remaining in queue)",
-                    intent.intent_type,
-                    waited.as_secs(),
-                    self.pending_intents.len()
-                );
-                self.deliver(intent.prompt).await?;
-                return Ok(true);
+        tracing::info!(
+            "[ProactiveSystem] Delivering {:?} proactive intent",
+            intent.intent_type
+        );
+        match delivery.deliver(intent.prompt.clone(), guard).await {
+            Ok(_) => {
+                if let Some(raw_prompt) = intent.raw_prompt.as_deref() {
+                    strategy
+                        .record_delivered(raw_prompt, intent.intent_type)
+                        .await;
+                }
+                let mut sys = system_arc.lock().await;
+                sys.delivery_backoff_until = None;
+                // 闹钟不占用“用户回复前最多主动搭话次数”，即时与延迟投递保持一致。
+                if intent.intent_type != IntentType::Alarm {
+                    sys.interest_manager.reset_interest();
+                }
+                Ok(true)
+            }
+            Err(error) => {
+                // deliver 已确认没有持久化 assistant，并回滚了本次 prompt，才会进入这里；
+                // 因此可以在全局退避后做有限次幂等重试，避免日程提醒永久丢失。
+                intent.delivery_attempts = intent.delivery_attempts.saturating_add(1);
+                let should_retry = intent.delivery_attempts < MAX_SAFE_DELIVERY_ATTEMPTS
+                    && intent.triggered_at.elapsed().as_secs() <= intent.intent_type.ttl_secs();
+                let mut sys = system_arc.lock().await;
+                sys.delivery_backoff_until = Some(Instant::now() + DELIVERY_FAILURE_BACKOFF);
+                let cooled = (sys.interest_manager.trigger_threshold * 0.5)
+                    .min(sys.interest_manager.max_interest_cap);
+                sys.interest_manager.interest = cooled;
+                if should_retry {
+                    sys.stash_intent(intent);
+                }
+                Err(error.context("proactive intent delivery failed"))
             }
         }
-
-        Ok(false)
     }
 
     // ============================================================
@@ -339,121 +669,142 @@ impl ProactiveSystem {
 
     /// 执行单次主动对话检查周期。
     async fn run_cycle(system_arc: Arc<Mutex<Self>>) -> anyhow::Result<()> {
-        let mut sys = system_arc.lock().await;
+        let (config, settings, strategy, delivery, interaction_epoch) = {
+            let mut sys = system_arc.lock().await;
+            if !sys.is_running || !sys.config.enable_proactive_system {
+                return Ok(());
+            }
+            sys.interest_manager.check_daily_reset();
+            tracing::info!(
+                "[ProactiveSystem] Cycle start. Interest: {:.2}/{:.2}, count: {}/{}, can_deliver={}, pending={}",
+                sys.interest_manager.interest,
+                sys.interest_manager.max_interest_cap,
+                sys.interest_manager.proactive_times,
+                sys.interest_manager.max_proactive_count,
+                sys.can_deliver,
+                sys.pending_intents.len(),
+            );
+            (
+                sys.config.clone(),
+                sys.settings.clone(),
+                sys.strategy_dispatcher.clone(),
+                sys.delivery_context(),
+                sys.interaction_epoch,
+            )
+        };
 
-        tracing::info!(
-            "[ProactiveSystem] Cycle start. Interest: {:.2}/{:.2}, count today: {}/{}, can_deliver={}, pending={}",
-            sys.interest_manager.interest,
-            sys.interest_manager.max_interest_cap,
-            sys.interest_manager.proactive_times,
-            sys.interest_manager.max_proactive_count,
-            sys.can_deliver,
-            sys.pending_intents.len(),
-        );
-
-        // ─── 0. 优先清暂存队列 ───
-        if sys.try_flush_pending_intent().await? {
+        let settings_snap = settings.read().await.clone();
+        let (context, script_active) = Self::read_runtime_context(&delivery.ai_service).await;
+        if script_active {
             return Ok(());
         }
 
-        // ─── 1. 快照 ───
-        let settings_snap = {
-            let snap = sys.settings.read().await;
-            snap.clone()
+        let (perception, pending) = {
+            let mut sys = system_arc.lock().await;
+            let perception = sys.activity_monitor.get_user_status();
+            let pending = sys.take_deliverable_pending(&perception);
+            (perception, pending)
         };
+        if let Some(intent) = pending {
+            let _ = Self::attempt_delivery(
+                system_arc.clone(),
+                delivery.clone(),
+                strategy.clone(),
+                intent,
+            )
+            .await?;
+            return Ok(());
+        }
 
-        // ─── 2. 感知（提前到这里，供 Alarm 的 evaluate 使用）───
-        let perception = sys.activity_monitor.get_user_status();
-
-        // ─── 3. 日程警报（跳过兴趣累积，但走 evaluate 闸门）───
-        if sys.config.enable_schedule_reminder {
-            let user_name = {
-                let svc = sys.ai_service.lock().await;
-                let gs = svc.game_status.lock().await;
-                gs.player.user_name.clone()
+        // 日程 prompt 生成很便宜，可以直接进入统一投递/暂存流程。
+        if config.enable_schedule_reminder {
+            let alarm = {
+                let mut sys = system_arc.lock().await;
+                sys.schedule_manager
+                    .check_schedule_reminder(&context.user_name, &settings_snap)
             };
-            if let Some(raw_prompt) = sys
-                .schedule_manager
-                .check_schedule_reminder(&user_name, &settings_snap)
-            {
-                let formatted = PromptRole::System.build_prompt(&raw_prompt);
-                if DeliveryEvaluator::can_deliver(IntentType::Alarm, &perception, sys.can_deliver) {
-                    tracing::info!("[ProactiveSystem] Alarm triggered, evaluate passed, delivering");
-                    sys.deliver(formatted).await?;
-                } else {
-                    tracing::info!("[ProactiveSystem] Alarm triggered, evaluate failed, stashing");
-                    sys.pending_intents.push(PendingIntent {
-                        prompt: formatted,
-                        intent_type: IntentType::Alarm,
-                        triggered_at: std::time::Instant::now(),
-                    });
-                }
+            if let Some(raw_prompt) = alarm {
+                let intent = PendingIntent::new(
+                    PromptRole::System.build_prompt(&raw_prompt),
+                    None,
+                    IntentType::Alarm,
+                    interaction_epoch,
+                );
+                let _ = Self::attempt_delivery(
+                    system_arc.clone(),
+                    delivery.clone(),
+                    strategy.clone(),
+                    intent,
+                )
+                .await?;
                 return Ok(());
             }
         }
 
-        // ─── 4. 兴趣累积 ───
-        sys.interest_manager.update_interest();
-        sys.interest_manager
-            .set_status_mod(perception.interest_modifier);
-
-        // ─── 5. 触发检查 ───
-        if !sys.interest_manager.should_trigger_talk() {
+        if system_arc
+            .lock()
+            .await
+            .delivery_backoff_until
+            .is_some_and(|until| Instant::now() < until)
+        {
+            tracing::debug!("[ProactiveSystem] Delivery failure backoff active; skipping strategy");
             return Ok(());
         }
 
-        tracing::info!(
-            "[ProactiveSystem] Trigger fired! Interest={:.2}",
-            sys.interest_manager.interest
+        let (triggered, can_deliver, screen_eligible) = {
+            let mut sys = system_arc.lock().await;
+            let visual_pending =
+                config.enable_visual_perception && sys.visual_monitor.check_visual_change();
+            let modifier = perception
+                .interest_modifier
+                .saturating_add(if visual_pending { 20 } else { 0 });
+            sys.interest_manager.update_interest(modifier);
+            let triggered = sys.interest_manager.should_trigger_talk();
+            let can_deliver = sys.can_deliver;
+            let screen_eligible = visual_pending
+                && DeliveryEvaluator::can_deliver(IntentType::Screen, &perception, can_deliver);
+            (triggered, can_deliver, screen_eligible)
+        };
+
+        if !triggered || !can_deliver {
+            return Ok(());
+        }
+        // 用户回复正在生成时，不要先白跑一次 VLM。
+        if delivery.generation_lock.try_lock().is_err() {
+            return Ok(());
+        }
+
+        // 这里不持有 ProactiveSystem / AIService / GameStatus 锁；VLM 再慢也不会阻塞 UI 状态上报。
+        let outcome = strategy
+            .get_proactive_prompt(
+                &context,
+                &settings_snap,
+                &perception,
+                &config,
+                screen_eligible,
+            )
+            .await;
+
+        if outcome.screen_attempted {
+            system_arc.lock().await.visual_monitor.mark_analyzed();
+        }
+
+        let Some(candidate) = outcome.candidate else {
+            // PASS、重复或模型失败后退回阈值以下，避免十秒后立刻再次触发昂贵策略。
+            let mut sys = system_arc.lock().await;
+            let cooled = (sys.interest_manager.trigger_threshold * 0.5)
+                .min(sys.interest_manager.max_interest_cap);
+            sys.interest_manager.interest = cooled;
+            return Ok(());
+        };
+
+        let intent = PendingIntent::new(
+            PromptRole::System.build_prompt(&candidate.prompt),
+            Some(candidate.prompt),
+            candidate.intent_type,
+            interaction_epoch,
         );
-
-        // gen_lock 快检
-        if sys.generation_lock.try_lock().is_err() {
-            tracing::debug!("[ProactiveSystem] gen_lock busy, aborting this trigger");
-            return Ok(());
-        }
-
-        // ─── 生成 prompt（SCREEN 调用视觉模型可能耗时，先禁用前端输入）───
-        events::emit_thinking(&sys.app, true);
-        let prompt_result = {
-            let svc = sys.ai_service.lock().await;
-            let gs = svc.game_status.lock().await;
-            sys.strategy_dispatcher
-                .get_proactive_prompt(&gs, &settings_snap, &perception, &sys.config)
-                .await
-        };
-        let Some((raw_prompt, intent_type)) = prompt_result else {
-            events::emit_thinking(&sys.app, false);
-            return Ok(());
-        };
-
-        // 兴趣立刻消耗（"已经想说话了"）
-        sys.interest_manager.reset_interest();
-
-        // ─── 投放闸门 ───
-        if DeliveryEvaluator::can_deliver(intent_type, &perception, sys.can_deliver) {
-            tracing::info!(
-                "[ProactiveSystem] Evaluate passed for {:?}, delivering immediately",
-                intent_type
-            );
-            let formatted = PromptRole::System.build_prompt(&raw_prompt);
-            sys.deliver(formatted).await?;
-        } else {
-            let formatted = PromptRole::System.build_prompt(&raw_prompt);
-            tracing::info!(
-                "[ProactiveSystem] Evaluate failed for {:?}, stashing (queue size: {} -> {})",
-                intent_type,
-                sys.pending_intents.len(),
-                sys.pending_intents.len() + 1,
-            );
-            sys.pending_intents.push(PendingIntent {
-                prompt: formatted,
-                intent_type,
-                triggered_at: std::time::Instant::now(),
-            });
-            events::emit_thinking(&sys.app, false);
-        }
-
+        let _ = Self::attempt_delivery(system_arc, delivery, strategy, intent).await?;
         Ok(())
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/proactive_history.rs
+++ b/src-tauri/src/ai_service/proactive_system/proactive_history.rs
@@ -1,0 +1,211 @@
+//! 主动搭话历史记录与反重复检测。
+//!
+//! 记录最近 N 条主动搭话文本及其时间戳，使用归一化后的编辑距离相似度
+//! 判断新内容是否与近期内容重复。相似度超过阈值时建议跳过。
+
+use std::collections::VecDeque;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// 默认保留历史条数。
+const DEFAULT_MAX_HISTORY: usize = 10;
+/// 默认相似度阈值，超过此值视为重复。
+const DEFAULT_SIMILARITY_THRESHOLD: f64 = 0.85;
+/// 默认历史有效期（毫秒），超过此时间的历史不再参与重复检测。
+const DEFAULT_MAX_AGE_MS: u64 = 60 * 60 * 1000; // 1 小时
+
+/// 一条主动搭话历史记录。
+#[derive(Clone, Debug)]
+pub struct ProactiveHistoryEntry {
+    pub text: String,
+    pub ts_ms: u64,
+}
+
+/// 主动搭话反重复器。
+#[derive(Clone, Debug)]
+pub struct ProactiveDeduplicator {
+    max_history: usize,
+    similarity_threshold: f64,
+    max_age_ms: u64,
+    entries: VecDeque<ProactiveHistoryEntry>,
+}
+
+impl Default for ProactiveDeduplicator {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_MAX_HISTORY,
+            DEFAULT_SIMILARITY_THRESHOLD,
+            DEFAULT_MAX_AGE_MS,
+        )
+    }
+}
+
+impl ProactiveDeduplicator {
+    pub fn new(max_history: usize, similarity_threshold: f64, max_age_ms: u64) -> Self {
+        Self {
+            max_history: max_history.max(1),
+            similarity_threshold: similarity_threshold.clamp(0.0, 1.0),
+            max_age_ms,
+            entries: VecDeque::new(),
+        }
+    }
+
+    /// 把新内容加入历史。
+    pub fn record(&mut self, text: impl Into<String>) {
+        let text = text.into();
+        if text.trim().is_empty() || text.trim() == "[PASS]" {
+            return;
+        }
+        let ts_ms = now_ms();
+        self.entries
+            .push_back(ProactiveHistoryEntry { text, ts_ms });
+        self.evict(ts_ms);
+    }
+
+    /// 检查给定文本是否与近期历史重复。
+    /// 返回 `(is_duplicate, best_similarity)`。
+    pub fn is_duplicate(&self, text: &str) -> (bool, f64) {
+        if text.trim().is_empty() || text.trim() == "[PASS]" {
+            return (false, 0.0);
+        }
+
+        let now = now_ms();
+        let current = normalize(text);
+        if current.is_empty() {
+            return (false, 0.0);
+        }
+
+        let mut best = 0.0;
+        for entry in &self.entries {
+            if now.saturating_sub(entry.ts_ms) > self.max_age_ms {
+                continue;
+            }
+            let old = normalize(&entry.text);
+            if old.is_empty() {
+                continue;
+            }
+            let score = similarity_ratio(&current, &old);
+            if score > best {
+                best = score;
+            }
+            if best >= self.similarity_threshold {
+                return (true, best);
+            }
+        }
+        (false, best)
+    }
+
+    /// 如果内容不重复，记录并返回 false；如果重复，返回 true。
+    pub fn check_and_record(&mut self, text: impl Into<String>) -> (bool, f64) {
+        let text = text.into();
+        let (dup, score) = self.is_duplicate(&text);
+        if !dup {
+            self.record(text);
+        }
+        (dup, score)
+    }
+
+    fn evict(&mut self, now_ms: u64) {
+        // 先移除过期
+        while self
+            .entries
+            .front()
+            .is_some_and(|e| now_ms.saturating_sub(e.ts_ms) > self.max_age_ms)
+        {
+            self.entries.pop_front();
+        }
+        // 再限制数量
+        while self.entries.len() > self.max_history {
+            self.entries.pop_front();
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_millis() as u64
+}
+
+/// 归一化文本：小写、去标点、压缩空白、截断。
+fn normalize(text: &str) -> String {
+    let mut normalized = String::new();
+    let mut previous_space = false;
+    for ch in text.trim().to_lowercase().chars() {
+        if ch.is_whitespace() {
+            if !previous_space && !normalized.is_empty() {
+                normalized.push(' ');
+                previous_space = true;
+            }
+            continue;
+        }
+        if ch.is_ascii_punctuation() {
+            continue;
+        }
+        normalized.push(ch);
+        previous_space = false;
+    }
+    normalized.trim().chars().take(512).collect()
+}
+
+/// 编辑距离相似度：1 - distance / max_len，范围 [0, 1]。
+fn similarity_ratio(left: &str, right: &str) -> f64 {
+    if left == right {
+        return 1.0;
+    }
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+
+    let left_chars: Vec<char> = left.chars().collect();
+    let right_chars: Vec<char> = right.chars().collect();
+
+    let mut previous: Vec<usize> = (0..=right_chars.len()).collect();
+    let mut current = vec![0; right_chars.len() + 1];
+
+    for (i, left_ch) in left_chars.iter().enumerate() {
+        current[0] = i + 1;
+        for (j, right_ch) in right_chars.iter().enumerate() {
+            let cost = usize::from(left_ch != right_ch);
+            current[j + 1] = (previous[j + 1] + 1)
+                .min(current[j] + 1)
+                .min(previous[j] + cost);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    let distance = previous[right_chars.len()] as f64;
+    let max_len = left_chars.len().max(right_chars.len()) as f64;
+    (1.0 - distance / max_len).clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exact_duplicate() {
+        let mut dedup = ProactiveDeduplicator::default();
+        assert!(!dedup.check_and_record("你好呀").0);
+        assert!(dedup.check_and_record("你好呀").0);
+    }
+
+    #[test]
+    fn test_similar_but_not_duplicate() {
+        let mut dedup = ProactiveDeduplicator::new(10, 0.85, 60 * 60 * 1000);
+        assert!(!dedup.check_and_record("今天天气不错").0);
+        assert!(!dedup.check_and_record("今天天气很好").0);
+    }
+
+    #[test]
+    fn test_pass_is_ignored() {
+        let mut dedup = ProactiveDeduplicator::default();
+        dedup.record("[PASS]");
+        assert_eq!(dedup.len(), 0);
+        assert!(!dedup.is_duplicate("[PASS]").0);
+    }
+}

--- a/src-tauri/src/ai_service/proactive_system/schedule_manager.rs
+++ b/src-tauri/src/ai_service/proactive_system/schedule_manager.rs
@@ -1,14 +1,17 @@
 use crate::ai_service::proactive_system::types::UserScheduleSettings;
 use chrono::Local;
+use std::collections::HashSet;
 
 pub struct ScheduleManager {
-    last_triggered_key: String,
+    triggered_date: String,
+    triggered_keys: HashSet<String>,
 }
 
 impl ScheduleManager {
     pub fn new() -> Self {
         Self {
-            last_triggered_key: String::new(),
+            triggered_date: String::new(),
+            triggered_keys: HashSet::new(),
         }
     }
 
@@ -17,18 +20,33 @@ impl ScheduleManager {
         user_name: &str,
         settings: &UserScheduleSettings,
     ) -> Option<String> {
-        let schedule_groups = settings.schedule_groups.as_ref()?;
-
         let now = Local::now();
+        let current_date_str = now.format("%Y-%m-%d").to_string();
         let current_time_str = now.format("%H:%M").to_string();
 
-        for group in schedule_groups.values() {
-            for item in &group.items {
-                if item.time == current_time_str {
-                    let trigger_key = format!("{}_{}", item.time, item.name);
-                    if trigger_key != self.last_triggered_key {
-                        self.last_triggered_key = trigger_key;
+        self.check_schedule_reminder_at(user_name, settings, &current_date_str, &current_time_str)
+    }
 
+    fn check_schedule_reminder_at(
+        &mut self,
+        user_name: &str,
+        settings: &UserScheduleSettings,
+        current_date: &str,
+        current_time: &str,
+    ) -> Option<String> {
+        let schedule_groups = settings.schedule_groups.as_ref()?;
+
+        if self.triggered_date != current_date {
+            self.triggered_date.clear();
+            self.triggered_date.push_str(current_date);
+            self.triggered_keys.clear();
+        }
+
+        for (group_id, group) in schedule_groups {
+            for (item_index, item) in group.items.iter().enumerate() {
+                if item.time == current_time {
+                    let trigger_key = format!("{group_id}:{item_index}:{}", item.time);
+                    if self.triggered_keys.insert(trigger_key) {
                         tracing::info!(
                             "[ScheduleManager] Triggered alarm for schedule: {}",
                             item.name
@@ -43,5 +61,77 @@ impl ScheduleManager {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai_service::proactive_system::types::{ScheduleGroup, ScheduleItem};
+    use std::collections::HashMap;
+
+    fn settings_with_two_due_items() -> UserScheduleSettings {
+        UserScheduleSettings {
+            schedule_groups: Some(HashMap::from([
+                (
+                    "work".to_string(),
+                    ScheduleGroup {
+                        title: "工作".to_string(),
+                        items: vec![ScheduleItem {
+                            name: "开会".to_string(),
+                            time: "09:30".to_string(),
+                            content: "周会".to_string(),
+                        }],
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "health".to_string(),
+                    ScheduleGroup {
+                        title: "健康".to_string(),
+                        items: vec![ScheduleItem {
+                            name: "喝水".to_string(),
+                            time: "09:30".to_string(),
+                            content: "补充水分".to_string(),
+                        }],
+                        ..Default::default()
+                    },
+                ),
+            ])),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn each_due_item_only_triggers_once_per_day() {
+        let settings = settings_with_two_due_items();
+        let mut manager = ScheduleManager::new();
+
+        let first = manager
+            .check_schedule_reminder_at("测试用户", &settings, "2026-07-10", "09:30")
+            .expect("first reminder should trigger");
+        let second = manager
+            .check_schedule_reminder_at("测试用户", &settings, "2026-07-10", "09:30")
+            .expect("second reminder should trigger");
+
+        assert_ne!(first, second);
+        assert!(first.contains("开会") || first.contains("喝水"));
+        assert!(second.contains("开会") || second.contains("喝水"));
+        assert!(manager
+            .check_schedule_reminder_at("测试用户", &settings, "2026-07-10", "09:30")
+            .is_none());
+    }
+
+    #[test]
+    fn reminders_reset_on_the_next_day() {
+        let settings = settings_with_two_due_items();
+        let mut manager = ScheduleManager::new();
+
+        assert!(manager
+            .check_schedule_reminder_at("测试用户", &settings, "2026-07-10", "09:30")
+            .is_some());
+        assert!(manager
+            .check_schedule_reminder_at("测试用户", &settings, "2026-07-11", "09:30")
+            .is_some());
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
+++ b/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
@@ -19,6 +19,7 @@ impl StrategyDispatcher {
             vd_api_key: config.vd_api_key.clone(),
             vd_base_url: config.vd_base_url.clone(),
             vd_model: config.vd_model.clone(),
+            provider: "openai".to_string(),
         };
         Self {
             screen_analyzer: Mutex::new(ScreenAnalyzer::new(sa_config)),
@@ -34,6 +35,7 @@ impl StrategyDispatcher {
                 vd_api_key: config.vd_api_key,
                 vd_base_url: config.vd_base_url,
                 vd_model: config.vd_model,
+                provider: "openai".to_string(),
             });
         }
     }
@@ -217,7 +219,7 @@ impl StrategyDispatcher {
             .screen_analyzer
             .lock()
             .await
-            .analyze_screen(analyze_prompt)
+            .analyze_screen(analyze_prompt, None)
             .await?;
 
         let user_name = &game_status.player.user_name;

--- a/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
+++ b/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
@@ -1,42 +1,92 @@
-use crate::ai_service::game_system::game_status::GameStatus;
 use crate::ai_service::proactive_system::config::ProactiveConfig;
+use crate::ai_service::proactive_system::proactive_history::ProactiveDeduplicator;
 use crate::ai_service::proactive_system::types::{
-    IntentType, PerceptionResult, UserScheduleSettings, UserState,
+    DispatchOutcome, IntentType, PerceptionResult, ProactiveCandidate, ProactiveContext,
+    UserScheduleSettings, UserState,
 };
-use crate::ai_service::screen_analyzer::{ScreenAnalyzer, ScreenAnalyzerConfig};
+use crate::ai_service::screen_analyzer::{
+    build_screen_analyzer_config, ScreenAnalyzer, ScreenContext,
+};
 use chrono::Local;
 use rand::Rng;
+use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
+
+const SCREEN_ATTEMPT_COOLDOWN: Duration = Duration::from_secs(60);
 
 pub struct StrategyDispatcher {
     screen_analyzer: Mutex<ScreenAnalyzer>,
+    deduplicator: Mutex<ProactiveDeduplicator>,
+    last_screen_attempt: Mutex<Option<Instant>>,
+    last_important_day_date: Mutex<Option<String>>,
 }
 
 impl StrategyDispatcher {
     pub fn new(app_handle: &tauri::AppHandle) -> Self {
         let config = ProactiveConfig::load(app_handle);
-        let sa_config = ScreenAnalyzerConfig {
-            vd_api_key: config.vd_api_key.clone(),
-            vd_base_url: config.vd_base_url.clone(),
-            vd_model: config.vd_model.clone(),
-            provider: "openai".to_string(),
-        };
+        let sa_config = build_screen_analyzer_config(app_handle, &config);
         Self {
             screen_analyzer: Mutex::new(ScreenAnalyzer::new(sa_config)),
+            deduplicator: Mutex::new(ProactiveDeduplicator::default()),
+            last_screen_attempt: Mutex::new(None),
+            last_important_day_date: Mutex::new(None),
         }
     }
 
-    /// 更新配置（同时同步 ScreenAnalyzer 的配置，同步执行无需 async）。
-    pub fn update_config(&self, app_handle: &tauri::AppHandle) {
+    /// 更新配置，同时可靠地同步 ScreenAnalyzer。不能因视觉请求正在占锁而静默丢失更新。
+    pub async fn update_config(&self, app_handle: &tauri::AppHandle) {
         let config = ProactiveConfig::load(app_handle);
-        // try_lock: update_config 不涉及 async，用同步锁即可
-        if let Ok(mut sa) = self.screen_analyzer.try_lock() {
-            sa.update_config(ScreenAnalyzerConfig {
-                vd_api_key: config.vd_api_key,
-                vd_base_url: config.vd_base_url,
-                vd_model: config.vd_model,
-                provider: "openai".to_string(),
-            });
+        self.screen_analyzer
+            .lock()
+            .await
+            .update_config(build_screen_analyzer_config(app_handle, &config));
+    }
+
+    async fn is_duplicate(&self, prompt: &str) -> bool {
+        let dedup = self.deduplicator.lock().await;
+        let (dup, score) = dedup.is_duplicate(prompt);
+        if dup {
+            tracing::info!(
+                "[StrategyDispatcher] Duplicate proactive prompt detected (score={:.2}), skipping.",
+                score
+            );
+            true
+        } else {
+            false
+        }
+    }
+
+    /// 只有真正生成出非空回复并成功投递后才提交去重历史。
+    pub async fn record_delivered(&self, prompt: &str, intent_type: IntentType) {
+        self.deduplicator.lock().await.record(prompt.to_string());
+        if intent_type == IntentType::ImportantDay {
+            *self.last_important_day_date.lock().await =
+                Some(Local::now().format("%Y-%m-%d").to_string());
+        }
+    }
+
+    async fn reserve_screen_attempt(&self) -> bool {
+        let mut last = self.last_screen_attempt.lock().await;
+        let now = Instant::now();
+        if last.is_some_and(|at| now.duration_since(at) < SCREEN_ATTEMPT_COOLDOWN) {
+            return false;
+        }
+        *last = Some(now);
+        true
+    }
+
+    async fn candidate_if_new(
+        &self,
+        prompt: String,
+        intent_type: IntentType,
+    ) -> Option<ProactiveCandidate> {
+        if self.is_duplicate(&prompt).await {
+            None
+        } else {
+            Some(ProactiveCandidate {
+                prompt,
+                intent_type,
+            })
         }
     }
 
@@ -44,47 +94,64 @@ impl StrategyDispatcher {
     /// 优先顺序: ImportantDay (每天仅一次) > Todo > Screen Observation > Topic
     pub async fn get_proactive_prompt(
         &self,
-        game_status: &GameStatus,
+        context: &ProactiveContext,
         settings: &UserScheduleSettings,
         perception: &PerceptionResult,
         config: &ProactiveConfig,
-    ) -> Option<(String, IntentType)> {
+        screen_eligible: bool,
+    ) -> DispatchOutcome {
+        let mut outcome = DispatchOutcome::default();
         let now = Local::now();
         let today_str = now.format("%m-%d").to_string();
+        let today_full = now.format("%Y-%m-%d").to_string();
 
-        // 1. 检查 ImportantDay (如果是今天且今天未触发过)
-        if config.enable_important_day_reminder {
+        // 1. 检查 ImportantDay。重复候选只跳过本策略，不能阻断后续策略。
+        let important_day_already_delivered =
+            self.last_important_day_date.lock().await.as_deref() == Some(today_full.as_str());
+        if config.enable_important_day_reminder && !important_day_already_delivered {
             if let Some(important_days) = &settings.important_days {
-                let last_talk_date = game_status
-                    .last_dialog_time
-                    .map(|dt| dt.format("%m-%d").to_string())
-                    .unwrap_or_default();
-
-                if last_talk_date != today_str {
-                    for day in important_days {
-                        if day.date.ends_with(&today_str) {
-                            let desc = day.desc.as_deref().unwrap_or("");
-                            let char_name = game_status
-                                .current_role_id
-                                .and_then(|rid| game_status.role_manager.get_loaded(rid))
-                                .and_then(|role| role.display_name.clone())
-                                .unwrap_or_else(|| "小灵".to_string());
-
+                for day in important_days {
+                    if day.date.ends_with(&today_str) {
+                        let desc = day.desc.as_deref().unwrap_or("");
+                        let prompt = format!(
+                            "{{今天是特殊的一天：{}，{}。可以和{}聊聊哦}}",
+                            day.title, desc, context.ai_name
+                        );
+                        if let Some(candidate) = self
+                            .candidate_if_new(prompt, IntentType::ImportantDay)
+                            .await
+                        {
                             tracing::info!(
                                 "[StrategyDispatcher] Triggered important day reminder: {}",
                                 day.title
                             );
-                            return Some((
-                                format!(
-                                    "{{今天是特殊的一天：{}，{}。可以和{}聊聊哦}}",
-                                    day.title, desc, char_name
-                                ),
-                                IntentType::ImportantDay,
-                            ));
+                            outcome.candidate = Some(candidate);
+                            return outcome;
                         }
                     }
                 }
             }
+        }
+
+        // 如果开启视觉理解优先模式，优先尝试 SCREEN，失败再按原逻辑随机
+        if config.enable_visual_perception
+            && config.visual_perception_priority
+            && screen_eligible
+            && self.reserve_screen_attempt().await
+        {
+            tracing::info!(
+                "[StrategyDispatcher] Visual perception priority enabled, trying SCREEN first."
+            );
+            outcome.screen_attempted = true;
+            if let Some((prompt, intent)) = self.get_screen_prompt(context).await {
+                if let Some(candidate) = self.candidate_if_new(prompt, intent).await {
+                    outcome.candidate = Some(candidate);
+                    return outcome;
+                }
+            }
+            tracing::info!(
+                "[StrategyDispatcher] SCREEN priority failed, falling back to weighted random."
+            );
         }
 
         // 2. 随机模式选择，根据启用状态动态构建候选列表
@@ -92,53 +159,59 @@ impl StrategyDispatcher {
         let mut weights = Vec::new();
 
         // 获取权重（如果配置文件有设置，否则基于 UserState 动态决定）
-        let mut todo_w = config.todo_weight;
-        let mut topic_w = config.topic_weight;
-        let mut screen_w = config.screen_weight;
+        let todo_default = if perception.state == UserState::WORK {
+            60.0
+        } else {
+            10.0
+        };
+        let topic_default = if perception.state == UserState::IDLE {
+            80.0
+        } else {
+            60.0
+        };
+        let screen_default = if perception.state == UserState::GAME {
+            60.0
+        } else {
+            30.0
+        };
+        let todo_w = normalized_weight(config.todo_weight, todo_default);
+        let topic_w = normalized_weight(config.topic_weight, topic_default);
+        // 有尚未消费的画面变化时提高 SCREEN 权重，但仍保留其他策略的机会。
+        let screen_w = normalized_weight(config.screen_weight, screen_default)
+            * if screen_eligible { 2.0 } else { 1.0 };
 
-        if todo_w <= 0.0 {
-            todo_w = if perception.state == UserState::WORK {
-                60.0
-            } else {
-                10.0
-            };
-        }
-        if topic_w <= 0.0 {
-            topic_w = if perception.state == UserState::IDLE {
-                80.0
-            } else {
-                60.0
-            };
-        }
-        if screen_w <= 0.0 {
-            screen_w = if perception.state == UserState::GAME {
-                60.0
-            } else {
-                30.0
-            };
-        }
-
-        if config.enable_todo_perception {
+        if config.enable_todo_perception && todo_w > 0.0 {
             modes.push("TODO");
             weights.push(todo_w);
         }
-        if config.enable_topic_creator {
+        if config.enable_topic_creator && topic_w > 0.0 {
             modes.push("TOPIC");
             weights.push(topic_w);
         }
-        if config.enable_visual_perception {
+        // priority 已经尝试过 SCREEN 时，本轮不能再次把 SCREEN 放回随机池。
+        if config.enable_visual_perception
+            && screen_eligible
+            && !outcome.screen_attempted
+            && screen_w > 0.0
+        {
             modes.push("SCREEN");
             weights.push(screen_w);
         }
 
         if modes.is_empty() {
-            return None;
+            return outcome;
         }
 
         // 轮盘赌/加权随机选择
         let selected_mode = {
             let mut rng = rand::thread_rng();
             let total_weight: f64 = weights.iter().sum();
+            if !total_weight.is_finite() || total_weight <= 0.0 {
+                tracing::warn!(
+                    "[StrategyDispatcher] Invalid total strategy weight: {total_weight}"
+                );
+                return outcome;
+            }
             let mut roll = rng.gen_range(0.0..total_weight);
             let mut selected = modes[0];
             for (i, &w) in weights.iter().enumerate() {
@@ -158,32 +231,47 @@ impl StrategyDispatcher {
 
         match selected_mode {
             "TODO" => {
-                if let Some(prompt) = self.get_todo_prompt(game_status, settings) {
-                    return Some((prompt, IntentType::Todo));
+                if let Some(prompt) = self.get_todo_prompt(context, settings) {
+                    if let Some(candidate) = self.candidate_if_new(prompt, IntentType::Todo).await {
+                        outcome.candidate = Some(candidate);
+                        return outcome;
+                    }
                 }
-                // 没有 Todo 时降级到 TOPIC
+                // 没有 Todo 或候选重复时降级到 TOPIC。
                 if config.enable_topic_creator {
-                    return Some((self.get_topic_prompt(game_status), IntentType::Topic));
+                    let prompt = self.get_topic_prompt(context);
+                    outcome.candidate = self.candidate_if_new(prompt, IntentType::Topic).await;
                 }
-                None
+                outcome
             }
             "SCREEN" => {
-                if let Some(prompt) = self.get_screen_prompt(game_status).await {
-                    return Some((prompt, IntentType::Screen));
+                if self.reserve_screen_attempt().await {
+                    outcome.screen_attempted = true;
+                    if let Some((prompt, intent)) = self.get_screen_prompt(context).await {
+                        if let Some(candidate) = self.candidate_if_new(prompt, intent).await {
+                            outcome.candidate = Some(candidate);
+                            return outcome;
+                        }
+                    }
                 }
-                // SCREEN 抓取失败或接口失败时降级到 TOPIC
+                // SCREEN 抓取失败、PASS、重复或仍在冷却时降级到 TOPIC。
                 if config.enable_topic_creator {
-                    return Some((self.get_topic_prompt(game_status), IntentType::Topic));
+                    let prompt = self.get_topic_prompt(context);
+                    outcome.candidate = self.candidate_if_new(prompt, IntentType::Topic).await;
                 }
-                None
+                outcome
             }
-            _ => Some((self.get_topic_prompt(game_status), IntentType::Topic)),
+            _ => {
+                let prompt = self.get_topic_prompt(context);
+                outcome.candidate = self.candidate_if_new(prompt, IntentType::Topic).await;
+                outcome
+            }
         }
     }
 
     fn get_todo_prompt(
         &self,
-        game_status: &GameStatus,
+        context: &ProactiveContext,
         settings: &UserScheduleSettings,
     ) -> Option<String> {
         let todo_groups = settings.todo_groups.as_ref()?;
@@ -204,44 +292,128 @@ impl StrategyDispatcher {
         let mut rng = rand::thread_rng();
         let idx = rng.gen_range(0..candidates.len());
         let selected = candidates[idx];
-        let user_name = &game_status.player.user_name;
-
         Some(format!(
             "{{你想起来{}有一个未完成的任务：'{} '。提醒一下吧？}}",
-            user_name, selected.text
+            context.user_name, selected.text
         ))
     }
 
-    async fn get_screen_prompt(&self, game_status: &GameStatus) -> Option<String> {
-        let analyze_prompt = "你是一个图像信息转述者，你将需要把你看到的画面描述给另一个AI让他理解用户的图片内容。用户开放了那个AI的自主窥屏功能，请获取桌面画面中的重点内容，用200字描述主体部分即可。如果你看到一个聊天窗口，有角色的立绘和对话框，不要描述这部分，只描述桌面上的其他内容。因为那部分是玩家与AI的聊天窗口。";
+    pub(crate) async fn get_screen_prompt_for_test(
+        &self,
+        proactive_context: &ProactiveContext,
+    ) -> Option<(String, IntentType)> {
+        let screen_context = ScreenContext {
+            ai_name: Some(proactive_context.ai_name.clone()),
+            user_name: Some(proactive_context.user_name.clone()),
+            recent_chat_summary: None,
+        };
 
-        let analysis = self
+        // 测试专用：强制评论屏幕，不允许 [PASS]。
+        let test_prompt = "你刚刚看了一眼主人的电脑屏幕。请用一句简短自然的话（不超过30字）评论屏幕上最有趣或最新的内容，像不经意间看到的那样。不要解释，直接说出这句话。";
+
+        let reply = self
             .screen_analyzer
             .lock()
             .await
-            .analyze_screen(analyze_prompt, None)
+            .analyze_screen(test_prompt, Some(&screen_context))
             .await?;
 
-        let user_name = &game_status.player.user_name;
-        let ai_name = game_status
-            .current_role_id
-            .and_then(|rid| game_status.role_manager.get_loaded(rid))
-            .and_then(|role| role.display_name.clone())
-            .unwrap_or_else(|| "你".to_string());
+        let cleaned = clean_screen_reply(&reply)?;
 
-        Some(format!(
-            "{{ {} 偷看了一眼 {} 的电脑桌面: {} }}",
-            ai_name, user_name, analysis
-        ))
+        Some((format!("{{ {}}}", cleaned), IntentType::Screen))
     }
 
-    fn get_topic_prompt(&self, game_status: &GameStatus) -> String {
-        let ai_name = game_status
-            .current_role_id
-            .and_then(|rid| game_status.role_manager.get_loaded(rid))
-            .and_then(|role| role.display_name.clone())
-            .unwrap_or_else(|| "你".to_string());
+    pub(crate) async fn get_screen_prompt(
+        &self,
+        proactive_context: &ProactiveContext,
+    ) -> Option<(String, IntentType)> {
+        let screen_context = ScreenContext {
+            ai_name: Some(proactive_context.ai_name.clone()),
+            user_name: Some(proactive_context.user_name.clone()),
+            recent_chat_summary: None,
+        };
 
-        format!("{{ {} 想继续说话了}}", ai_name)
+        let reply = self
+            .screen_analyzer
+            .lock()
+            .await
+            .analyze_screen_for_proactive(Some(&screen_context))
+            .await?;
+
+        let Some(cleaned) = clean_screen_reply(&reply) else {
+            tracing::info!("[StrategyDispatcher] Screen proactive returned [PASS], falling back.");
+            return None;
+        };
+
+        Some((format!("{{ {}}}", cleaned), IntentType::Screen))
+    }
+
+    fn get_topic_prompt(&self, context: &ProactiveContext) -> String {
+        // 加入随机变体，避免 deduplicator 把每次 TOPIC 都判为重复
+        let templates = [
+            format!("{{ {} 想找主人说说话}}", context.ai_name),
+            format!("{{ {} 突然想到一件事}}", context.ai_name),
+            format!("{{ {} 有话想对主人说}}", context.ai_name),
+            format!("{{ {} 想继续陪主人聊天}}", context.ai_name),
+            format!("{{ {} 看着主人，忍不住想开口}}", context.ai_name),
+        ];
+
+        let mut rng = rand::thread_rng();
+        let idx = rng.gen_range(0..templates.len());
+        templates[idx].clone()
+    }
+}
+
+fn normalized_weight(configured: f64, fallback: f64) -> f64 {
+    if configured.is_finite() && configured >= 0.0 {
+        configured
+    } else if fallback.is_finite() && fallback >= 0.0 {
+        fallback
+    } else {
+        0.0
+    }
+}
+
+fn clean_screen_reply(reply: &str) -> Option<String> {
+    let mut cleaned = reply.trim().trim_matches(['"', '\'', '“', '”']).trim();
+    for prefix in ["AI:", "Ai:", "ai:", "AI：", "Ai：", "ai："] {
+        if let Some(rest) = cleaned.strip_prefix(prefix) {
+            cleaned = rest.trim();
+            break;
+        }
+    }
+    cleaned = cleaned.trim_matches(['"', '\'', '“', '”']).trim();
+    if cleaned.is_empty() || cleaned.to_ascii_uppercase().starts_with("[PASS]") {
+        None
+    } else {
+        Some(cleaned.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_weights_fall_back_to_positive_values() {
+        assert_eq!(normalized_weight(f64::NAN, 30.0), 30.0);
+        assert_eq!(normalized_weight(f64::INFINITY, 30.0), 30.0);
+        assert_eq!(normalized_weight(-10.0, 30.0), 30.0);
+        assert_eq!(normalized_weight(0.0, 30.0), 0.0);
+        assert_eq!(normalized_weight(f64::NAN, 0.0), 0.0);
+    }
+
+    #[test]
+    fn pass_variants_are_never_delivered() {
+        assert!(clean_screen_reply("[PASS]").is_none());
+        assert!(clean_screen_reply(" [pass]：画面没有变化").is_none());
+        assert!(clean_screen_reply("[PASS].").is_none());
+        assert!(clean_screen_reply("\"[PASS]\"").is_none());
+        assert!(clean_screen_reply("AI: [PASS]").is_none());
+        assert!(clean_screen_reply("“AI： [PASS]”").is_none());
+        assert_eq!(
+            clean_screen_reply("AI：挺有意思的").as_deref(),
+            Some("挺有意思的")
+        );
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/types.rs
+++ b/src-tauri/src/ai_service/proactive_system/types.rs
@@ -33,6 +33,15 @@ pub struct PerceptionResult {
     pub current_screen_text: String,
 }
 
+/// 主动对话调度所需的最小只读上下文。
+///
+/// 这里刻意不持有 `GameStatus` 的锁，避免屏幕分析的网络请求阻塞正常聊天。
+#[derive(Clone, Debug, Default)]
+pub struct ProactiveContext {
+    pub user_name: String,
+    pub ai_name: String,
+}
+
 // ==========================================
 // 日程与待办配置结构 (schedules.json 映射)
 // ==========================================
@@ -124,7 +133,46 @@ impl IntentType {
 pub struct PendingIntent {
     /// 已格式化的系统旁白（PromptRole::System.build_prompt 的结果）
     pub prompt: String,
+    /// 去重使用的原始提示词。只有真正投递成功后才写入主动对话历史。
+    pub raw_prompt: Option<String>,
     pub intent_type: IntentType,
+    /// 创建策略时的用户交互代次；用于丢弃用户发言前启动的过期屏幕/闲聊结果。
+    pub interaction_epoch: u64,
+    /// 已进入生成阶段但未产出任何持久化回复的次数。
+    pub delivery_attempts: u8,
     /// 生成时间，用于 TTL 过期判断
     pub triggered_at: Instant,
+}
+
+impl PendingIntent {
+    pub fn new(
+        prompt: String,
+        raw_prompt: Option<String>,
+        intent_type: IntentType,
+        interaction_epoch: u64,
+    ) -> Self {
+        let now = Instant::now();
+        Self {
+            prompt,
+            raw_prompt,
+            intent_type,
+            interaction_epoch,
+            delivery_attempts: 0,
+            triggered_at: now,
+        }
+    }
+}
+
+/// 调度器生成的候选意图。prompt 仍是未经过 PromptRole 包装的原始文本。
+#[derive(Clone, Debug)]
+pub struct ProactiveCandidate {
+    pub prompt: String,
+    pub intent_type: IntentType,
+}
+
+/// 一轮策略选择的结果，同时告诉主循环本轮是否真的调用过视觉模型。
+#[derive(Clone, Debug, Default)]
+pub struct DispatchOutcome {
+    pub candidate: Option<ProactiveCandidate>,
+    pub screen_attempted: bool,
 }

--- a/src-tauri/src/ai_service/proactive_system/visual_monitor.rs
+++ b/src-tauri/src/ai_service/proactive_system/visual_monitor.rs
@@ -5,11 +5,15 @@ use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_
 
 pub struct VisualMonitor {
     last_hash: Option<u64>,
+    pending_change: bool,
 }
 
 impl VisualMonitor {
     pub fn new() -> Self {
-        Self { last_hash: None }
+        Self {
+            last_hash: None,
+            pending_change: false,
+        }
     }
 
     /// 执行快速的 GDI 像素网格采样并检测画面是否变化。
@@ -72,15 +76,19 @@ impl VisualMonitor {
                     // Hamming distance >= 6 means change detected (threshold matching Python dhash difference)
                     let change_detected = diff >= 6;
                     if change_detected {
+                        self.pending_change = true;
                         tracing::info!(
                             "[VisualMonitor] Screen change detected! Hamming distance: {}",
                             diff
                         );
                     }
-                    change_detected
+                    self.pending_change
                 } else {
                     self.last_hash = Some(hash);
-                    false
+                    // 首次采样也需要分析一次，否则用户在启动后画面不变化时永远不会进入视觉路径。
+                    self.pending_change = true;
+                    tracing::debug!("[VisualMonitor] Initial screen sample marked for analysis");
+                    true
                 }
             }
         }
@@ -89,5 +97,10 @@ impl VisualMonitor {
         {
             false
         }
+    }
+
+    /// 视觉模型已经消费了当前变化，清除待分析标记。
+    pub fn mark_analyzed(&mut self) {
+        self.pending_change = false;
     }
 }

--- a/src-tauri/src/ai_service/screen_analyzer.rs
+++ b/src-tauri/src/ai_service/screen_analyzer.rs
@@ -7,12 +7,16 @@ use reqwest::Client;
 use serde_json::Value;
 use std::time::Instant;
 
+use crate::ai_service::llm::provider_config::resolve_chat_provider;
+use crate::config::proactive::ProactiveConfig;
+
 /// 屏幕分析器的配置（从环境/Store 加载）。
 #[derive(Clone, Debug)]
 pub struct ScreenAnalyzerConfig {
     pub vd_api_key: String,
     pub vd_base_url: String,
     pub vd_model: String,
+    pub provider: String,
 }
 
 impl Default for ScreenAnalyzerConfig {
@@ -20,9 +24,18 @@ impl Default for ScreenAnalyzerConfig {
         Self {
             vd_api_key: String::new(),
             vd_base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1".to_string(),
-            vd_model: "qwen3.5-plus".to_string(),
+            vd_model: "qwen3-vl-flash".to_string(),
+            provider: "openai".to_string(),
         }
     }
+}
+
+/// Shared context passed by proactive and manual screen-analysis callers.
+#[derive(Clone, Debug, Default)]
+pub struct ScreenContext {
+    pub ai_name: Option<String>,
+    pub user_name: Option<String>,
+    pub recent_chat_summary: Option<String>,
 }
 
 /// 最后一次分析的性能与用量报告。
@@ -58,9 +71,24 @@ impl ScreenAnalyzer {
         &self.last_report
     }
 
+    /// Proactive entry point kept in the shared contract so engine and visual
+    /// implementation PRs can be reviewed independently.
+    pub async fn analyze_screen_for_proactive(
+        &mut self,
+        context: Option<&ScreenContext>,
+    ) -> Option<String> {
+        let prompt = "你刚刚看了一眼主人的电脑屏幕。若有值得自然搭话的内容，请直接回复一句不超过50字的话；否则只回复[PASS]。";
+        self.analyze_screen(prompt, context).await
+    }
+
     /// 核心方法：截屏 → 发送给 VLM 分析 → 返回文本描述。
-    /// 这是策略分发器和主动对话系统的主要入口。
-    pub async fn analyze_screen(&mut self, prompt: &str) -> Option<String> {
+    /// `context` is part of the stable cross-PR API; the visual implementation
+    /// PR enriches the prompt with it.
+    pub async fn analyze_screen(
+        &mut self,
+        prompt: &str,
+        _context: Option<&ScreenContext>,
+    ) -> Option<String> {
         let api_key = &self.config.vd_api_key;
         if api_key.is_empty() {
             tracing::warn!("[ScreenAnalyzer] VD_API_KEY is empty, skipping screenshot analysis.");
@@ -193,6 +221,31 @@ impl ScreenAnalyzer {
         };
 
         None
+    }
+}
+
+/// Resolve the visual model once for every caller. The visual implementation
+/// PR extends protocol handling without changing this shared API.
+pub fn build_screen_analyzer_config(
+    app_handle: &tauri::AppHandle,
+    config: &ProactiveConfig,
+) -> ScreenAnalyzerConfig {
+    if config.vd_follow_chat_model {
+        if let Some(provider) = resolve_chat_provider(app_handle) {
+            return ScreenAnalyzerConfig {
+                vd_api_key: provider.api_key,
+                vd_base_url: provider.base_url,
+                vd_model: provider.model,
+                provider: provider.provider,
+            };
+        }
+    }
+
+    ScreenAnalyzerConfig {
+        vd_api_key: config.vd_api_key.clone(),
+        vd_base_url: config.vd_base_url.clone(),
+        vd_model: config.vd_model.clone(),
+        provider: "openai".to_string(),
     }
 }
 

--- a/src-tauri/src/api/adventure.rs
+++ b/src-tauri/src/api/adventure.rs
@@ -194,12 +194,16 @@ pub async fn start_adventure(app: AppHandle, adventure_folder: String) -> Result
         let is_running = service.script_manager.is_running.clone();
         (script, game_status, config, is_running)
     };
+    is_running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .map_err(|_| "已有剧本正在运行，请先结束当前剧情".to_string())?;
 
     let ai_service = state.ai_service.clone();
     let channels = state.script_channels.clone();
     let db = state.db.clone();
     let data_dir = state.ai_service.lock().await.data_dir.clone();
     let llm = state.chat.llm.clone();
+    let generation_lock = state.generation_lock.clone();
     let achievement_manager = state.achievement_manager.clone();
 
     tokio::spawn(async move {
@@ -208,6 +212,7 @@ pub async fn start_adventure(app: AppHandle, adventure_folder: String) -> Result
             data_dir: &data_dir,
             app: &app,
             game_status,
+            generation_lock,
             config: &config,
             llm: llm.as_ref(),
             channels,

--- a/src-tauri/src/api/chat.rs
+++ b/src-tauri/src/api/chat.rs
@@ -44,12 +44,24 @@ pub async fn send_chat_message(
         svc.game_status.clone()
     };
 
+    // 从收到用户消息起就预留生成权；截图 VLM 期间也不能让旧的主动回复插队。
+    let generation_guard = state.generation_lock.clone().lock_owned().await;
+    if game_status.lock().await.script_status.is_some() {
+        return Err("剧情正在运行，请使用剧情输入框继续".to_string());
+    }
+
+    // 在截图分析前推进交互代次，让已经在途的旧 Screen/Topic 结果失效。
+    if let Some(proactive) = &state.proactive_system {
+        proactive.lock().await.on_user_message_received().await;
+    }
+
     let user_name = game_status.lock().await.player.user_name.clone();
 
     // 发送思考事件
-    events::emit_thinking(&app, true);
+    events::emit_thinking(&app, true, false);
 
-    // 截图分析：在创建 GeneratorDeps 之前，确保旁白台词已写入 line_list
+    // 截图分析：先异步获取旁白文本，实际写入 line_list 推迟到 generation_lock 内
+    let mut narration_opt: Option<String> = None;
     if let Some(ref b64) = screenshot_base64 {
         if let Ok(image_bytes) = base64::Engine::decode(&base64::prelude::BASE64_STANDARD, b64) {
             let prompt = format!(
@@ -63,19 +75,8 @@ pub async fn send_chat_message(
             };
 
             if let Some(narration) = analysis {
-                let mut gs = game_status.lock().await;
-                gs.add_line(
-                    &state.db,
-                    LineBase {
-                        content: PromptRole::Narrator.build_prompt(&narration),
-                        attribute: LineAttributeExt(LineAttribute::User),
-                        display_name: Some("旁白".to_string()),
-                        ..Default::default()
-                    },
-                )
-                .await
-                .map_err(|e| format!("添加旁白台词失败: {}", e))?;
-                tracing::info!("[Chat] Screenshot analysis narration added to game_status.");
+                narration_opt = Some(PromptRole::Narrator.build_prompt(&narration));
+                tracing::info!("[Chat] Screenshot analysis narration ready.");
             }
         }
     }
@@ -83,23 +84,15 @@ pub async fn send_chat_message(
     let deps = GeneratorDeps {
         app: app.clone(),
         db: state.db.clone(),
-        game_status,
+        game_status: game_status.clone(),
         processor: state.chat.processor.clone(),
         translator: state.chat.translator.clone(),
         llm,
         concurrency,
         god_agent: state.god_agent.clone(),
         suppress_thinking: false,
+        is_proactive: false,
     };
-
-    // Notify proactive system of user input
-    if let Some(proactive) = &state.proactive_system {
-        let proactive_clone = proactive.clone();
-        tokio::spawn(async move {
-            let mut sys = proactive_clone.lock().await;
-            sys.on_user_message_received().await;
-        });
-    }
 
     // 成就触发检查
     let achievement_manager = state.achievement_manager.clone();
@@ -147,10 +140,32 @@ pub async fn send_chat_message(
     });
 
     let generator = MessageGenerator::new(deps);
-    let gen_lock = state.generation_lock.clone();
+    let db_for_narration = state.db.clone();
 
     tokio::spawn(async move {
-        let _lock = gen_lock.lock().await;
+        let _generation_guard = generation_guard;
+
+        // 在 generation_lock 保护下按顺序写入旁白行，避免被主动回复插队覆盖
+        if let Some(narration) = narration_opt {
+            let mut gs = game_status.lock().await;
+            if let Err(e) = gs
+                .add_line(
+                    &db_for_narration,
+                    LineBase {
+                        content: narration,
+                        attribute: LineAttributeExt(LineAttribute::User),
+                        display_name: Some("旁白".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
+                tracing::error!("[Chat] 添加旁白台词失败: {}", e);
+            } else {
+                tracing::info!("[Chat] Screenshot analysis narration added to game_status.");
+            }
+        }
+
         match generator.process_message(Some(text)).await {
             Ok(acc) => tracing::info!("消息生成完成，长度: {}", acc.len()),
             Err(e) => tracing::error!("消息生成失败: {:#}", e),
@@ -158,6 +173,38 @@ pub async fn send_chat_message(
     });
 
     Ok(())
+}
+
+#[tauri::command]
+pub async fn test_screen_analyzer(
+    app: AppHandle,
+    prompt: Option<String>,
+) -> Result<String, String> {
+    let state = app.state::<AppState>();
+
+    let default_prompt = "你是一个图像信息转述者，请用200字描述你看到的桌面主要内容。".to_string();
+    let prompt = prompt.unwrap_or(default_prompt);
+
+    let mut sa = state.screen_analyzer.lock().await;
+    match sa.analyze_screen(&prompt, None).await {
+        Some(result) => {
+            let report = sa.get_report();
+            tracing::info!(
+                "[TestScreenAnalyzer] success in {:.2}s, input_tokens={:?}, output_tokens={:?}",
+                report.response_time_secs,
+                report.input_tokens,
+                report.output_tokens
+            );
+            Ok(result)
+        }
+        None => {
+            let report = sa.get_report();
+            Err(format!(
+                "视觉理解测试失败。可能原因：API Key 为空、模型不支持视觉、网络超时或 Base URL 错误。耗时 {:.2}s",
+                report.response_time_secs
+            ))
+        }
+    }
 }
 
 /// 处理以 "/" 开头的调试指令（仅在后端日志输出，不发往前端）。

--- a/src-tauri/src/api/game.rs
+++ b/src-tauri/src/api/game.rs
@@ -746,16 +746,29 @@ pub async fn remove_role_from_scene(app: AppHandle, role_id: i32) -> Result<Json
 #[tauri::command]
 pub async fn notify_player_entry(app: AppHandle) -> Result<(), String> {
     let state = app.state::<AppState>();
+    let llm = state
+        .chat
+        .llm
+        .clone()
+        .ok_or_else(|| "LLM 未配置".to_string())?;
+    let concurrency = AppConfig::load(&app)
+        .map(|c| c.consumers as usize)
+        .unwrap_or(1)
+        .max(1);
+    let game_status = {
+        let svc = state.ai_service.lock().await;
+        svc.game_status.clone()
+    };
+    // 入场旁白和对应生成必须是一个原子顺序，不能被主动回复插到中间。
+    let generation_guard = state.generation_lock.clone().lock_owned().await;
 
     // Phase 1: 去重 & 添加旁白台词
     {
-        let svc = state.ai_service.lock().await;
-        let mut gs = svc.game_status.lock().await;
+        let mut gs = game_status.lock().await;
 
         if gs.player_entered {
             return Ok(());
         }
-        gs.player_entered = true;
 
         let current_role_id = match gs.current_role_id {
             Some(id) => id,
@@ -764,6 +777,7 @@ pub async fn notify_player_entry(app: AppHandle) -> Result<(), String> {
                 return Ok(());
             }
         };
+        gs.player_entered = true;
 
         let ai_name = gs
             .role_manager
@@ -806,20 +820,6 @@ pub async fn notify_player_entry(app: AppHandle) -> Result<(), String> {
     } // 释放锁
 
     // Phase 2: 触发 AI 响应（suppress_thinking=true，不显示思考指示器）
-    let llm = state
-        .chat
-        .llm
-        .clone()
-        .ok_or_else(|| "LLM 未配置".to_string())?;
-    let concurrency = AppConfig::load(&app)
-        .map(|c| c.consumers as usize)
-        .unwrap_or(1)
-        .max(1);
-    let game_status = {
-        let svc = state.ai_service.lock().await;
-        svc.game_status.clone()
-    };
-
     let deps = GeneratorDeps {
         app: app.clone(),
         db: state.db.clone(),
@@ -830,13 +830,13 @@ pub async fn notify_player_entry(app: AppHandle) -> Result<(), String> {
         concurrency,
         god_agent: state.god_agent.clone(),
         suppress_thinking: true,
+        is_proactive: false,
     };
 
     let generator = MessageGenerator::new(deps);
-    let gen_lock = state.generation_lock.clone();
 
     tokio::spawn(async move {
-        let _lock = gen_lock.lock().await;
+        let _generation_guard = generation_guard;
         match generator.process_message(None).await {
             Ok(acc) => tracing::info!("[Entry] 入场问候生成完成，长度: {}", acc.len()),
             Err(e) => tracing::error!("[Entry] 入场问候生成失败: {:#}", e),

--- a/src-tauri/src/api/schedule.rs
+++ b/src-tauri/src/api/schedule.rs
@@ -61,21 +61,52 @@ pub async fn save_schedules(app: AppHandle, data: UserScheduleSettings) -> Resul
 
     // Reload settings in the proactive system
     if let Some(proactive) = &state.proactive_system {
-        let mut sys = proactive.lock().await;
-        sys.reload().await;
+        crate::ai_service::proactive_system::ProactiveSystem::reload(proactive.clone()).await;
     }
 
     Ok("日程设置已保存！".to_string())
 }
 
 #[tauri::command]
+pub async fn test_proactive_message(app: AppHandle) -> Result<String, String> {
+    let state = app.state::<AppState>();
+
+    if let Some(ps) = &state.proactive_system {
+        match crate::ai_service::proactive_system::ProactiveSystem::test_screen_proactive(
+            ps.clone(),
+        )
+        .await
+        {
+            Ok(Some(prompt)) => Ok(format!("已触发主动搭话: {}", prompt)),
+            Ok(None) => Ok("屏幕分析返回 [PASS]，未触发搭话".to_string()),
+            Err(e) => Err(e),
+        }
+    } else {
+        Err("主动对话系统未初始化".to_string())
+    }
+}
+
+#[tauri::command]
 pub async fn reload_proactive_system(app: AppHandle) -> Result<String, String> {
     let state = app.state::<AppState>();
+    let proactive_running = state.proactive_system.is_some();
+
+    // 先应用主动系统的开关/闸门；即便视觉请求仍在收尾，在途结果也会按新配置复核。
     if let Some(proactive) = &state.proactive_system {
-        let mut sys = proactive.lock().await;
-        sys.reload().await;
+        crate::ai_service::proactive_system::ProactiveSystem::reload(proactive.clone()).await;
+    }
+
+    // 无论主动系统是否已启动，都刷新共享屏幕分析器，让“看桌面”等路径使用最新设置。
+    let pconfig = crate::config::proactive::ProactiveConfig::load(&app);
+    let sa_config =
+        crate::ai_service::screen_analyzer::build_screen_analyzer_config(&app, &pconfig);
+    let mut sa = state.screen_analyzer.lock().await;
+    sa.update_config(sa_config);
+    drop(sa);
+
+    if proactive_running {
         Ok("主动对话系统配置已重载！".to_string())
     } else {
-        Err("主动对话系统未运行！".to_string())
+        Ok("设置已保存，主动对话系统当前未运行，将在启动后自动生效。".to_string())
     }
 }

--- a/src-tauri/src/api/script.rs
+++ b/src-tauri/src/api/script.rs
@@ -7,6 +7,7 @@ use crate::ai_service::game_system::script_engine::events::ScriptContext;
 use crate::ai_service::game_system::script_engine::ScriptManager;
 use crate::AppState;
 use serde::Serialize;
+use std::sync::atomic::Ordering;
 use tauri::{AppHandle, Manager};
 
 // ============================================================
@@ -81,6 +82,7 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
     let db = state.db.clone();
     let data_dir = state.ai_service.lock().await.data_dir.clone();
     let llm = state.chat.llm.clone();
+    let generation_lock = state.generation_lock.clone();
     let achievement_manager = state.achievement_manager.clone();
 
     // Lock AIService briefly to validate and extract needed data
@@ -97,6 +99,9 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
         let is_running = service.script_manager.is_running.clone();
         (script, game_status, config, is_running)
     };
+    is_running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .map_err(|_| "已有剧本正在运行，请先结束当前剧情".to_string())?;
 
     // Run script in background task (does NOT hold AIService lock across awaits)
     tokio::spawn(async move {
@@ -105,6 +110,7 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
             data_dir: &data_dir,
             app: &app,
             game_status,
+            generation_lock,
             config: &config,
             llm: llm.as_ref(),
             channels,

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -642,6 +642,24 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         description: "MAX_PROACTIVE_TIMES — 在用户响应之前，能主动对话的次数".to_string(),
                         setting_type: "text".to_string(),
                     },
+                    ConfigSetting {
+                        key: proactive::keys::PROACTIVE_INTERVAL_SECS.to_string(),
+                        value: read_setting(app, proactive::keys::PROACTIVE_INTERVAL_SECS, "10"),
+                        description: "PROACTIVE_INTERVAL_SECS — 主动对话轮询间隔（秒，默认 10，最小 2）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::INTEREST_TRIGGER_THRESHOLD.to_string(),
+                        value: read_setting(app, proactive::keys::INTEREST_TRIGGER_THRESHOLD, "30.0"),
+                        description: "INTEREST_TRIGGER_THRESHOLD — 兴趣度触发阈值（默认 30，越低越容易被触发）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::INTEREST_DECAY_STEP.to_string(),
+                        value: read_setting(app, proactive::keys::INTEREST_DECAY_STEP, "15.0"),
+                        description: "INTEREST_DECAY_STEP — 每次主动对话后兴趣度上限衰减量（默认 15，设为 0 则不衰减）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
                 ],
             },
         );
@@ -652,6 +670,12 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
             Subcategory {
                 description: "主动对话时调用的 Vision LLM 视觉分析模型以及截图分析设置".to_string(),
                 settings: vec![
+                    ConfigSetting {
+                        key: proactive::keys::VD_FOLLOW_CHAT_MODEL.to_string(),
+                        value: read_setting(app, proactive::keys::VD_FOLLOW_CHAT_MODEL, "true"),
+                        description: "VD_FOLLOW_CHAT_MODEL — 跟随当前对话模型；若当前是不可关闭长思考的模型，视觉识别也会明显变慢。低延迟建议关闭并配置独立轻量视觉模型".to_string(),
+                        setting_type: "bool".to_string(),
+                    },
                     ConfigSetting {
                         key: proactive::keys::VD_API_KEY.to_string(),
                         value: read_setting(app, proactive::keys::VD_API_KEY, ""),
@@ -670,8 +694,10 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                     },
                     ConfigSetting {
                         key: proactive::keys::VD_MODEL.to_string(),
-                        value: read_setting(app, proactive::keys::VD_MODEL, "qwen3.5-plus"),
-                        description: "VD_MODEL — 视觉模型型号".to_string(),
+                        value: read_setting(app, proactive::keys::VD_MODEL, "qwen3-vl-flash"),
+                        description:
+                            "VD_MODEL — 独立视觉模型型号（低延迟推荐非思考型 VL/Flash，例如 qwen3-vl-flash）"
+                                .to_string(),
                         setting_type: "text".to_string(),
                     },
                     ConfigSetting {
@@ -689,6 +715,14 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "SCREEN_WEIGHT — 视觉模式触发权重（越大越容易偷看屏幕聊天，默认 30）"
                                 .to_string(),
                         setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::VISUAL_PERCEPTION_PRIORITY.to_string(),
+                        value: read_setting(app, proactive::keys::VISUAL_PERCEPTION_PRIORITY, "false"),
+                        description:
+                            "VISUAL_PERCEPTION_PRIORITY — 视觉理解优先模式（开启后每次主动回复优先看屏幕，失败才找话题）"
+                                .to_string(),
+                        setting_type: "bool".to_string(),
                     },
                 ],
             },

--- a/src-tauri/src/config/proactive.rs
+++ b/src-tauri/src/config/proactive.rs
@@ -5,11 +5,16 @@ use tauri_plugin_store::StoreExt;
 pub mod keys {
     pub const ENABLE_PROACTIVE_SYSTEM: &str = "ENABLE_PROACTIVE_SYSTEM";
     pub const MAX_PROACTIVE_TIMES: &str = "MAX_PROACTIVE_TIMES";
+    pub const PROACTIVE_INTERVAL_SECS: &str = "PROACTIVE_INTERVAL_SECS";
+    pub const INTEREST_TRIGGER_THRESHOLD: &str = "INTEREST_TRIGGER_THRESHOLD";
+    pub const INTEREST_DECAY_STEP: &str = "INTEREST_DECAY_STEP";
+    pub const VD_FOLLOW_CHAT_MODEL: &str = "VD_FOLLOW_CHAT_MODEL";
     pub const VD_API_KEY: &str = "VD_API_KEY";
     pub const VD_BASE_URL: &str = "VD_BASE_URL";
     pub const VD_MODEL: &str = "VD_MODEL";
     pub const ENABLE_VISUAL_PRECEPTION: &str = "ENABLE_VISUAL_PRECEPTION";
     pub const SCREEN_WEIGHT: &str = "SCREEN_WEIGHT";
+    pub const VISUAL_PERCEPTION_PRIORITY: &str = "VISUAL_PERCEPTION_PRIORITY";
     pub const ENABLE_TOPIC_CREATER: &str = "ENABLE_TOPIC_CREATER";
     pub const TOPIC_WEIGHT: &str = "TOPIC_WEIGHT";
     pub const ENABLE_TODO_PRECEPTION: &str = "ENABLE_TODO_PRECEPTION";
@@ -22,11 +27,16 @@ pub mod keys {
 pub struct ProactiveConfig {
     pub enable_proactive_system: bool,
     pub max_proactive_times: i32,
+    pub proactive_interval_secs: u64,
+    pub interest_trigger_threshold: f64,
+    pub interest_decay_step: f64,
+    pub vd_follow_chat_model: bool,
     pub vd_api_key: String,
     pub vd_base_url: String,
     pub vd_model: String,
     pub enable_visual_perception: bool,
     pub screen_weight: f64,
+    pub visual_perception_priority: bool,
     pub enable_topic_creator: bool,
     pub topic_weight: f64,
     pub enable_todo_perception: bool,
@@ -86,21 +96,46 @@ impl ProactiveConfig {
                 .unwrap_or(default)
         };
 
+        let get_bounded_f64 = |key: &str, default: f64, min: f64, max: f64| -> f64 {
+            let value = get_f64(key, default);
+            if value.is_finite() {
+                value.clamp(min, max)
+            } else {
+                tracing::warn!(
+                    "[ProactiveConfig] {} is not finite, falling back to {}",
+                    key,
+                    default
+                );
+                default
+            }
+        };
+
         Self {
             enable_proactive_system: get_bool(keys::ENABLE_PROACTIVE_SYSTEM, false),
-            max_proactive_times: get_i32(keys::MAX_PROACTIVE_TIMES, 3),
+            max_proactive_times: get_i32(keys::MAX_PROACTIVE_TIMES, 3).clamp(0, 1_000),
+            proactive_interval_secs: get_i32(keys::PROACTIVE_INTERVAL_SECS, 10).clamp(2, 3_600)
+                as u64,
+            interest_trigger_threshold: get_bounded_f64(
+                keys::INTEREST_TRIGGER_THRESHOLD,
+                30.0,
+                0.0,
+                95.0,
+            ),
+            interest_decay_step: get_bounded_f64(keys::INTEREST_DECAY_STEP, 15.0, 0.0, 100.0),
+            vd_follow_chat_model: get_bool(keys::VD_FOLLOW_CHAT_MODEL, true),
             vd_api_key: get_string(keys::VD_API_KEY, ""),
             vd_base_url: get_string(
                 keys::VD_BASE_URL,
                 "https://dashscope.aliyuncs.com/compatible-mode/v1",
             ),
-            vd_model: get_string(keys::VD_MODEL, "qwen3.5-plus"),
+            vd_model: get_string(keys::VD_MODEL, "qwen3-vl-flash"),
             enable_visual_perception: get_bool(keys::ENABLE_VISUAL_PRECEPTION, true),
-            screen_weight: get_f64(keys::SCREEN_WEIGHT, 30.0),
+            screen_weight: get_bounded_f64(keys::SCREEN_WEIGHT, 30.0, 0.0, 10_000.0),
+            visual_perception_priority: get_bool(keys::VISUAL_PERCEPTION_PRIORITY, false),
             enable_topic_creator: get_bool(keys::ENABLE_TOPIC_CREATER, true),
-            topic_weight: get_f64(keys::TOPIC_WEIGHT, 60.0),
+            topic_weight: get_bounded_f64(keys::TOPIC_WEIGHT, 60.0, 0.0, 10_000.0),
             enable_todo_perception: get_bool(keys::ENABLE_TODO_PRECEPTION, true),
-            todo_weight: get_f64(keys::TODO_WEIGHT, 10.0),
+            todo_weight: get_bounded_f64(keys::TODO_WEIGHT, 10.0, 0.0, 10_000.0),
             enable_schedule_reminder: get_bool(keys::ENABLE_SCHEDULE_REMINDER, true),
             enable_important_day_reminder: get_bool(keys::ENABLE_IMPORTANT_DAY_REMINDER, true),
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ pub fn run() {
                     vd_api_key: pconfig.vd_api_key,
                     vd_base_url: pconfig.vd_base_url,
                     vd_model: pconfig.vd_model,
+                    provider: "openai".to_string(),
                 };
                 std::sync::Arc::new(tokio::sync::Mutex::new(ScreenAnalyzer::new(sa_config)))
             };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,7 +25,7 @@ use ai_service::god_agent::config::resolve_god_agent_provider;
 use ai_service::god_agent::GodAgentCore;
 use ai_service::llm::LlmClient;
 use ai_service::message_system::processor::MessageProcessor;
-use ai_service::screen_analyzer::{ScreenAnalyzer, ScreenAnalyzerConfig};
+use ai_service::screen_analyzer::{ScreenAnalyzer, build_screen_analyzer_config};
 use ai_service::service::SharedAIService;
 use ai_service::translator::Translator;
 
@@ -159,12 +159,7 @@ pub fn run() {
 
             let screen_analyzer = {
                 let pconfig = config::proactive::ProactiveConfig::load(&app.handle());
-                let sa_config = ScreenAnalyzerConfig {
-                    vd_api_key: pconfig.vd_api_key,
-                    vd_base_url: pconfig.vd_base_url,
-                    vd_model: pconfig.vd_model,
-                    provider: "openai".to_string(),
-                };
+                let sa_config = build_screen_analyzer_config(&app.handle(), &pconfig);
                 std::sync::Arc::new(tokio::sync::Mutex::new(ScreenAnalyzer::new(sa_config)))
             };
 
@@ -344,6 +339,7 @@ pub fn run() {
             api::game::notify_player_entry,
             api::chat::send_chat_message,
             api::chat::rollback_conversation,
+            api::chat::test_screen_analyzer,
             api::screenshot::start_screenshot,
             api::screenshot::get_overlay_data,
             api::screenshot::confirm_screenshot,
@@ -366,6 +362,7 @@ pub fn run() {
             api::schedule::get_schedules,
             api::schedule::save_schedules,
             api::schedule::reload_proactive_system,
+            api::schedule::test_proactive_message,
             api::proactive_set_can_deliver,
             api::achievement::get_achievement_list,
             api::achievement::unlock_achievement,


### PR DESCRIPTION
## 范围

本 PR 只处理主动对话 Rust 后端、脚本事件和投放生命周期，不包含视觉实现细节与 Vue 界面。

- 重构主动循环、活动监控、日程调度和策略分派
- 增加投放闸门、生命周期代次、过期结果淘汰和失败回滚
- 完善历史去重、兴趣值消耗、退避重试与待投放意图管理
- 接入聊天、游戏、冒险、脚本和日程 API

## 规模与依赖

- 依赖先合并 #489
- GitHub 页面累计：25 个文件，1791 行新增、474 行删除
- 相对 #489 的本层增量：22 个文件，1659 行新增、467 行删除
- 页面累计新增严格低于 2000 行

## 人工检查

1. 开启主动对话，确认活动、视觉和日程触发正常启动。
2. 在请求进行中停用或重载，确认过期结果不会继续投放。
3. 模拟投放失败，确认兴趣值回滚并按退避策略恢复。
4. 连续重载系统，确认不会产生重复循环。

## 验证

- `node scripts/prepare-desktop-resources.mjs`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- 最终组合分支 `cargo test --lib`：21 passed，0 failed
- `git diff --check`