### PR TITLE
功能：完善主动回复状态、设置与投放界面

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,8 +24,10 @@ import { useSedentaryReminder } from './composables/useSedentaryReminder'
 import { useUpdater } from './composables/useUpdater'
 import { useCanDeliver } from './composables/useCanDeliver'
 
-// 激活主动对话投放条件上报（仅在此处挂载一次）
-useCanDeliver()
+// 只有主窗口能作为主动回复投放闸门；设置/截图等辅助 WebView 不能覆盖主窗口状态。
+if (getCurrentWindow().label === 'main') {
+  useCanDeliver()
+}
 
 // ─── 久坐提醒 ────────────────────────────────────────────────
 useSedentaryReminder()

--- a/src/api/services/schedule.ts
+++ b/src/api/services/schedule.ts
@@ -34,3 +34,13 @@ export const reloadProactiveSystem = async (): Promise<void> => {
     throw error
   }
 }
+
+export const testProactiveMessage = async (): Promise<string> => {
+  try {
+    const result = await invoke<string>('test_proactive_message')
+    return result
+  } catch (error: any) {
+    console.error('测试主动消息错误:', error.message)
+    throw error
+  }
+}

--- a/src/api/tauri-events.ts
+++ b/src/api/tauri-events.ts
@@ -18,7 +18,14 @@ export function initializeTauriEventListeners() {
 
   listen('ai:thinking', (event) => {
     console.log('[Tauri] ai:thinking', event.payload)
-    eventQueue.addEvent(asEvent(event.payload, { type: 'thinking', duration: 0 }))
+    const payload = event.payload as { isThinking?: boolean; isProactive?: boolean }
+    eventQueue.addEvent(
+      asEvent(event.payload, {
+        type: 'thinking',
+        duration: 0,
+        isProactive: Boolean(payload.isProactive),
+      }),
+    )
   })
 
   listen('ai:thinking_progress', (event) => {
@@ -27,6 +34,16 @@ export function initializeTauriEventListeners() {
     const gameStore = useGameStore()
     if (typeof payload.thinkingLength === 'number') {
       gameStore.thinkingLength = payload.thinkingLength
+    }
+  })
+
+  listen('ai:proactive_thinking', (event) => {
+    const payload = event.payload as { isThinking?: boolean }
+    console.log('[Tauri] ai:proactive_thinking', payload)
+    const gameStore = useGameStore()
+    gameStore.isProactiveThinking = Boolean(payload.isThinking)
+    if (!payload.isThinking) {
+      gameStore.thinkingLength = 0
     }
   })
 

--- a/src/components/game/standard/GameDialog.vue
+++ b/src/components/game/standard/GameDialog.vue
@@ -21,22 +21,24 @@
           </div>
           <div
             v-show="!uiStore.isNarrowScreen"
-            class="text-xl font-bold text-[#6eb4ff] font-[inherit] text-shadow-[inherit]"
+            class="text-xl font-bold text-[#6eb4ff] font-[inherit] text-shadow-[inherit] mr-3.75"
           >
             <div id="character-sub">{{ uiStore.showCharacterSubtitle }}</div>
           </div>
 
-          <!-- 右侧区域：情绪标签 + 操作按钮组（窄屏时占据剩余全部宽度，优先显示） -->
+          <!-- 情绪标签，放在名称与操作按钮组之间 -->
+          <div
+            v-show="!uiStore.isNarrowScreen"
+            class="text-xl font-bold text-[#ff77dd] font-[inherit] text-shadow-[inherit] shrink-0"
+          >
+            <div id="character-emotion">{{ uiStore.showCharacterEmotion }}</div>
+          </div>
+
+          <!-- 右侧区域：操作按钮组（窄屏时占据剩余全部宽度，优先显示） -->
           <div
             class="flex items-baseline ml-auto min-w-0"
             :class="{ 'flex-1 shrink-0': uiStore.isNarrowScreen }"
           >
-            <div
-              class="text-xl font-bold text-[#ff77dd] font-[inherit] text-shadow-[inherit] shrink-0"
-            >
-              <div id="character-emotion">{{ uiStore.showCharacterEmotion }}</div>
-            </div>
-
             <!-- 操作按钮组（窄屏时占据右侧容器剩余空间，可横向滚动） -->
             <div
               class="overflow-x-auto custom-scroll"
@@ -291,17 +293,42 @@ const placeholderText = computed(() => {
   switch (gameStore.currentStatus) {
     case 'input':
       return uiStore.showPlayerHintLine || '在这里输入消息...'
-    case 'thinking':
+    case 'thinking': {
+      const len = gameStore.thinkingLength
+      if (gameStore.isProactiveThinking) {
+        if (len > 0) {
+          const stageHint =
+            len < 300
+              ? '正在观察屏幕'
+              : len < 1000
+                ? '正在组织语言'
+                : len < 2500
+                  ? '正在检查细节'
+                  : '正在深入构思'
+          return `主动回复中（${stageHint}，已思考 ${len} 字）`
+        }
+        return '主动回复中...'
+      }
+
       const currentInteractRole = gameStore.currentInteractRole
       if (currentInteractRole) {
         const baseMessage = currentInteractRole.thinkMessage
-        if (gameStore.thinkingLength > 0) {
-          return `${baseMessage}（已深度思考 ${gameStore.thinkingLength} 字）`
+        if (len > 0) {
+          const stageHint =
+            len < 300
+              ? '正在理解主人的话'
+              : len < 1000
+                ? '正在组织语言'
+                : len < 2500
+                  ? '正在检查细节'
+                  : '正在深入构思'
+          return `${baseMessage}（${stageHint}，已思考 ${len} 字）`
         }
         return baseMessage
       } else {
         return '等待回应中...'
       }
+    }
     case 'responding':
     case 'presenting':
       return ''

--- a/src/components/pet/ChatInput.vue
+++ b/src/components/pet/ChatInput.vue
@@ -61,17 +61,43 @@ const placeholderText = computed(() => {
   switch (gameStore.currentStatus) {
     case 'input':
       return uiStore.showPlayerHintLine || '输入消息...'
-    case 'thinking':
+    case 'thinking': {
+      const len = gameStore.thinkingLength
+      if (gameStore.isProactiveThinking) {
+        if (len > 0) {
+          const stageHint =
+            len < 300
+              ? '正在观察屏幕'
+              : len < 1000
+                ? '正在组织语言'
+                : len < 2500
+                  ? '正在检查细节'
+                  : '正在深入构思'
+          return `主动回复中（${stageHint}，已思考 ${len} 字）`
+        }
+        return '主动回复中...'
+      }
+
       const currentInteractRole = gameStore.currentInteractRole
       if (currentInteractRole) {
         const baseMessage = currentInteractRole.thinkMessage
-        if (gameStore.thinkingLength > 0) {
-          return `${baseMessage}（已深度思考 ${gameStore.thinkingLength} 字）`
+        if (len > 0) {
+          // 根据思考字数给出更生动的阶段提示
+          const stageHint =
+            len < 300
+              ? '正在理解主人的话'
+              : len < 1000
+                ? '正在组织语言'
+                : len < 2500
+                  ? '正在检查细节'
+                  : '正在深入构思'
+          return `${baseMessage}（${stageHint}，已思考 ${len} 字）`
         }
         return baseMessage
       } else {
         return '等待回应中...'
       }
+    }
     case 'responding':
       return '聊天ing~'
     case 'presenting':

--- a/src/components/schedule/pages/ProactivePage.vue
+++ b/src/components/schedule/pages/ProactivePage.vue
@@ -4,86 +4,239 @@
     v-if="uiStore.scheduleView === 'proactive_settings'"
     class="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-1 p-1"
   >
-    <div v-for="setting in settings" :key="setting.key" class="mb-6">
-      <!-- 使用 SettingItem 组件渲染不同类型的输入控件 -->
-      <SettingItem :setting="setting" @update:value="(value) => (setting.value = value)" />
+    <div v-if="settings['ENABLE_PROACTIVE_SYSTEM']" class="mb-5">
+      <SettingItem
+        :setting="settings['ENABLE_PROACTIVE_SYSTEM']"
+        @update:value="(value) => (settings['ENABLE_PROACTIVE_SYSTEM'].value = value)"
+      />
     </div>
 
-    <div class="flex gap-2 align-text-bottom w-auto h-auto items-center">
-      <div
-        class="w-18 px-5 py-2.5 bg-brand text-white border-none rounded-lg cursor-pointer text-sm font-medium transition-colors duration-200 hover:bg-[#0056b3]"
-      >
-        <button @click="saveSettings">保存</button>
+    <div class="grid grid-cols-1 gap-x-8 gap-y-5 md:grid-cols-2 mb-5">
+      <template v-for="key in performanceSettingKeys" :key="key">
+        <div v-if="settings[key]" class="min-w-0">
+          <SettingItem
+            :setting="settings[key]"
+            @update:value="(value) => (settings[key].value = value)"
+          />
+        </div>
+      </template>
+    </div>
+
+    <p v-if="configLoading" class="mb-4 text-sm text-white/65">正在加载主动对话配置...</p>
+
+    <div class="flex flex-col gap-3">
+      <p class="max-w-[72ch] text-xs leading-5 text-amber-200/80">
+        速度提示：跟随开启思考的聊天模型会更慢；追求响应速度时，可关闭“跟随当前对话模型”，并在「更多设置」中配置独立的轻量视觉模型。
+      </p>
+
+      <div class="flex flex-wrap gap-3 align-text-bottom w-auto h-auto items-center">
+        <button
+          class="px-5 py-2.5 bg-brand text-white border-none rounded-lg cursor-pointer text-sm font-medium transition-colors duration-200 hover:bg-[#0056b3] disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="saving || testStatus.loading || configLoading"
+          @click="saveSettings"
+        >
+          {{ saving ? '保存并应用中...' : '保存并应用' }}
+        </button>
+        <button
+          class="px-5 py-2.5 bg-[#6366f1] text-white border-none rounded-lg cursor-pointer text-sm font-medium transition-colors duration-200 hover:bg-[#4f46e5] disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="testStatus.loading || saving || configLoading"
+          @click="handleTestProactive"
+        >
+          {{
+            testStatus.loading
+              ? `测试中 ${testStatus.elapsedSeconds.toFixed(1)}s`
+              : '测试主动消息'
+          }}
+        </button>
+        <button
+          class="px-5 py-2.5 bg-slate-600 text-white border-none rounded-lg cursor-pointer text-sm font-medium transition-colors duration-200 hover:bg-slate-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="saving || testStatus.loading"
+          @click="openAdvancedSettings"
+        >
+          更多设置
+        </button>
       </div>
-      <p :style="{ color: saveStatus.color }">
+
+      <p v-if="testStatus.loading" class="text-sm text-indigo-200">
+        阶段：{{ testStatus.stage }}，已耗时 {{ testStatus.elapsedSeconds.toFixed(1) }} 秒
+      </p>
+      <p v-if="saveStatus.message" :style="{ color: saveStatus.color }" class="text-sm">
         {{ saveStatus.message }}
+      </p>
+      <p v-if="testStatus.message" :style="{ color: testStatus.color }" class="text-sm">
+        {{ testStatus.message }}
+      </p>
+      <p class="text-xs text-white/60">
+        更多主动对话参数（视觉模型、兴趣度阈值、话题权重等）请前往「更多设置」调整。
       </p>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, reactive } from 'vue'
+import { ref, onMounted, onUnmounted, reactive } from 'vue'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import { getEnvConfigByKey, saveEnvConfigSettings } from '@/api/services/config'
-import { reloadProactiveSystem } from '@/api/services/schedule'
+import { reloadProactiveSystem, testProactiveMessage } from '@/api/services/schedule'
 import type { ConfigItem } from '@/api/services/config'
 import SettingItem from '@/components/base/items/SettingItem.vue'
 const uiStore = useUIStore()
 const settings = ref<Record<string, ConfigItem>>({})
+const SUCCESS_COLOR = '#4ade80'
+const ERROR_COLOR = '#ef4444'
+const quickSettingKeys = [
+  'ENABLE_PROACTIVE_SYSTEM',
+  'PROACTIVE_INTERVAL_SECS',
+  'VD_FOLLOW_CHAT_MODEL',
+  'VISUAL_PERCEPTION_PRIORITY',
+  'SCREEN_WEIGHT',
+] as const
+const performanceSettingKeys = quickSettingKeys.slice(1)
+const saving = ref(false)
+const configLoading = ref(false)
+let saveStatusTimer: number | null = null
+let testStatusTimer: number | null = null
+let testProgressTimer: number | null = null
+
 const saveStatus = reactive({
   message: '',
-  color: 'var(--success-color)',
+  color: SUCCESS_COLOR,
 })
 
-const saveSettings = async () => {
-  // 将 settings 转换为 Record<string, string> 格式
+const testStatus = reactive({
+  message: '',
+  color: SUCCESS_COLOR,
+  loading: false,
+  stage: '',
+  elapsedSeconds: 0,
+})
+
+const errorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error || '未知错误')
+
+const clearSaveStatusLater = () => {
+  if (saveStatusTimer !== null) window.clearTimeout(saveStatusTimer)
+  saveStatusTimer = window.setTimeout(() => {
+    saveStatus.message = ''
+    saveStatusTimer = null
+  }, 8000)
+}
+
+const persistAndReloadSettings = async () => {
   const formData: Record<string, string> = {}
   Object.entries(settings.value).forEach(([key, config]) => {
     formData[key] = config.value
   })
 
-  saveStatus.message = ''
+  await saveEnvConfigSettings(formData)
 
   try {
-    saveStatus.message = (await saveEnvConfigSettings(formData)).message
-    saveStatus.color = 'var(--success-color)'
-    reloadProactiveSystem()
+    await reloadProactiveSystem()
+  } catch (error) {
+    throw new Error(`配置已保存，但主动对话系统重载失败，当前运行实例尚未应用：${errorMessage(error)}`)
+  }
 
-    await loadConfig()
-  } catch (error: any) {
-    saveStatus.message = `错误: ${error.message}`
-    saveStatus.color = 'red'
+  await loadConfig()
+}
+
+const saveSettings = async () => {
+  if (saving.value || testStatus.loading) return
+
+  saving.value = true
+  saveStatus.message = '正在保存并重载主动对话系统...'
+  saveStatus.color = '#a5b4fc'
+
+  try {
+    await persistAndReloadSettings()
+    saveStatus.message = '配置已保存，主动对话系统已应用最新设置'
+    saveStatus.color = SUCCESS_COLOR
+  } catch (error) {
+    saveStatus.message = `应用失败：${errorMessage(error)}`
+    saveStatus.color = ERROR_COLOR
   } finally {
-    setTimeout(() => {
-      saveStatus.message = ''
-    }, 5000)
+    saving.value = false
+    clearSaveStatusLater()
   }
 }
 
-const loadConfig = async () => {
-  const configKeys = [
-    'ENABLE_PROACTIVE_SYSTEM',
-    'MAX_PROACTIVE_TIMES',
-    'VD_API_KEY',
-    'VD_BASE_URL',
-    'VD_MODEL',
-    'ENABLE_VISUAL_PRECEPTION',
-    'SCREEN_WEIGHT',
-    'ENABLE_TOPIC_CREATER',
-    'TOPIC_WEIGHT',
-    'ENABLE_TODO_PRECEPTION',
-    'TODO_WEIGHT',
-    'ENABLE_SCHEDULE_REMINDER',
-    'ENABLE_IMPORTANT_DAY_REMINDER',
-  ]
+const openAdvancedSettings = () => {
+  // 打开高级设置并直接切换到"其他高级设置"页签，方便用户找到主动对话配置
+  uiStore.setAdvanceInitialTab('other')
+  uiStore.setSettingsTab('advance')
+  uiStore.toggleSettings(true)
+}
 
-  for (const key of configKeys) {
-    settings.value[key] = await getEnvConfigByKey(key)
+const loadConfig = async () => {
+  configLoading.value = true
+  try {
+    const entries = await Promise.all(
+      quickSettingKeys.map(async (key) => [key, await getEnvConfigByKey(key)] as const),
+    )
+    settings.value = Object.fromEntries(entries)
+  } finally {
+    configLoading.value = false
+  }
+}
+
+const handleTestProactive = async () => {
+  if (testStatus.loading || saving.value) return
+
+  testStatus.loading = true
+  testStatus.message = ''
+  testStatus.color = SUCCESS_COLOR
+  testStatus.stage = '正在应用当前页面的设置'
+  testStatus.elapsedSeconds = 0
+
+  if (testStatusTimer !== null) {
+    window.clearTimeout(testStatusTimer)
+    testStatusTimer = null
+  }
+
+  const startedAt = performance.now()
+  const updateElapsed = () => {
+    testStatus.elapsedSeconds = (performance.now() - startedAt) / 1000
+  }
+  testProgressTimer = window.setInterval(updateElapsed, 100)
+
+  try {
+    await persistAndReloadSettings()
+    testStatus.stage = '完整链路处理中（截图 → 视觉识别 → 回复生成）'
+    const result = await testProactiveMessage()
+    updateElapsed()
+    testStatus.stage = '测试完成'
+    testStatus.message = `${result}（总耗时 ${testStatus.elapsedSeconds.toFixed(1)} 秒）`
+    testStatus.color = SUCCESS_COLOR
+  } catch (error) {
+    updateElapsed()
+    testStatus.stage = '测试失败'
+    testStatus.message = `测试失败（${testStatus.elapsedSeconds.toFixed(1)} 秒）：${errorMessage(error)}`
+    testStatus.color = ERROR_COLOR
+  } finally {
+    if (testProgressTimer !== null) {
+      window.clearInterval(testProgressTimer)
+      testProgressTimer = null
+    }
+    testStatus.loading = false
+    testStatusTimer = window.setTimeout(() => {
+      testStatus.message = ''
+      testStatus.stage = ''
+      testStatusTimer = null
+    }, 12000)
   }
 }
 
 onMounted(async () => {
-  loadConfig()
+  try {
+    await loadConfig()
+  } catch (error) {
+    saveStatus.message = `加载主动对话配置失败：${errorMessage(error)}`
+    saveStatus.color = ERROR_COLOR
+  }
+})
+
+onUnmounted(() => {
+  if (saveStatusTimer !== null) window.clearTimeout(saveStatusTimer)
+  if (testStatusTimer !== null) window.clearTimeout(testStatusTimer)
+  if (testProgressTimer !== null) window.clearInterval(testProgressTimer)
 })
 </script>

--- a/src/components/settings/pages/SettingsAdvance.vue
+++ b/src/components/settings/pages/SettingsAdvance.vue
@@ -54,13 +54,31 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
+import { useUIStore } from '@/stores/modules/ui/ui'
 import { MenuPage } from '../../ui'
 import SettingsLlmProviders from './SettingsLlmProviders.vue'
 import SettingsAdvanceMenu from './SettingsAdvanceMenu.vue'
 import SettingsAdvanceOther from './SettingsAdvanceOther.vue'
 
-const advanceTab = ref<'menu' | 'llm' | 'other'>('menu')
+const uiStore = useUIStore()
+
+const advanceTab = ref<'menu' | 'llm' | 'other'>(uiStore.advanceInitialTab)
+
+// 当通过外部入口（如日程弹窗的"更多设置"）指定了初始页签时，
+// 打开高级设置后自动切到对应页签，并重置状态避免影响后续操作。
+watch(
+  () => uiStore.advanceInitialTab,
+  (newTab) => {
+    // `menu` is the consumed/default state.  Ignore the reset notification so
+    // it does not immediately overwrite an externally requested destination.
+    if (newTab === 'menu') return
+
+    advanceTab.value = newTab
+    uiStore.advanceInitialTab = 'menu'
+  },
+  { immediate: true },
+)
 
 const advanceOtherRef = ref<InstanceType<typeof SettingsAdvanceOther> | null>(null)
 

--- a/src/components/settings/pages/SettingsAdvanceOther.vue
+++ b/src/components/settings/pages/SettingsAdvanceOther.vue
@@ -82,7 +82,7 @@
 
           <form @submit.prevent="saveSettings">
             <div
-              v-for="setting in selectedSubcategory.settings"
+              v-for="setting in visibleSettings"
               :key="setting.key"
               class="mb-6"
             >
@@ -129,6 +129,7 @@ import { ref, onMounted, computed, reactive, watch, nextTick } from 'vue'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import SettingItem from '@/components/base/items/SettingItem.vue'
 import { getEnvConfigSettings, saveEnvConfigSettings } from '@/api/services/config'
+import { reloadProactiveSystem } from '@/api/services/schedule'
 
 // --- 响应式状态定义 ---
 const uiStore = useUIStore()
@@ -160,6 +161,18 @@ const selectedSubcategory = computed(() => {
   return null
 })
 
+const hiddenKeysWhenFollowing = ['VD_API_KEY', 'VD_BASE_URL', 'VD_MODEL']
+const visibleSettings = computed(() => {
+  if (!selectedSubcategory.value) return []
+  const settings = selectedSubcategory.value.settings
+  const followSetting = settings.find((s: any) => s.key === 'VD_FOLLOW_CHAT_MODEL')
+  const followChatModel = followSetting?.value?.toLowerCase() === 'true'
+  return settings.filter((s: any) => {
+    if (!followChatModel) return true
+    return !hiddenKeysWhenFollowing.includes(s.key)
+  })
+})
+
 // --- 方法定义 ---
 
 const isActive = (category: string, subcategory: string) => {
@@ -187,12 +200,22 @@ const saveSettings = async () => {
   saveStatus.message = ''
 
   try {
-    saveStatus.message = (await saveEnvConfigSettings(formData)).message
+    const saveResult = await saveEnvConfigSettings(formData)
+
+    try {
+      await reloadProactiveSystem()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error || '未知错误')
+      throw new Error(`配置已保存，但主动对话系统重载失败，当前运行实例尚未应用：${message}`)
+    }
+
+    saveStatus.message = `${saveResult.message} 主动对话系统已重载。`
     saveStatus.colorClass = 'text-green-500'
 
     await loadConfig(false)
-  } catch (error: any) {
-    saveStatus.message = `错误: ${error.message}`
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error || '未知错误')
+    saveStatus.message = `错误: ${message}`
     saveStatus.colorClass = 'text-red-500'
   } finally {
     isLoading.value = false

--- a/src/components/settings_pet/components/tabs/WindowTab.vue
+++ b/src/components/settings_pet/components/tabs/WindowTab.vue
@@ -30,7 +30,7 @@
     <div class="flex flex-col pb-4 flex-1 gap-3">
       <!-- 渲染设置项卡片 (复刻原图 1、2 号卡片风格) -->
       <SettingItem
-        v-for="setting in settings"
+        v-for="setting in visibleSettings"
         :key="setting.key"
         :setting="setting"
         :is-dark-mode="isDarkMode"
@@ -95,7 +95,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, reactive } from "vue";
+import { ref, onMounted, reactive, computed } from "vue";
 import { Save } from "lucide-vue-next";
 import {
   getEnvConfigByKey,
@@ -110,6 +110,16 @@ defineProps<{
 }>();
 
 const settings = ref<Record<string, ConfigItem>>({});
+const hiddenKeysWhenFollowing = ['VD_API_KEY', 'VD_BASE_URL', 'VD_MODEL']
+const visibleSettings = computed(() => {
+  const followChatModel = settings.value['VD_FOLLOW_CHAT_MODEL']?.value?.toLowerCase() === 'true'
+  return Object.values(settings.value).filter((s) => {
+    // VD_FOLLOW_CHAT_MODEL 在日程弹窗的主动对话设置中显示，此处仅用于控制隐藏
+    if (s.key === 'VD_FOLLOW_CHAT_MODEL') return false
+    if (!followChatModel) return true
+    return !hiddenKeysWhenFollowing.includes(s.key)
+  })
+})
 const saveStatus = reactive({
   message: "",
   color: "#10b981", // 成功颜色
@@ -125,12 +135,21 @@ const saveSettings = async () => {
   saveStatus.color = "#6366f1"; // 靛蓝色提示
 
   try {
-    saveStatus.message = (await saveEnvConfigSettings(formData)).message;
+    const saveResult = await saveEnvConfigSettings(formData);
+
+    try {
+      await reloadProactiveSystem();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error || "未知错误");
+      throw new Error(`配置已保存，但主动对话系统重载失败，当前运行实例尚未应用：${message}`);
+    }
+
+    saveStatus.message = `${saveResult.message} 主动对话系统已重载。`;
     saveStatus.color = "#10b981";
-    reloadProactiveSystem();
     await loadConfig();
-  } catch (error: any) {
-    saveStatus.message = `错误: ${error.message}`;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error || "未知错误");
+    saveStatus.message = `错误: ${message}`;
     saveStatus.color = "#ef4444";
   } finally {
     setTimeout(() => {
@@ -141,13 +160,13 @@ const saveSettings = async () => {
 
 const loadConfig = async () => {
   const configKeys = [
-    'ENABLE_PROACTIVE_SYSTEM',
-    'MAX_PROACTIVE_TIMES',
+    'VD_FOLLOW_CHAT_MODEL',
     'VD_API_KEY',
     'VD_BASE_URL',
     'VD_MODEL',
     'ENABLE_VISUAL_PRECEPTION',
     'SCREEN_WEIGHT',
+    'VISUAL_PERCEPTION_PRIORITY',
     'ENABLE_TOPIC_CREATER',
     'TOPIC_WEIGHT',
     'ENABLE_TODO_PRECEPTION',

--- a/src/components/views/PetMode.vue
+++ b/src/components/views/PetMode.vue
@@ -60,6 +60,7 @@ import { eventQueue } from '@/core/events/event-queue'
 import ChatInput from '../pet/ChatInput.vue'
 import DialogueBox from '../pet/DialogueBox.vue'
 import GameRolesStage from '../pet/GameRolesStage.vue'
+import { setExternalDeliveryBlocked } from '@/composables/useCanDeliver'
 
 const BASE_AVATAR_SIZE = 240
 const CHAT_BASE_H = 45
@@ -246,9 +247,13 @@ const handleAvatarClick = () => {
 }
 
 const handleOpenSettings = async () => {
+  setExternalDeliveryBlocked(true)
   try {
     const existing = await WebviewWindow.getByLabel('settings')
     if (existing) {
+      void existing.once('tauri://destroyed', () => {
+        setExternalDeliveryBlocked(false)
+      })
       await existing.setFocus()
       return
     }
@@ -270,9 +275,14 @@ const handleOpenSettings = async () => {
     })
 
     webview.once('tauri://error', (e) => {
+      setExternalDeliveryBlocked(false)
       console.error('创建桌宠轻量设置窗口失败:', e)
     })
+    webview.once('tauri://destroyed', () => {
+      setExternalDeliveryBlocked(false)
+    })
   } catch (error) {
+    setExternalDeliveryBlocked(false)
     console.error('打开设置窗口时出错:', error)
   }
 }
@@ -349,7 +359,9 @@ const handleExitPetMode = async () => {
     if (settingsWindow) {
       await settingsWindow.close()
     }
+    setExternalDeliveryBlocked(false)
   } catch {
+    setExternalDeliveryBlocked(false)
     // 窗口不存在，忽略
   }
 

--- a/src/composables/useCanDeliver.ts
+++ b/src/composables/useCanDeliver.ts
@@ -1,4 +1,4 @@
-import { ref, watch, onMounted } from 'vue'
+import { onBeforeUnmount, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { invoke } from '@tauri-apps/api/core'
 import { useUIStore } from '@/stores/modules/ui/ui'
@@ -15,6 +15,7 @@ const CHAT_ROUTES = ['LingChat', 'PetMode']
 
 // ===== 全局输入状态（由 GameDialog / ChatInput 组件上报） =====
 let _inputHasText = false
+let _externalWindowBlocked = false
 const _inputListeners = new Set<() => void>()
 
 /** 各输入组件在 watch 中调用此函数来更新输入状态 */
@@ -24,16 +25,28 @@ export function setInputHasText(val: boolean) {
   _inputListeners.forEach((fn) => fn())
 }
 
+/** 独立设置/覆盖层窗口打开时，由主窗口显式阻止主动回复。 */
+export function setExternalDeliveryBlocked(val: boolean) {
+  if (_externalWindowBlocked === val) return
+  _externalWindowBlocked = val
+  _inputListeners.forEach((fn) => fn())
+}
+
 export function useCanDeliver() {
   const router = useRouter()
   const uiStore = useUIStore()
 
   const canDeliver = ref(false)
-  let lastInvoked: boolean | null = null
+  let acknowledged: boolean | null = null
+  let syncing = false
+  let retryTimer: number | null = null
+  let retryDelayMs = 250
+  let disposed = false
 
   function recompute() {
     const onChatRoute = CHAT_ROUTES.includes(router.currentRoute.value.name as string)
-    canDeliver.value = onChatRoute && !uiStore.showSettings && !_inputHasText
+    canDeliver.value =
+      onChatRoute && !uiStore.showSettings && !_inputHasText && !_externalWindowBlocked
   }
 
   // 监听变更
@@ -49,15 +62,51 @@ export function useCanDeliver() {
 
   // 输入状态变化时重新计算
   _inputListeners.add(recompute)
-
-  // 值翻转时通知后端
-  watch(canDeliver, (val) => {
-    if (val !== lastInvoked) {
-      lastInvoked = val
-      invoke('proactive_set_can_deliver', { canDeliver: val })
-        .catch((e) => console.error('[CanDeliver] invoke failed:', e))
-    }
+  onBeforeUnmount(() => {
+    disposed = true
+    _inputListeners.delete(recompute)
+    if (retryTimer !== null) window.clearTimeout(retryTimer)
   })
+
+  // 串行同步，避免 true/false 两次 invoke 乱序完成后把后端留在过期状态。
+  async function syncCanDeliver() {
+    if (syncing || disposed) return
+    syncing = true
+
+    try {
+      while (!disposed && acknowledged !== canDeliver.value) {
+        const target = canDeliver.value
+        try {
+          await invoke('proactive_set_can_deliver', { canDeliver: target })
+          acknowledged = target
+          retryDelayMs = 250
+          if (retryTimer !== null) {
+            window.clearTimeout(retryTimer)
+            retryTimer = null
+          }
+        } catch (error) {
+          console.error('[CanDeliver] invoke failed:', error)
+          retryTimer = window.setTimeout(() => {
+            retryTimer = null
+            void syncCanDeliver()
+          }, retryDelayMs)
+          retryDelayMs = Math.min(retryDelayMs * 2, 5000)
+          break
+        }
+      }
+    } finally {
+      syncing = false
+    }
+  }
+
+  // 值翻转时通知后端；只有调用成功后才更新 acknowledged。
+  watch(
+    canDeliver,
+    () => {
+      void syncCanDeliver()
+    },
+    { immediate: true },
+  )
 
   return { canDeliver }
 }

--- a/src/core/events/processors/status-reset-processor.ts
+++ b/src/core/events/processors/status-reset-processor.ts
@@ -18,6 +18,7 @@ export default class StatusResetProcessor implements IEventProcessor {
       (event.status as 'input' | 'thinking' | 'responding' | 'presenting') || 'input'
     gameStore.currentLine = ''
     gameStore.thinkingLength = 0
+    gameStore.isProactiveThinking = false
     console.log('游戏状态已重置为:', event.status || 'input')
   }
 }

--- a/src/core/events/processors/thinking-processor.ts
+++ b/src/core/events/processors/thinking-processor.ts
@@ -14,11 +14,13 @@ export default class ThinkingProcessor implements IEventProcessor {
       // AI 开始思考，锁定输入
       gameStore.currentStatus = 'thinking'
       gameStore.thinkingLength = 0
+      gameStore.isProactiveThinking = Boolean(event.isProactive)
     } else {
       // AI 停止思考（通常是错误恢复），重置到可输入状态
       gameStore.currentStatus = 'input'
       gameStore.currentLine = ''
       gameStore.thinkingLength = 0
+      gameStore.isProactiveThinking = false
     }
   }
 }

--- a/src/stores/modules/game/state.ts
+++ b/src/stores/modules/game/state.ts
@@ -66,6 +66,8 @@ export interface GameState {
   currentStatus: 'input' | 'thinking' | 'responding' | 'presenting'
   /** 当前思考链累计字数（用于实时显示“已深度思考 N 字”） */
   thinkingLength: number
+  /** 当前是否处于主动回复的思考阶段 */
+  isProactiveThinking: boolean
   dialogHistory: GameMessage[]
   currentScene: SceneInfo | null // 当前加载的场景
   command: string | null
@@ -90,6 +92,7 @@ export const state: GameState = {
   currentLine: '',
   currentStatus: 'input',
   thinkingLength: 0,
+  isProactiveThinking: false,
   dialogHistory: [],
   currentScene: null,
   command: null,

--- a/src/stores/modules/ui/ui.ts
+++ b/src/stores/modules/ui/ui.ts
@@ -31,6 +31,7 @@ interface UIState {
   showCharacterThinkLine: string
   showSettings: boolean
   currentSettingsTab: string
+  advanceInitialTab: 'menu' | 'llm' | 'other'
 
   currentBackgroundTransition: number
   currentPresentPic: string
@@ -92,6 +93,7 @@ export const useUIStore = defineStore('ui', {
     showCharacterThinkLine: 'Ling Ling Thinking...',
     showSettings: false,
     currentSettingsTab: 'text',
+    advanceInitialTab: 'menu',
     currentBackgroundTransition: 300,
     currentPresentPic: '',
     currentPresentPicScale: 1,
@@ -197,6 +199,9 @@ export const useUIStore = defineStore('ui', {
     },
     setSettingsTab(tab: string) {
       this.currentSettingsTab = tab
+    },
+    setAdvanceInitialTab(tab: 'menu' | 'llm' | 'other') {
+      this.advanceInitialTab = tab
     },
 
     // ========== Notification Actions ==========

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -44,6 +44,8 @@ export interface ScriptDialogueEvent extends ScriptEvent {
 export interface ScriptThinkingEvent extends ScriptEvent {
   type: 'thinking'
   isThinking: boolean
+  /** 是否为主动回复触发的前置思考 */
+  isProactive?: boolean
 }
 
 export interface ScriptFreeDialogueEvent extends ScriptEvent {


### PR DESCRIPTION
## 范围

本 PR 只处理主动回复状态、设置页和前端投放闸门，不包含窗口/DPI 功能或 Rust 主动引擎实现。

- 展示主动回复阶段、思考状态和思考字数
- 收敛主动对话设置并增加高级设置跳转与配置重载
- 增加并初始化 `useCanDeliver` 前端投放状态管理
- 在 `PetMode` 中处理设置/游戏流程对主动投放的阻塞状态
- 同步脚本事件、游戏状态和日程测试入口的前端类型

## 规模与依赖

- 基于 `tauri-refactor`，可独立完成前端构建
- 建议合并顺序：#489 → #491 → 本 PR
- 16 个文件，454 行新增、85 行删除
- 不包含已撤回的窗口尺寸、DPI 与窗口恢复改动

## 验证

- `pnpm install --frozen-lockfile`
- `pnpm build`（包含 `vue-tsc --noEmit --skipLibCheck`）
- 主动回复最终组合树与原主动功能分支一致（仅保留上游新版 icon）
- `git diff --check`

生产构建通过；仅保留仓库已有的 Vite 动态/静态导入提示。