### PR TITLE
feat(window): add DPI-safe backend geometry

### DIFF
--- a/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
+++ b/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
@@ -19,6 +19,7 @@ impl StrategyDispatcher {
             vd_api_key: config.vd_api_key.clone(),
             vd_base_url: config.vd_base_url.clone(),
             vd_model: config.vd_model.clone(),
+            provider: "openai".to_string(),
         };
         Self {
             screen_analyzer: Mutex::new(ScreenAnalyzer::new(sa_config)),
@@ -34,6 +35,7 @@ impl StrategyDispatcher {
                 vd_api_key: config.vd_api_key,
                 vd_base_url: config.vd_base_url,
                 vd_model: config.vd_model,
+                provider: "openai".to_string(),
             });
         }
     }
@@ -217,7 +219,7 @@ impl StrategyDispatcher {
             .screen_analyzer
             .lock()
             .await
-            .analyze_screen(analyze_prompt)
+            .analyze_screen(analyze_prompt, None)
             .await?;
 
         let user_name = &game_status.player.user_name;

--- a/src-tauri/src/ai_service/screen_analyzer.rs
+++ b/src-tauri/src/ai_service/screen_analyzer.rs
@@ -7,12 +7,16 @@ use reqwest::Client;
 use serde_json::Value;
 use std::time::Instant;
 
+use crate::ai_service::llm::provider_config::resolve_chat_provider;
+use crate::config::proactive::ProactiveConfig;
+
 /// 屏幕分析器的配置（从环境/Store 加载）。
 #[derive(Clone, Debug)]
 pub struct ScreenAnalyzerConfig {
     pub vd_api_key: String,
     pub vd_base_url: String,
     pub vd_model: String,
+    pub provider: String,
 }
 
 impl Default for ScreenAnalyzerConfig {
@@ -20,9 +24,18 @@ impl Default for ScreenAnalyzerConfig {
         Self {
             vd_api_key: String::new(),
             vd_base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1".to_string(),
-            vd_model: "qwen3.5-plus".to_string(),
+            vd_model: "qwen3-vl-flash".to_string(),
+            provider: "openai".to_string(),
         }
     }
+}
+
+/// Shared context passed by proactive and manual screen-analysis callers.
+#[derive(Clone, Debug, Default)]
+pub struct ScreenContext {
+    pub ai_name: Option<String>,
+    pub user_name: Option<String>,
+    pub recent_chat_summary: Option<String>,
 }
 
 /// 最后一次分析的性能与用量报告。
@@ -58,9 +71,24 @@ impl ScreenAnalyzer {
         &self.last_report
     }
 
+    /// Proactive entry point kept in the shared contract so engine and visual
+    /// implementation PRs can be reviewed independently.
+    pub async fn analyze_screen_for_proactive(
+        &mut self,
+        context: Option<&ScreenContext>,
+    ) -> Option<String> {
+        let prompt = "你刚刚看了一眼主人的电脑屏幕。若有值得自然搭话的内容，请直接回复一句不超过50字的话；否则只回复[PASS]。";
+        self.analyze_screen(prompt, context).await
+    }
+
     /// 核心方法：截屏 → 发送给 VLM 分析 → 返回文本描述。
-    /// 这是策略分发器和主动对话系统的主要入口。
-    pub async fn analyze_screen(&mut self, prompt: &str) -> Option<String> {
+    /// `context` is part of the stable cross-PR API; the visual implementation
+    /// PR enriches the prompt with it.
+    pub async fn analyze_screen(
+        &mut self,
+        prompt: &str,
+        _context: Option<&ScreenContext>,
+    ) -> Option<String> {
         let api_key = &self.config.vd_api_key;
         if api_key.is_empty() {
             tracing::warn!("[ScreenAnalyzer] VD_API_KEY is empty, skipping screenshot analysis.");
@@ -193,6 +221,31 @@ impl ScreenAnalyzer {
         };
 
         None
+    }
+}
+
+/// Resolve the visual model once for every caller. The visual implementation
+/// PR extends protocol handling without changing this shared API.
+pub fn build_screen_analyzer_config(
+    app_handle: &tauri::AppHandle,
+    config: &ProactiveConfig,
+) -> ScreenAnalyzerConfig {
+    if config.vd_follow_chat_model {
+        if let Some(provider) = resolve_chat_provider(app_handle) {
+            return ScreenAnalyzerConfig {
+                vd_api_key: provider.api_key,
+                vd_base_url: provider.base_url,
+                vd_model: provider.model,
+                provider: provider.provider,
+            };
+        }
+    }
+
+    ScreenAnalyzerConfig {
+        vd_api_key: config.vd_api_key.clone(),
+        vd_base_url: config.vd_base_url.clone(),
+        vd_model: config.vd_model.clone(),
+        provider: "openai".to_string(),
     }
 }
 

--- a/src-tauri/src/api/pet.rs
+++ b/src-tauri/src/api/pet.rs
@@ -1,8 +1,236 @@
 use serde::Deserialize;
 use std::sync::{Arc, Mutex};
-#[cfg(desktop)]
-use tauri::LogicalSize;
 use tauri::{AppHandle, Manager};
+#[cfg(desktop)]
+use tauri::{PhysicalPosition, PhysicalSize};
+
+#[cfg(desktop)]
+use crate::window_geometry::{WindowDimensions, WindowSizePlan};
+use crate::{config, window_geometry};
+
+#[cfg(desktop)]
+const PET_BASE_WIDTH: f64 = 240.0;
+#[cfg(desktop)]
+const PET_AVATAR_HEIGHT: f64 = 240.0;
+#[cfg(desktop)]
+const PET_DIALOG_HEIGHT: f64 = 75.0;
+#[cfg(desktop)]
+const PET_CHAT_HEIGHT: f64 = 45.0;
+#[cfg(desktop)]
+const MIN_PET_SCALE: f64 = 0.7;
+#[cfg(desktop)]
+const MAX_PET_SCALE: f64 = 1.3;
+
+#[cfg(desktop)]
+fn window_operation_error(operation: &str, error: impl std::fmt::Display) -> String {
+    let message = format!("桌宠窗口操作失败（{operation}）: {error}");
+    tracing::error!("{message}");
+    message
+}
+
+#[cfg(desktop)]
+fn pet_window_size(scale: Option<f64>) -> Result<WindowDimensions, String> {
+    let scale = scale.unwrap_or(1.0);
+    if !scale.is_finite() || !(MIN_PET_SCALE..=MAX_PET_SCALE).contains(&scale) {
+        let message =
+            format!("无效的桌宠缩放比例 {scale}，允许范围为 {MIN_PET_SCALE}..={MAX_PET_SCALE}");
+        tracing::warn!("{message}");
+        return Err(message);
+    }
+
+    // 与前端 calcWindowLayout 保持一致，避免 CSS 布局与窗口逻辑尺寸相差 1px。
+    let width = (PET_BASE_WIDTH * scale).round();
+    let height = (PET_AVATAR_HEIGHT * scale).round()
+        + (PET_DIALOG_HEIGHT * scale).round()
+        + (PET_CHAT_HEIGHT * scale).round();
+    if !width.is_finite() || !height.is_finite() || width < 1.0 || height < 1.0 {
+        let message = format!("桌宠目标窗口尺寸无效: {width}x{height} (scale={scale})");
+        tracing::warn!("{message}");
+        return Err(message);
+    }
+
+    Ok(WindowDimensions::new(width as u32, height as u32))
+}
+
+#[cfg(desktop)]
+fn configured_window_plan(
+    app: &AppHandle,
+    window: &tauri::WebviewWindow<tauri::Wry>,
+) -> Result<(WindowSizePlan, Option<&'static str>), String> {
+    let width_raw = config::read_setting(
+        app,
+        config::keys::WINDOW_WIDTH,
+        &window_geometry::MAIN_WINDOW_DEFAULT_WIDTH.to_string(),
+    );
+    let height_raw = config::read_setting(
+        app,
+        config::keys::WINDOW_HEIGHT,
+        &window_geometry::MAIN_WINDOW_DEFAULT_HEIGHT.to_string(),
+    );
+    let (requested, repair_preset) =
+        match window_geometry::parse_main_window_size(&width_raw, &height_raw) {
+            Ok(size) => (size, None),
+            Err(error) => {
+                tracing::warn!("退出桌宠时发现主窗口尺寸配置无效，将恢复安全默认值：{error}");
+                (window_geometry::default_main_window_size(), Some("default"))
+            }
+        };
+    let plan = window_geometry::plan_main_window_size(window, requested)?;
+    Ok((plan, repair_preset))
+}
+
+#[cfg(desktop)]
+#[derive(Clone, Debug)]
+struct NormalWindowSnapshot {
+    inner_size: PhysicalSize<u32>,
+    position: PhysicalPosition<i32>,
+    fullscreen: bool,
+    maximized: bool,
+    maximizable: bool,
+}
+
+#[cfg(desktop)]
+fn capture_normal_window_snapshot(
+    window: &tauri::WebviewWindow<tauri::Wry>,
+) -> Result<NormalWindowSnapshot, String> {
+    let fullscreen = window
+        .is_fullscreen()
+        .map_err(|error| window_operation_error("读取全屏状态", error))?;
+    let maximized = window
+        .is_maximized()
+        .map_err(|error| window_operation_error("读取最大化状态", error))?;
+    let maximizable = window
+        .is_maximizable()
+        .map_err(|error| window_operation_error("读取可最大化状态", error))?;
+
+    let leave_result = (|| -> Result<(), String> {
+        if fullscreen {
+            window
+                .set_fullscreen(false)
+                .map_err(|error| window_operation_error("退出全屏", error))?;
+        }
+        if maximized {
+            window
+                .unmaximize()
+                .map_err(|error| window_operation_error("取消最大化", error))?;
+        }
+        Ok(())
+    })();
+
+    if let Err(error) = leave_result {
+        let mut rollback_errors = Vec::new();
+        if maximized {
+            record_window_result(&mut rollback_errors, "恢复最大化状态", window.maximize());
+        }
+        if fullscreen {
+            record_window_result(
+                &mut rollback_errors,
+                "恢复全屏状态",
+                window.set_fullscreen(true),
+            );
+        }
+        return Err(if rollback_errors.is_empty() {
+            error.clone()
+        } else {
+            format!(
+                "{error}；窗口状态回滚不完整：{}",
+                rollback_errors.join("；")
+            )
+        });
+    }
+
+    let snapshot = (|| -> Result<NormalWindowSnapshot, String> {
+        Ok(NormalWindowSnapshot {
+            inner_size: window
+                .inner_size()
+                .map_err(|error| window_operation_error("读取普通主窗口尺寸", error))?,
+            position: window
+                .outer_position()
+                .map_err(|error| window_operation_error("读取普通主窗口位置", error))?,
+            fullscreen,
+            maximized,
+            maximizable,
+        })
+    })();
+
+    if let Err(error) = snapshot.as_ref() {
+        let mut rollback_errors = Vec::new();
+        if maximized {
+            record_window_result(&mut rollback_errors, "恢复最大化状态", window.maximize());
+        }
+        if fullscreen {
+            record_window_result(
+                &mut rollback_errors,
+                "恢复全屏状态",
+                window.set_fullscreen(true),
+            );
+        }
+        return Err(if rollback_errors.is_empty() {
+            error.clone()
+        } else {
+            format!(
+                "{error}；窗口状态回滚不完整：{}",
+                rollback_errors.join("；")
+            )
+        });
+    }
+
+    snapshot
+}
+
+#[cfg(desktop)]
+fn record_window_result(errors: &mut Vec<String>, operation: &str, result: tauri::Result<()>) {
+    if let Err(error) = result {
+        errors.push(window_operation_error(operation, error));
+    }
+}
+
+#[cfg(desktop)]
+fn restore_snapshot_best_effort(
+    window: &tauri::WebviewWindow<tauri::Wry>,
+    snapshot: &NormalWindowSnapshot,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    record_window_result(
+        &mut errors,
+        "恢复鼠标事件",
+        window.set_ignore_cursor_events(false),
+    );
+    record_window_result(
+        &mut errors,
+        "恢复任务栏图标",
+        window.set_skip_taskbar(false),
+    );
+    record_window_result(&mut errors, "取消窗口置顶", window.set_always_on_top(false));
+    record_window_result(&mut errors, "恢复尺寸调整", window.set_resizable(true));
+    record_window_result(
+        &mut errors,
+        "恢复可最大化状态",
+        window.set_maximizable(snapshot.maximizable),
+    );
+    record_window_result(&mut errors, "恢复窗口装饰", window.set_decorations(true));
+    if let Err(error) = window_geometry::set_main_window_constraints(window) {
+        errors.push(error);
+    }
+    record_window_result(
+        &mut errors,
+        "恢复原主窗口尺寸",
+        window.set_size(snapshot.inner_size),
+    );
+    record_window_result(
+        &mut errors,
+        "恢复原主窗口位置",
+        window.set_position(snapshot.position),
+    );
+    if snapshot.maximized {
+        record_window_result(&mut errors, "恢复最大化状态", window.maximize());
+    }
+    if snapshot.fullscreen {
+        record_window_result(&mut errors, "恢复全屏状态", window.set_fullscreen(true));
+    }
+    errors
+}
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct Rect {
@@ -15,6 +243,9 @@ pub struct Rect {
 pub struct HitTestState {
     pub solid_rects: Arc<Mutex<Vec<Rect>>>,
     pub enabled: Arc<Mutex<bool>>,
+    pub transition_lock: Arc<Mutex<()>>,
+    #[cfg(desktop)]
+    normal_window: Arc<Mutex<Option<NormalWindowSnapshot>>>,
 }
 
 impl Default for HitTestState {
@@ -22,6 +253,9 @@ impl Default for HitTestState {
         Self {
             solid_rects: Arc::new(Mutex::new(Vec::new())),
             enabled: Arc::new(Mutex::new(false)),
+            transition_lock: Arc::new(Mutex::new(())),
+            #[cfg(desktop)]
+            normal_window: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -40,38 +274,231 @@ pub fn set_pet_mode(
     app_handle: AppHandle,
     state: tauri::State<'_, HitTestState>,
 ) -> Result<(), String> {
-    if let Ok(mut locked_enabled) = state.enabled.lock() {
-        *locked_enabled = enable;
-    }
+    // Serialize native mode changes and resolution saves without holding the
+    // small state mutex across the whole sequence of GUI operations.
+    let _transition_guard = state
+        .transition_lock
+        .lock()
+        .map_err(|error| format!("等待窗口模式切换失败：{error}"))?;
 
     #[cfg(desktop)]
-    if let Some(window) = app_handle.get_webview_window("main") {
+    {
+        let window = app_handle.get_webview_window("main").ok_or_else(|| {
+            let message = "找不到 main 窗口，无法切换桌宠模式".to_string();
+            tracing::error!("{message}");
+            message
+        })?;
+        let currently_enabled = *state
+            .enabled
+            .lock()
+            .map_err(|error| format!("读取桌宠模式状态失败：{error}"))?;
+
         if enable {
-            let scale_val = scale.unwrap_or(1.0);
+            let target_size = pet_window_size(scale)?;
+            // Clear any stale click-through state before leaving fullscreen or
+            // changing styles so a failed transition remains recoverable.
+            window
+                .set_ignore_cursor_events(false)
+                .map_err(|error| window_operation_error("重置鼠标事件", error))?;
+            let snapshot = if currently_enabled {
+                None
+            } else {
+                Some(capture_normal_window_snapshot(&window)?)
+            };
 
-            // Calculate sizes based on pet dimensions: BASE_AVATAR_SIZE = 240, CHAT_BASE_H = 45, DIALOG_BASE_H = 75
-            // But let's check: GameRoleAvatar frame size is Math.round(210 * scale). Let's use standard pet size:
-            // Width: 240 * scale, Height: (240 + 75 + 45) * scale = 360 * scale.
-            let width = (240.0 * scale_val) as u32;
-            let height = ((240.0 + 75.0 + 45.0) * scale_val) as u32;
+            let enter_result = (|| -> Result<(), String> {
+                if snapshot.is_some() {
+                    window_geometry::clear_window_minimum_size(&window)?;
+                    window
+                        .set_skip_taskbar(true)
+                        .map_err(|error| window_operation_error("隐藏任务栏图标", error))?;
+                    window
+                        .set_always_on_top(true)
+                        .map_err(|error| window_operation_error("设置窗口置顶", error))?;
+                    window
+                        .set_resizable(false)
+                        .map_err(|error| window_operation_error("禁止调整尺寸", error))?;
+                    window
+                        .set_maximizable(false)
+                        .map_err(|error| window_operation_error("禁止窗口最大化", error))?;
+                    window
+                        .set_decorations(false)
+                        .map_err(|error| window_operation_error("隐藏窗口装饰", error))?;
+                } else {
+                    // Scale changes while already in pet mode must not inherit
+                    // a restored main-window minimum constraint.
+                    window_geometry::clear_window_minimum_size(&window)?;
+                }
 
-            let _ = window.set_skip_taskbar(true);
-            let _ = window.set_always_on_top(true);
-            let _ = window.set_resizable(false);
-            let _ = window.set_decorations(false);
-            let _ = window.set_size(LogicalSize::new(width, height));
+                let plan = window_geometry::plan_borderless_window_size(
+                    &window,
+                    target_size,
+                    WindowDimensions::new(1, 1),
+                )?;
+                window_geometry::apply_window_size_plan(
+                    &window,
+                    &plan,
+                    snapshot.as_ref().map(|snapshot| snapshot.position),
+                )?;
+                tracing::info!(
+                    width = plan.applied.width,
+                    height = plan.applied.height,
+                    mode_changed = !currently_enabled,
+                    adjusted = plan.adjusted,
+                    "桌宠窗口尺寸与原生状态已应用"
+                );
+                Ok(())
+            })();
+
+            if let Err(error) = enter_result {
+                if let Some(snapshot) = snapshot.as_ref() {
+                    let rollback_errors = restore_snapshot_best_effort(&window, snapshot);
+                    if !rollback_errors.is_empty() {
+                        tracing::error!(
+                            "进入桌宠失败后的窗口回滚不完整：{}",
+                            rollback_errors.join("；")
+                        );
+                    }
+                    if let Ok(mut enabled) = state.enabled.lock() {
+                        *enabled = false;
+                    }
+                }
+                return Err(error);
+            }
+
+            if let Some(snapshot) = snapshot {
+                let commit_result = (|| -> Result<(), String> {
+                    *state
+                        .normal_window
+                        .lock()
+                        .map_err(|error| format!("保存主窗口状态失败：{error}"))? =
+                        Some(snapshot.clone());
+                    *state
+                        .enabled
+                        .lock()
+                        .map_err(|error| format!("提交桌宠模式状态失败：{error}"))? = true;
+                    Ok(())
+                })();
+                if let Err(error) = commit_result {
+                    let rollback_errors = restore_snapshot_best_effort(&window, &snapshot);
+                    if let Ok(mut normal_window) = state.normal_window.lock() {
+                        *normal_window = None;
+                    }
+                    if let Ok(mut enabled) = state.enabled.lock() {
+                        *enabled = false;
+                    }
+                    return Err(if rollback_errors.is_empty() {
+                        error
+                    } else {
+                        format!("{error}；窗口回滚不完整：{}", rollback_errors.join("；"))
+                    });
+                }
+            } else {
+                *state
+                    .enabled
+                    .lock()
+                    .map_err(|error| format!("提交桌宠模式状态失败：{error}"))? = true;
+            }
         } else {
-            // Restore normal window
-            let _ = window.set_skip_taskbar(false);
-            let _ = window.set_always_on_top(false);
-            let _ = window.set_resizable(true);
-            let _ = window.set_decorations(true);
-            let _ = window.set_size(LogicalSize::new(1500, 800));
-            // Center the window on screen so it doesn't expand from the pet's top-left corner
-            let _ = window.center();
-            // Always restore cursor ignore to false
-            let _ = window.set_ignore_cursor_events(false);
+            // Disable hit testing immediately.  Even if a later cosmetic or
+            // positioning operation fails, the user must never be left with a
+            // click-through normal window.
+            *state
+                .enabled
+                .lock()
+                .map_err(|error| format!("更新桌宠模式状态失败：{error}"))? = false;
+
+            let snapshot = state
+                .normal_window
+                .lock()
+                .map_err(|error| format!("读取主窗口快照失败：{error}"))?
+                .clone();
+            let mut errors = Vec::new();
+
+            record_window_result(
+                &mut errors,
+                "恢复鼠标事件",
+                window.set_ignore_cursor_events(false),
+            );
+            record_window_result(
+                &mut errors,
+                "恢复任务栏图标",
+                window.set_skip_taskbar(false),
+            );
+            record_window_result(&mut errors, "取消窗口置顶", window.set_always_on_top(false));
+            record_window_result(&mut errors, "恢复尺寸调整", window.set_resizable(true));
+            record_window_result(
+                &mut errors,
+                "恢复可最大化状态",
+                window.set_maximizable(
+                    snapshot
+                        .as_ref()
+                        .map(|snapshot| snapshot.maximizable)
+                        .unwrap_or(true),
+                ),
+            );
+            record_window_result(&mut errors, "恢复窗口装饰", window.set_decorations(true));
+
+            match configured_window_plan(&app_handle, &window) {
+                Ok((plan, repair_preset)) => {
+                    match window_geometry::apply_main_window_plan(&window, &plan, None) {
+                        Err(error) => errors.push(error),
+                        Ok(applied) => {
+                            let final_plan = applied.plan;
+                            if repair_preset.is_some() || final_plan.adjusted {
+                                if let Err(error) = config::persist_main_window_size(
+                                    &app_handle,
+                                    final_plan.applied,
+                                    repair_preset,
+                                ) {
+                                    tracing::warn!(
+                                        "主窗口已安全恢复，但修复持久化配置失败：{error}"
+                                    );
+                                }
+                            }
+                            tracing::info!(
+                                width = final_plan.applied.width,
+                                height = final_plan.applied.height,
+                                adjusted = final_plan.adjusted,
+                                "已恢复安全主窗口尺寸"
+                            );
+                        }
+                    }
+                }
+                Err(error) => errors.push(error),
+            }
+
+            if let Some(snapshot) = snapshot.as_ref() {
+                if snapshot.maximized {
+                    record_window_result(&mut errors, "恢复最大化状态", window.maximize());
+                }
+                if snapshot.fullscreen {
+                    record_window_result(&mut errors, "恢复全屏状态", window.set_fullscreen(true));
+                }
+            }
+
+            if errors.is_empty() {
+                *state
+                    .normal_window
+                    .lock()
+                    .map_err(|error| format!("清理主窗口快照失败：{error}"))? = None;
+            } else {
+                let message = format!("恢复主窗口时发生错误：{}", errors.join("；"));
+                tracing::error!("{message}");
+                return Err(message);
+            }
         }
+
+        tracing::info!(enable, "桌宠窗口模式已应用");
     }
+
+    #[cfg(not(desktop))]
+    {
+        *state
+            .enabled
+            .lock()
+            .map_err(|error| format!("更新桌宠模式状态失败：{error}"))? = enable;
+    }
+
     Ok(())
 }

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -642,6 +642,24 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         description: "MAX_PROACTIVE_TIMES — 在用户响应之前，能主动对话的次数".to_string(),
                         setting_type: "text".to_string(),
                     },
+                    ConfigSetting {
+                        key: proactive::keys::PROACTIVE_INTERVAL_SECS.to_string(),
+                        value: read_setting(app, proactive::keys::PROACTIVE_INTERVAL_SECS, "10"),
+                        description: "PROACTIVE_INTERVAL_SECS — 主动对话轮询间隔（秒，默认 10，最小 2）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::INTEREST_TRIGGER_THRESHOLD.to_string(),
+                        value: read_setting(app, proactive::keys::INTEREST_TRIGGER_THRESHOLD, "30.0"),
+                        description: "INTEREST_TRIGGER_THRESHOLD — 兴趣度触发阈值（默认 30，越低越容易被触发）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::INTEREST_DECAY_STEP.to_string(),
+                        value: read_setting(app, proactive::keys::INTEREST_DECAY_STEP, "15.0"),
+                        description: "INTEREST_DECAY_STEP — 每次主动对话后兴趣度上限衰减量（默认 15，设为 0 则不衰减）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
                 ],
             },
         );
@@ -652,6 +670,12 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
             Subcategory {
                 description: "主动对话时调用的 Vision LLM 视觉分析模型以及截图分析设置".to_string(),
                 settings: vec![
+                    ConfigSetting {
+                        key: proactive::keys::VD_FOLLOW_CHAT_MODEL.to_string(),
+                        value: read_setting(app, proactive::keys::VD_FOLLOW_CHAT_MODEL, "true"),
+                        description: "VD_FOLLOW_CHAT_MODEL — 跟随当前对话模型；若当前是不可关闭长思考的模型，视觉识别也会明显变慢。低延迟建议关闭并配置独立轻量视觉模型".to_string(),
+                        setting_type: "bool".to_string(),
+                    },
                     ConfigSetting {
                         key: proactive::keys::VD_API_KEY.to_string(),
                         value: read_setting(app, proactive::keys::VD_API_KEY, ""),
@@ -670,8 +694,10 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                     },
                     ConfigSetting {
                         key: proactive::keys::VD_MODEL.to_string(),
-                        value: read_setting(app, proactive::keys::VD_MODEL, "qwen3.5-plus"),
-                        description: "VD_MODEL — 视觉模型型号".to_string(),
+                        value: read_setting(app, proactive::keys::VD_MODEL, "qwen3-vl-flash"),
+                        description:
+                            "VD_MODEL — 独立视觉模型型号（低延迟推荐非思考型 VL/Flash，例如 qwen3-vl-flash）"
+                                .to_string(),
                         setting_type: "text".to_string(),
                     },
                     ConfigSetting {
@@ -689,6 +715,14 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "SCREEN_WEIGHT — 视觉模式触发权重（越大越容易偷看屏幕聊天，默认 30）"
                                 .to_string(),
                         setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::VISUAL_PERCEPTION_PRIORITY.to_string(),
+                        value: read_setting(app, proactive::keys::VISUAL_PERCEPTION_PRIORITY, "false"),
+                        description:
+                            "VISUAL_PERCEPTION_PRIORITY — 视觉理解优先模式（开启后每次主动回复优先看屏幕，失败才找话题）"
+                                .to_string(),
+                        setting_type: "bool".to_string(),
                     },
                 ],
             },

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use tauri::{AppHandle, Wry};
+use tauri::{AppHandle, Manager, Wry};
 use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_store::{Store, StoreExt};
 
@@ -17,6 +17,9 @@ use crate::ai_service::llm::provider_config::{
     save_role_assignment, LlmProviderConfig, LlmProvidersResponse,
 };
 use crate::config::tts::TtsConfig;
+use crate::window_geometry::{
+    self, WindowDimensions, WindowSizePlan, MAIN_WINDOW_DEFAULT_HEIGHT, MAIN_WINDOW_DEFAULT_WIDTH,
+};
 
 // ========== 字段键（对标 Python .env） ==========
 pub mod keys {
@@ -52,6 +55,11 @@ pub mod keys {
     // 对话增强
     pub const ENABLE_TIME_SENSE: &str = "features.enable_time_sense";
     pub const ENABLE_EMOTION_CLASSIFIER: &str = "features.enable_emotion_classifier";
+
+    // 界面设置
+    pub const WINDOW_WIDTH: &str = "ui.window_width";
+    pub const WINDOW_HEIGHT: &str = "ui.window_height";
+    pub const WINDOW_RESOLUTION_PRESET: &str = "ui.window_resolution_preset";
 
     // 功能开关
     pub const USE_PERSISTENT_MEMORY: &str = "features.use_persistent_memory";
@@ -280,6 +288,8 @@ pub struct ConfigSetting {
     pub description: String,
     #[serde(rename = "type")]
     pub setting_type: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub options: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -295,7 +305,7 @@ pub struct Category {
 
 pub type ConfigTree = BTreeMap<String, Category>;
 
-fn read_setting(app: &AppHandle, key: &str, default: &str) -> String {
+pub fn read_setting(app: &AppHandle, key: &str, default: &str) -> String {
     settings_store(app)
         .ok()
         .and_then(|store| {
@@ -331,6 +341,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "LLM_OUTPUT_SEC_LANG — 是否允许输出第二语言（关闭后仅输出中文）"
                                 .to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: keys::CONSUMERS.to_string(),
@@ -338,6 +349,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         description: "COMSUMERS — 并发消费者数量（增大可加速流式输出，默认 3）"
                             .to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: keys::LLM_NO_EMOTION_LIMIT.to_string(),
@@ -346,6 +358,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "NO_EMOTION_LIMIT_PROMPT — 解除 emotion 数量限制（可能增加 token 消耗）"
                                 .to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                 ],
             },
@@ -373,6 +386,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                     description: "ENABLE_TRANSLATE — 启用 AI 翻译（将中文对话翻译为第二语言）"
                         .to_string(),
                     setting_type: "bool".to_string(),
+                    options: vec![],
                 }],
             },
         );
@@ -400,12 +414,14 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         value: read_setting(app, keys::ENABLE_TIME_SENSE, "true"),
                         description: "USE_TIME_SENSE — 启用时间感知（根据上下文时间添加系统提醒）".to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: keys::ENABLE_EMOTION_CLASSIFIER.to_string(),
                         value: read_setting(app, keys::ENABLE_EMOTION_CLASSIFIER, "true"),
                         description: "ENABLE_EMOTION_CLASSIFIER — 启用情感分类器（ONNX 模型，用于自动标注对话 emotion）".to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                 ],
             },
@@ -424,6 +440,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "USE_PERSISTENT_MEMORY — 开启后记忆会自动压缩，减少 token 消耗"
                                 .to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: keys::MEMORY_UPDATE_INTERVAL.to_string(),
@@ -431,6 +448,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         description: "MEMORY_UPDATE_INTERVAL — 触发记忆摘要的新消息数（默认 250）"
                             .to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: keys::MEMORY_RECENT_WINDOW.to_string(),
@@ -438,6 +456,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         description: "MEMORY_RECENT_WINDOW — 摘要时保留的最近消息数（默认 30）"
                             .to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                 ],
             },
@@ -465,18 +484,21 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         value: read_setting(app, keys::AUTO_START_TTS_SOFTWARE, "false"),
                         description: "启动游戏时自动启动 TTS 软件".to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: keys::TTS_SOFTWARE_PATH.to_string(),
                         value: read_setting(app, keys::TTS_SOFTWARE_PATH, ""),
                         description: "TTS 软件的可执行文件路径".to_string(),
                         setting_type: "path".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: keys::VOICE_CHECK.to_string(),
                         value: read_setting(app, keys::VOICE_CHECK, "false"),
                         description: "启动时检查语音模型是否就绪".to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                 ],
             },
@@ -492,72 +514,84 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         value: read_setting(app, tts::keys::SIMPLE_VITS_API_URL, "http://127.0.0.1:23456"),
                         description: "Simple-Vits-API 地址（VITS 适配器）".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: tts::keys::BV2_API_URL.to_string(),
                         value: read_setting(app, tts::keys::BV2_API_URL, "http://127.0.0.1:6006"),
                         description: "Simple-Vits-API 地址（Bert-Vits2 适配器）".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: tts::keys::GSV_API_URL.to_string(),
                         value: read_setting(app, tts::keys::GSV_API_URL, "http://127.0.0.1:9880"),
                         description: "GPT-SoVITS API 地址".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: tts::keys::SBV2_API_URL.to_string(),
                         value: read_setting(app, tts::keys::SBV2_API_URL, "http://127.0.0.1:5000"),
                         description: "Style-Bert-Vits2 本地服务地址".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: tts::keys::SBV2API_API_URL.to_string(),
                         value: read_setting(app, tts::keys::SBV2API_API_URL, "http://localhost:3000"),
                         description: "SBV2 API 服务地址".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: tts::keys::AIVIS_API_URL.to_string(),
                         value: read_setting(app, tts::keys::AIVIS_API_URL, "https://api.aivis-project.com/v1"),
                         description: "AIVIS 云 API 地址".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: tts::keys::AIVIS_API_KEY.to_string(),
                         value: read_setting(app, tts::keys::AIVIS_API_KEY, ""),
                         description: "AIVIS API 密钥（原环境变量 AIVIS_API_KRY）".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: tts::keys::INDEXTTS_API_URL.to_string(),
                         value: read_setting(app, tts::keys::INDEXTTS_API_URL, "http://127.0.0.1:23467/voice/indextts/presets"),
                         description: "IndexTTS2 API 地址".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: tts::keys::OPENTTS_API_URL.to_string(),
                         value: read_setting(app, tts::keys::OPENTTS_API_URL, "https://api.siliconflow.cn/v1"),
                         description: "OpenTTS API 地址（硅基流动）".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: tts::keys::OPENTTS_API_KEY.to_string(),
                         value: read_setting(app, tts::keys::OPENTTS_API_KEY, ""),
                         description: "OpenTTS API 密钥".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: tts::keys::OPENTTS_MODEL.to_string(),
                         value: read_setting(app, tts::keys::OPENTTS_MODEL, "FunAudioLLM/CosyVoice2-0.5B"),
                         description: "OpenTTS 模型名称".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: tts::keys::OPENTTS_VOICE.to_string(),
                         value: read_setting(app, tts::keys::OPENTTS_VOICE, "speech:pai:7s86w73x9i:vkgcswgqicskwpdwevri"),
                         description: "OpenTTS voice / 音色标识".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                 ],
             },
@@ -575,6 +609,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         value: read_setting(app, tts::keys::TTS_AUDIO_FORMAT, "wav"),
                         description: "音频文件格式（wav / mp3 / flac / ogg 等）".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     // 语音语言改为角色级配置，全局入口隐藏
                     // ConfigSetting {
@@ -582,6 +617,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                     //     value: read_setting(app, tts::keys::VOICE_LANG, "ja"),
                     //     description: "语音合成语言（ja / zh / auto）".to_string(),
                     //     setting_type: "text".to_string(),
+                    //     options: vec![],
                     // },
                 ],
             },
@@ -608,7 +644,8 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                     value: read_setting(app, keys::GITHUB_TOKEN, ""),
                     description: "填入你的 GitHub Token（无需任何权限，仅用于调用 GraphQL API）。留空使用 REST API，无法获取独立 upvote 数（会用 👍 表情数代替）。Token 创建地址：https://github.com/settings/tokens".to_string(),
                     setting_type: "text".to_string(),
-                }],
+                        options: vec![],
+                    }],
             },
         );
 
@@ -616,6 +653,55 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
             "创意工坊".to_string(),
             Category {
                 subcategories: workshop_subs,
+            },
+        );
+    }
+
+    // ===== 界面设置 =====
+    {
+        let mut ui_subs = BTreeMap::new();
+
+        ui_subs.insert(
+            "窗口".to_string(),
+            Subcategory {
+                description: "主窗口内容区尺寸（逻辑像素；保存后立即安全应用）".to_string(),
+                settings: vec![
+                    ConfigSetting {
+                        key: keys::WINDOW_RESOLUTION_PRESET.to_string(),
+                        value: read_setting(app, keys::WINDOW_RESOLUTION_PRESET, "default"),
+                        description: "尺寸预设".to_string(),
+                        setting_type: "select".to_string(),
+                        options: vec![
+                            "default".to_string(),
+                            "fit".to_string(),
+                            "1920x1080".to_string(),
+                            "2560x1440".to_string(),
+                            "1280x720".to_string(),
+                            "custom".to_string(),
+                        ],
+                    },
+                    ConfigSetting {
+                        key: keys::WINDOW_WIDTH.to_string(),
+                        value: read_setting(app, keys::WINDOW_WIDTH, "1500"),
+                        description: "内容区宽度（逻辑像素，默认 1500）".to_string(),
+                        setting_type: "text".to_string(),
+                        options: vec![],
+                    },
+                    ConfigSetting {
+                        key: keys::WINDOW_HEIGHT.to_string(),
+                        value: read_setting(app, keys::WINDOW_HEIGHT, "800"),
+                        description: "内容区高度（逻辑像素，默认 800）".to_string(),
+                        setting_type: "text".to_string(),
+                        options: vec![],
+                    },
+                ],
+            },
+        );
+
+        tree.insert(
+            "界面设置".to_string(),
+            Category {
+                subcategories: ui_subs,
             },
         );
     }
@@ -635,30 +721,35 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         value: read_setting(app, proactive::keys::ENABLE_PROACTIVE_SYSTEM, "false"),
                         description: "ENABLE_PROACTIVE_SYSTEM — 是否启用主动对话系统".to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::MAX_PROACTIVE_TIMES.to_string(),
                         value: read_setting(app, proactive::keys::MAX_PROACTIVE_TIMES, "3"),
                         description: "MAX_PROACTIVE_TIMES — 在用户响应之前，能主动对话的次数".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::PROACTIVE_INTERVAL_SECS.to_string(),
                         value: read_setting(app, proactive::keys::PROACTIVE_INTERVAL_SECS, "10"),
                         description: "PROACTIVE_INTERVAL_SECS — 主动对话轮询间隔（秒，默认 10，最小 2）".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::INTEREST_TRIGGER_THRESHOLD.to_string(),
                         value: read_setting(app, proactive::keys::INTEREST_TRIGGER_THRESHOLD, "30.0"),
                         description: "INTEREST_TRIGGER_THRESHOLD — 兴趣度触发阈值（默认 30，越低越容易被触发）".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::INTEREST_DECAY_STEP.to_string(),
                         value: read_setting(app, proactive::keys::INTEREST_DECAY_STEP, "15.0"),
                         description: "INTEREST_DECAY_STEP — 每次主动对话后兴趣度上限衰减量（默认 15，设为 0 则不衰减）".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                 ],
             },
@@ -675,12 +766,14 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         value: read_setting(app, proactive::keys::VD_FOLLOW_CHAT_MODEL, "true"),
                         description: "VD_FOLLOW_CHAT_MODEL — 跟随当前对话模型；若当前是不可关闭长思考的模型，视觉识别也会明显变慢。低延迟建议关闭并配置独立轻量视觉模型".to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::VD_API_KEY.to_string(),
                         value: read_setting(app, proactive::keys::VD_API_KEY, ""),
                         description: "VD_API_KEY — 视觉模型 API Key".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::VD_BASE_URL.to_string(),
@@ -691,6 +784,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         ),
                         description: "VD_BASE_URL — 视觉模型 API Base URL".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::VD_MODEL.to_string(),
@@ -699,6 +793,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "VD_MODEL — 独立视觉模型型号（低延迟推荐非思考型 VL/Flash，例如 qwen3-vl-flash）"
                                 .to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::ENABLE_VISUAL_PRECEPTION.to_string(),
@@ -707,6 +802,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "ENABLE_VISUAL_PRECEPTION — 是否允许主动视觉感知桌面画面（偷看屏幕）"
                                 .to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::SCREEN_WEIGHT.to_string(),
@@ -715,6 +811,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "SCREEN_WEIGHT — 视觉模式触发权重（越大越容易偷看屏幕聊天，默认 30）"
                                 .to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::VISUAL_PERCEPTION_PRIORITY.to_string(),
@@ -723,6 +820,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "VISUAL_PERCEPTION_PRIORITY — 视觉理解优先模式（开启后每次主动回复优先看屏幕，失败才找话题）"
                                 .to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                 ],
             },
@@ -739,12 +837,14 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         value: read_setting(app, proactive::keys::ENABLE_TOPIC_CREATER, "true"),
                         description: "ENABLE_TOPIC_CREATER — 允许自主寻找并开启新话题".to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::TOPIC_WEIGHT.to_string(),
                         value: read_setting(app, proactive::keys::TOPIC_WEIGHT, "60.0"),
                         description: "TOPIC_WEIGHT — 随机话题触发权重（默认 60）".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::ENABLE_TODO_PRECEPTION.to_string(),
@@ -753,12 +853,14 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "ENABLE_TODO_PRECEPTION — 允许在闲暇时自动读取未完成 TODO 并温和提醒"
                                 .to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::TODO_WEIGHT.to_string(),
                         value: read_setting(app, proactive::keys::TODO_WEIGHT, "10.0"),
                         description: "TODO_WEIGHT — TODO 提醒触发权重（默认 10）".to_string(),
                         setting_type: "text".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::ENABLE_SCHEDULE_REMINDER.to_string(),
@@ -766,6 +868,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         description: "ENABLE_SCHEDULE_REMINDER — 启用强日程日程报时弹窗提醒"
                             .to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                     ConfigSetting {
                         key: proactive::keys::ENABLE_IMPORTANT_DAY_REMINDER.to_string(),
@@ -778,6 +881,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "ENABLE_IMPORTANT_DAY_REMINDER — 启用重要节日与特殊日子暖心提醒"
                                 .to_string(),
                         setting_type: "bool".to_string(),
+                        options: vec![],
                     },
                 ],
             },
@@ -796,38 +900,318 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
 
 // ========== Tauri 命令 ==========
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowSaveResult {
+    pub status: String,
+    pub requested: WindowDimensions,
+    pub applied: WindowDimensions,
+    pub adjusted: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SaveSettingsResult {
+    pub status: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window: Option<WindowSaveResult>,
+}
+
+fn string_to_json_value(value: &str) -> JsonValue {
+    if value == "true" {
+        JsonValue::Bool(true)
+    } else if value == "false" {
+        JsonValue::Bool(false)
+    } else if let Ok(number) = value.parse::<i64>() {
+        JsonValue::Number(number.into())
+    } else if let Ok(number) = value.parse::<f64>() {
+        serde_json::Number::from_f64(number)
+            .map(JsonValue::Number)
+            .unwrap_or_else(|| JsonValue::String(value.to_string()))
+    } else {
+        JsonValue::String(value.to_string())
+    }
+}
+
+fn restore_store_values(
+    store: &Arc<Store<Wry>>,
+    previous_values: &[(String, Option<JsonValue>)],
+) -> Result<(), String> {
+    for (key, previous) in previous_values {
+        match previous {
+            Some(value) => store.set(key.clone(), value.clone()),
+            None => {
+                store.delete(key);
+            }
+        }
+    }
+    store
+        .save()
+        .map_err(|error| format!("回滚配置存储失败：{error}"))
+}
+
+pub(crate) fn persist_main_window_size(
+    app: &AppHandle,
+    dimensions: WindowDimensions,
+    preset: Option<&str>,
+) -> Result<(), String> {
+    let store = settings_store(app).map_err(|error| error.to_string())?;
+    store.set(
+        keys::WINDOW_WIDTH,
+        JsonValue::Number(dimensions.width.into()),
+    );
+    store.set(
+        keys::WINDOW_HEIGHT,
+        JsonValue::Number(dimensions.height.into()),
+    );
+    if let Some(preset) = preset {
+        store.set(
+            keys::WINDOW_RESOLUTION_PRESET,
+            JsonValue::String(preset.to_string()),
+        );
+    }
+    store.save().map_err(|error| error.to_string())
+}
+
+fn resolve_window_plan(
+    app: &AppHandle,
+    window: &tauri::WebviewWindow<Wry>,
+    values: &mut BTreeMap<String, String>,
+) -> Result<WindowSizePlan, String> {
+    let preset = values
+        .get(keys::WINDOW_RESOLUTION_PRESET)
+        .map(String::as_str);
+
+    let requested = match preset {
+        Some("default") => {
+            WindowDimensions::new(MAIN_WINDOW_DEFAULT_WIDTH, MAIN_WINDOW_DEFAULT_HEIGHT)
+        }
+        Some("fit") => window_geometry::recommended_main_window_size(window)?,
+        Some("1920x1080") => WindowDimensions::new(1920, 1080),
+        Some("2560x1440") => WindowDimensions::new(2560, 1440),
+        Some("1280x720") => WindowDimensions::new(1280, 720),
+        Some("custom") | None => {
+            let width_raw = values.get(keys::WINDOW_WIDTH).cloned().unwrap_or_else(|| {
+                read_setting(
+                    app,
+                    keys::WINDOW_WIDTH,
+                    &MAIN_WINDOW_DEFAULT_WIDTH.to_string(),
+                )
+            });
+            let height_raw = values.get(keys::WINDOW_HEIGHT).cloned().unwrap_or_else(|| {
+                read_setting(
+                    app,
+                    keys::WINDOW_HEIGHT,
+                    &MAIN_WINDOW_DEFAULT_HEIGHT.to_string(),
+                )
+            });
+            window_geometry::parse_main_window_size(&width_raw, &height_raw)?
+        }
+        Some(other) => return Err(format!("未知的窗口尺寸预设：{other}")),
+    };
+
+    let plan = window_geometry::plan_main_window_size(window, requested)?;
+    // Persist the safe effective size, not an impossible off-screen request.
+    values.insert(
+        keys::WINDOW_WIDTH.to_string(),
+        plan.applied.width.to_string(),
+    );
+    values.insert(
+        keys::WINDOW_HEIGHT.to_string(),
+        plan.applied.height.to_string(),
+    );
+    Ok(plan)
+}
+
 #[tauri::command]
 pub fn get_settings_tree(app: AppHandle) -> ConfigTree {
     build_config_tree(&app)
 }
 
 #[tauri::command]
-pub fn save_settings(app: AppHandle, values: BTreeMap<String, String>) -> Result<String, String> {
+pub fn save_settings(
+    app: AppHandle,
+    state: tauri::State<'_, crate::api::pet::HitTestState>,
+    mut values: BTreeMap<String, String>,
+) -> Result<SaveSettingsResult, String> {
     let store = settings_store(&app).map_err(|e| e.to_string())?;
 
+    let has_window_values = values.contains_key(keys::WINDOW_RESOLUTION_PRESET)
+        || values.contains_key(keys::WINDOW_WIDTH)
+        || values.contains_key(keys::WINDOW_HEIGHT);
+
+    // Serialize main-window saves with pet-mode transitions.  Unrelated
+    // settings do not need to wait on native window operations.
+    let _window_transition = if has_window_values {
+        Some(
+            state
+                .transition_lock
+                .lock()
+                .map_err(|error| format!("等待窗口模式切换失败：{error}"))?,
+        )
+    } else {
+        None
+    };
+
+    let main_window = if has_window_values {
+        Some(
+            app.get_webview_window("main")
+                .ok_or_else(|| "找不到 main 窗口，无法校验并应用窗口尺寸".to_string())?,
+        )
+    } else {
+        None
+    };
+
+    let target_window_plan = if let Some(window) = main_window.as_ref() {
+        Some(
+            resolve_window_plan(&app, window, &mut values).map_err(|message| {
+                tracing::warn!("拒绝保存无效窗口尺寸：{message}");
+                message
+            })?,
+        )
+    } else {
+        None
+    };
+
+    // Read the mode before mutating the store so a poisoned state lock cannot
+    // leave a successfully written configuration with no corresponding result.
+    let pet_mode_enabled = if target_window_plan.is_some() {
+        Some(
+            *state
+                .enabled
+                .lock()
+                .map_err(|error| format!("读取桌宠模式状态失败：{error}"))?,
+        )
+    } else {
+        None
+    };
+
+    let previous_values: Vec<_> = values
+        .keys()
+        .map(|key| (key.clone(), store.get(key)))
+        .collect();
+
     for (key, value) in &values {
-        let json_value = if value == "true" {
-            JsonValue::Bool(true)
-        } else if value == "false" {
-            JsonValue::Bool(false)
-        } else if let Ok(n) = value.parse::<i64>() {
-            JsonValue::Number(n.into())
-        } else if let Ok(n) = value.parse::<f64>() {
-            // 浮点数也存为 Number（serde_json 内部会区分）
-            if let Some(f) = serde_json::Number::from_f64(n) {
-                JsonValue::Number(f)
-            } else {
-                JsonValue::String(value.clone())
-            }
-        } else {
-            JsonValue::String(value.clone())
-        };
-        store.set(key.clone(), json_value);
+        store.set(key.clone(), string_to_json_value(value));
     }
 
-    store.save().map_err(|e| e.to_string())?;
+    if let Err(error) = store.save() {
+        let rollback_error = restore_store_values(&store, &previous_values).err();
+        return Err(match rollback_error {
+            Some(rollback_error) => {
+                format!("保存配置失败：{error}；同时无法完整恢复原配置：{rollback_error}")
+            }
+            None => format!("保存配置失败，已恢复原配置：{error}"),
+        });
+    }
 
-    Ok("配置已成功保存并已生效！".to_string())
+    let window_result = if let (Some(window), Some(plan)) =
+        (main_window.as_ref(), target_window_plan.as_ref())
+    {
+        if pet_mode_enabled.unwrap_or(false) {
+            tracing::info!(
+                width = plan.applied.width,
+                height = plan.applied.height,
+                "桌宠模式已开启，主窗口尺寸已保存并延迟到退出桌宠时应用"
+            );
+            Some(WindowSaveResult {
+                status: "deferred".to_string(),
+                requested: plan.requested,
+                applied: plan.applied,
+                adjusted: plan.adjusted,
+            })
+        } else {
+            let applied = match window_geometry::apply_main_window_plan(window, plan, None) {
+                Ok(applied) => applied,
+                Err(error) => {
+                    let rollback_error = restore_store_values(&store, &previous_values).err();
+                    return Err(match rollback_error {
+                        Some(rollback_error) => format!(
+                            "应用窗口尺寸失败：{error}；同时无法完整恢复原配置：{rollback_error}"
+                        ),
+                        None => format!("应用窗口尺寸失败，已恢复原配置：{error}"),
+                    });
+                }
+            };
+            let final_plan = applied.plan;
+
+            // Fullscreen/maximized transitions can change the measured frame or
+            // active DPI.  If the final safe plan differs from the preliminary
+            // one, commit the authoritative size and roll back both native state
+            // and Store if this second persistence step fails.
+            if final_plan.applied != plan.applied {
+                store.set(
+                    keys::WINDOW_WIDTH,
+                    JsonValue::Number(final_plan.applied.width.into()),
+                );
+                store.set(
+                    keys::WINDOW_HEIGHT,
+                    JsonValue::Number(final_plan.applied.height.into()),
+                );
+                if let Err(error) = store.save() {
+                    let store_rollback = restore_store_values(&store, &previous_values).err();
+                    let window_rollback =
+                        window_geometry::rollback_applied_main_window_plan(window, &applied).err();
+                    let mut rollback_errors = Vec::new();
+                    if let Some(error) = store_rollback {
+                        rollback_errors.push(error);
+                    }
+                    if let Some(error) = window_rollback {
+                        rollback_errors.push(error);
+                    }
+                    return Err(if rollback_errors.is_empty() {
+                        format!("保存最终窗口尺寸失败，配置与窗口均已恢复：{error}")
+                    } else {
+                        format!(
+                            "保存最终窗口尺寸失败：{error}；回滚不完整：{}",
+                            rollback_errors.join("；")
+                        )
+                    });
+                }
+            }
+            Some(WindowSaveResult {
+                status: "applied".to_string(),
+                requested: final_plan.requested,
+                applied: final_plan.applied,
+                adjusted: final_plan.adjusted,
+            })
+        }
+    } else {
+        None
+    };
+
+    let message = match window_result.as_ref() {
+        Some(result) if result.status == "deferred" && result.adjusted => format!(
+            "配置已保存；目标尺寸 {}x{} 超出当前显示器工作区，已安全调整为 {}x{}，将在退出桌宠后应用。",
+            result.requested.width,
+            result.requested.height,
+            result.applied.width,
+            result.applied.height
+        ),
+        Some(result) if result.status == "deferred" => format!(
+            "配置已保存；主窗口将在退出桌宠后调整为 {}x{}。",
+            result.applied.width, result.applied.height
+        ),
+        Some(result) if result.adjusted => format!(
+            "目标尺寸 {}x{} 超出当前显示器工作区，已安全调整并应用为 {}x{}。",
+            result.requested.width,
+            result.requested.height,
+            result.applied.width,
+            result.applied.height
+        ),
+        Some(result) => format!(
+            "配置已保存，主窗口内容区已调整为 {}x{}。",
+            result.applied.width, result.applied.height
+        ),
+        None => "配置已成功保存。".to_string(),
+    };
+
+    Ok(SaveSettingsResult {
+        status: "success".to_string(),
+        message,
+        window: window_result,
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/config/proactive.rs
+++ b/src-tauri/src/config/proactive.rs
@@ -5,11 +5,16 @@ use tauri_plugin_store::StoreExt;
 pub mod keys {
     pub const ENABLE_PROACTIVE_SYSTEM: &str = "ENABLE_PROACTIVE_SYSTEM";
     pub const MAX_PROACTIVE_TIMES: &str = "MAX_PROACTIVE_TIMES";
+    pub const PROACTIVE_INTERVAL_SECS: &str = "PROACTIVE_INTERVAL_SECS";
+    pub const INTEREST_TRIGGER_THRESHOLD: &str = "INTEREST_TRIGGER_THRESHOLD";
+    pub const INTEREST_DECAY_STEP: &str = "INTEREST_DECAY_STEP";
+    pub const VD_FOLLOW_CHAT_MODEL: &str = "VD_FOLLOW_CHAT_MODEL";
     pub const VD_API_KEY: &str = "VD_API_KEY";
     pub const VD_BASE_URL: &str = "VD_BASE_URL";
     pub const VD_MODEL: &str = "VD_MODEL";
     pub const ENABLE_VISUAL_PRECEPTION: &str = "ENABLE_VISUAL_PRECEPTION";
     pub const SCREEN_WEIGHT: &str = "SCREEN_WEIGHT";
+    pub const VISUAL_PERCEPTION_PRIORITY: &str = "VISUAL_PERCEPTION_PRIORITY";
     pub const ENABLE_TOPIC_CREATER: &str = "ENABLE_TOPIC_CREATER";
     pub const TOPIC_WEIGHT: &str = "TOPIC_WEIGHT";
     pub const ENABLE_TODO_PRECEPTION: &str = "ENABLE_TODO_PRECEPTION";
@@ -22,11 +27,16 @@ pub mod keys {
 pub struct ProactiveConfig {
     pub enable_proactive_system: bool,
     pub max_proactive_times: i32,
+    pub proactive_interval_secs: u64,
+    pub interest_trigger_threshold: f64,
+    pub interest_decay_step: f64,
+    pub vd_follow_chat_model: bool,
     pub vd_api_key: String,
     pub vd_base_url: String,
     pub vd_model: String,
     pub enable_visual_perception: bool,
     pub screen_weight: f64,
+    pub visual_perception_priority: bool,
     pub enable_topic_creator: bool,
     pub topic_weight: f64,
     pub enable_todo_perception: bool,
@@ -86,21 +96,46 @@ impl ProactiveConfig {
                 .unwrap_or(default)
         };
 
+        let get_bounded_f64 = |key: &str, default: f64, min: f64, max: f64| -> f64 {
+            let value = get_f64(key, default);
+            if value.is_finite() {
+                value.clamp(min, max)
+            } else {
+                tracing::warn!(
+                    "[ProactiveConfig] {} is not finite, falling back to {}",
+                    key,
+                    default
+                );
+                default
+            }
+        };
+
         Self {
             enable_proactive_system: get_bool(keys::ENABLE_PROACTIVE_SYSTEM, false),
-            max_proactive_times: get_i32(keys::MAX_PROACTIVE_TIMES, 3),
+            max_proactive_times: get_i32(keys::MAX_PROACTIVE_TIMES, 3).clamp(0, 1_000),
+            proactive_interval_secs: get_i32(keys::PROACTIVE_INTERVAL_SECS, 10).clamp(2, 3_600)
+                as u64,
+            interest_trigger_threshold: get_bounded_f64(
+                keys::INTEREST_TRIGGER_THRESHOLD,
+                30.0,
+                0.0,
+                95.0,
+            ),
+            interest_decay_step: get_bounded_f64(keys::INTEREST_DECAY_STEP, 15.0, 0.0, 100.0),
+            vd_follow_chat_model: get_bool(keys::VD_FOLLOW_CHAT_MODEL, true),
             vd_api_key: get_string(keys::VD_API_KEY, ""),
             vd_base_url: get_string(
                 keys::VD_BASE_URL,
                 "https://dashscope.aliyuncs.com/compatible-mode/v1",
             ),
-            vd_model: get_string(keys::VD_MODEL, "qwen3.5-plus"),
+            vd_model: get_string(keys::VD_MODEL, "qwen3-vl-flash"),
             enable_visual_perception: get_bool(keys::ENABLE_VISUAL_PRECEPTION, true),
-            screen_weight: get_f64(keys::SCREEN_WEIGHT, 30.0),
+            screen_weight: get_bounded_f64(keys::SCREEN_WEIGHT, 30.0, 0.0, 10_000.0),
+            visual_perception_priority: get_bool(keys::VISUAL_PERCEPTION_PRIORITY, false),
             enable_topic_creator: get_bool(keys::ENABLE_TOPIC_CREATER, true),
-            topic_weight: get_f64(keys::TOPIC_WEIGHT, 60.0),
+            topic_weight: get_bounded_f64(keys::TOPIC_WEIGHT, 60.0, 0.0, 10_000.0),
             enable_todo_perception: get_bool(keys::ENABLE_TODO_PRECEPTION, true),
-            todo_weight: get_f64(keys::TODO_WEIGHT, 10.0),
+            todo_weight: get_bounded_f64(keys::TODO_WEIGHT, 10.0, 0.0, 10_000.0),
             enable_schedule_reminder: get_bool(keys::ENABLE_SCHEDULE_REMINDER, true),
             enable_important_day_reminder: get_bool(keys::ENABLE_IMPORTANT_DAY_REMINDER, true),
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ pub fn run() {
                     vd_api_key: pconfig.vd_api_key,
                     vd_base_url: pconfig.vd_base_url,
                     vd_model: pconfig.vd_model,
+                    provider: "openai".to_string(),
                 };
                 std::sync::Arc::new(tokio::sync::Mutex::new(ScreenAnalyzer::new(sa_config)))
             };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod manifest;
 mod migration;
 mod resource_sync;
 mod utils;
+mod window_geometry;
 
 use std::sync::Arc;
 
@@ -110,6 +111,56 @@ pub fn run() {
             app.manage(lan_sync::LanSyncState::default());
             app.manage(utils::cpu_perf::CpuDetectionCache::new());
 
+            let window = app
+                .get_webview_window("main")
+                .ok_or_else(|| tauri::Error::AssetNotFound("main window not found".to_string()))?;
+
+            // Apply persisted geometry before heavyweight service initialization so a
+            // custom size does not visibly jump after the application has loaded.
+            let width_raw = config::read_setting(
+                app.handle(),
+                config::keys::WINDOW_WIDTH,
+                &window_geometry::MAIN_WINDOW_DEFAULT_WIDTH.to_string(),
+            );
+            let height_raw = config::read_setting(
+                app.handle(),
+                config::keys::WINDOW_HEIGHT,
+                &window_geometry::MAIN_WINDOW_DEFAULT_HEIGHT.to_string(),
+            );
+            let (requested_size, repair_preset) =
+                match window_geometry::parse_main_window_size(&width_raw, &height_raw) {
+                    Ok(size) => (size, None),
+                    Err(error) => {
+                        tracing::warn!("启动时窗口尺寸配置无效，将恢复安全默认值：{error}");
+                        (window_geometry::default_main_window_size(), Some("default"))
+                    }
+                };
+
+            match window_geometry::plan_main_window_size(&window, requested_size) {
+                Ok(plan) => match window_geometry::apply_main_window_plan(&window, &plan, None) {
+                    Ok(applied) => {
+                        let final_plan = applied.plan;
+                        if repair_preset.is_some() || final_plan.adjusted {
+                            if let Err(error) = config::persist_main_window_size(
+                                app.handle(),
+                                final_plan.applied,
+                                repair_preset,
+                            ) {
+                                tracing::warn!(
+                                    "窗口已恢复到安全尺寸，但修复持久化配置失败：{error}"
+                                );
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        tracing::error!("启动时应用主窗口尺寸失败：{error}");
+                    }
+                },
+                Err(error) => {
+                    tracing::error!("启动时无法为当前显示器规划安全窗口尺寸：{error}");
+                }
+            }
+
             let rt = tokio::runtime::Runtime::new()?;
             let (db, ai_service, chat) = rt.block_on(init::initialize(app))?;
 
@@ -201,10 +252,7 @@ pub fn run() {
                 god_agent,
             });
 
-            // Spawn Windows mouse polling click-through loop
-            let window = app
-                .get_webview_window("main")
-                .ok_or_else(|| tauri::Error::AssetNotFound("main window not found".to_string()))?;
+            // Spawn Windows mouse polling click-through loop.
 
             // Set up close handler for exit auto-save
             ai_service::game_system::auto_save::AutoSaveManager::setup_close_handler(

--- a/src-tauri/src/window_geometry.rs
+++ b/src-tauri/src/window_geometry.rs
@@ -1,0 +1,563 @@
+use serde::Serialize;
+use tauri::{LogicalSize, PhysicalPosition, PhysicalSize, WebviewWindow, Wry};
+
+pub const MAIN_WINDOW_DEFAULT_WIDTH: u32 = 1500;
+pub const MAIN_WINDOW_DEFAULT_HEIGHT: u32 = 800;
+pub const MAIN_WINDOW_MIN_WIDTH: u32 = 1024;
+pub const MAIN_WINDOW_MIN_HEIGHT: u32 = 640;
+const MAX_DIMENSION: u32 = 16_384;
+
+// Keep a small safety gap inside the operating system work area.  Main-window
+// frame fallbacks are logical values and are converted per monitor so mixed-DPI
+// displays do not under-reserve title-bar space.
+const EDGE_MARGIN_PHYSICAL: u32 = 8;
+const MIN_MAIN_FRAME_WIDTH_LOGICAL: f64 = 8.0;
+const MIN_MAIN_FRAME_HEIGHT_LOGICAL: f64 = 48.0;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowDimensions {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl WindowDimensions {
+    pub const fn new(width: u32, height: u32) -> Self {
+        Self { width, height }
+    }
+
+    pub fn logical_size(self) -> LogicalSize<f64> {
+        LogicalSize::new(self.width as f64, self.height as f64)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WorkAreaMetrics {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    scale_factor: f64,
+    frame_width: u32,
+    frame_height: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum FramePolicy {
+    CurrentWindow,
+    DecoratedMainWindow,
+    BorderlessWindow,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct WindowSizePlan {
+    pub requested: WindowDimensions,
+    pub applied: WindowDimensions,
+    pub adjusted: bool,
+    metrics: Option<WorkAreaMetrics>,
+}
+
+pub const fn default_main_window_size() -> WindowDimensions {
+    WindowDimensions::new(MAIN_WINDOW_DEFAULT_WIDTH, MAIN_WINDOW_DEFAULT_HEIGHT)
+}
+
+fn parse_dimension(raw: &str, label: &str, minimum: u32) -> Result<u32, String> {
+    let trimmed = raw.trim();
+    let parsed = trimmed
+        .parse::<u32>()
+        .map_err(|error| format!("{label}无效（{trimmed}）：请输入整数，错误为 {error}"))?;
+
+    if !(minimum..=MAX_DIMENSION).contains(&parsed) {
+        return Err(format!(
+            "{label}超出允许范围：{parsed}（允许 {minimum}..={MAX_DIMENSION}，并会进一步受当前显示器工作区限制）"
+        ));
+    }
+
+    Ok(parsed)
+}
+
+pub fn parse_main_window_size(
+    width_raw: &str,
+    height_raw: &str,
+) -> Result<WindowDimensions, String> {
+    Ok(WindowDimensions::new(
+        parse_dimension(width_raw, "主窗口宽度", MAIN_WINDOW_MIN_WIDTH)?,
+        parse_dimension(height_raw, "主窗口高度", MAIN_WINDOW_MIN_HEIGHT)?,
+    ))
+}
+
+fn work_area_metrics(
+    window: &WebviewWindow<Wry>,
+    frame_policy: FramePolicy,
+) -> Result<Option<WorkAreaMetrics>, String> {
+    let monitor = match window.current_monitor() {
+        Ok(Some(monitor)) => Some(monitor),
+        Ok(None) => window
+            .primary_monitor()
+            .map_err(|error| format!("无法读取主显示器信息以校验窗口尺寸：{error}"))?,
+        Err(current_error) => {
+            tracing::warn!("读取当前显示器失败，将尝试主显示器：{current_error}");
+            window.primary_monitor().map_err(|primary_error| {
+                format!(
+                    "无法读取显示器信息以校验窗口尺寸：当前显示器错误 {current_error}；主显示器错误 {primary_error}"
+                )
+            })?
+        }
+    };
+
+    let Some(monitor) = monitor else {
+        return Ok(None);
+    };
+
+    let scale_factor = monitor.scale_factor();
+    if !scale_factor.is_finite() || scale_factor <= 0.0 {
+        return Err(format!("显示器缩放比例无效：{scale_factor}"));
+    }
+
+    let work_area = monitor.work_area();
+    let (measured_frame_width, measured_frame_height) =
+        match (window.inner_size(), window.outer_size()) {
+            (Ok(inner), Ok(outer)) => (
+                outer.width.saturating_sub(inner.width),
+                outer.height.saturating_sub(inner.height),
+            ),
+            _ => (0, 0),
+        };
+    let currently_decorated = window.is_decorated().unwrap_or_else(|error| {
+        tracing::warn!("读取窗口装饰状态失败，将按有边框窗口预留空间：{error}");
+        true
+    });
+    let (frame_width, frame_height) = match frame_policy {
+        FramePolicy::BorderlessWindow => (0, 0),
+        FramePolicy::DecoratedMainWindow => (
+            measured_frame_width.max((MIN_MAIN_FRAME_WIDTH_LOGICAL * scale_factor).ceil() as u32),
+            measured_frame_height.max((MIN_MAIN_FRAME_HEIGHT_LOGICAL * scale_factor).ceil() as u32),
+        ),
+        FramePolicy::CurrentWindow if currently_decorated => (
+            measured_frame_width.max((MIN_MAIN_FRAME_WIDTH_LOGICAL * scale_factor).ceil() as u32),
+            measured_frame_height.max((MIN_MAIN_FRAME_HEIGHT_LOGICAL * scale_factor).ceil() as u32),
+        ),
+        FramePolicy::CurrentWindow => (measured_frame_width, measured_frame_height),
+    };
+
+    Ok(Some(WorkAreaMetrics {
+        x: work_area.position.x,
+        y: work_area.position.y,
+        width: work_area.size.width,
+        height: work_area.size.height,
+        scale_factor,
+        frame_width,
+        frame_height,
+    }))
+}
+
+fn maximum_logical_inner_size(metrics: WorkAreaMetrics) -> WindowDimensions {
+    let horizontal_reserve = metrics
+        .frame_width
+        .saturating_add(EDGE_MARGIN_PHYSICAL.saturating_mul(2));
+    let vertical_reserve = metrics
+        .frame_height
+        .saturating_add(EDGE_MARGIN_PHYSICAL.saturating_mul(2));
+
+    WindowDimensions::new(
+        (metrics.width.saturating_sub(horizontal_reserve) as f64 / metrics.scale_factor)
+            .floor()
+            .max(1.0) as u32,
+        (metrics.height.saturating_sub(vertical_reserve) as f64 / metrics.scale_factor)
+            .floor()
+            .max(1.0) as u32,
+    )
+}
+
+fn clamp_dimensions_to_work_area(
+    requested: WindowDimensions,
+    maximum: WindowDimensions,
+) -> WindowDimensions {
+    WindowDimensions::new(
+        requested.width.min(maximum.width),
+        requested.height.min(maximum.height),
+    )
+}
+
+fn plan_window_size_with_policy(
+    window: &WebviewWindow<Wry>,
+    requested: WindowDimensions,
+    minimum: WindowDimensions,
+    frame_policy: FramePolicy,
+) -> Result<WindowSizePlan, String> {
+    if requested.width < minimum.width || requested.height < minimum.height {
+        return Err(format!(
+            "窗口目标尺寸 {}x{} 低于界面可用下限 {}x{}",
+            requested.width, requested.height, minimum.width, minimum.height
+        ));
+    }
+
+    let metrics = work_area_metrics(window, frame_policy)?;
+    let applied = if let Some(metrics) = metrics {
+        let maximum = maximum_logical_inner_size(metrics);
+        if maximum.width < minimum.width || maximum.height < minimum.height {
+            return Err(format!(
+                "当前显示器可用工作区过小：最多约 {}x{} 逻辑像素，应用至少需要 {}x{}",
+                maximum.width, maximum.height, minimum.width, minimum.height
+            ));
+        }
+        clamp_dimensions_to_work_area(requested, maximum)
+    } else {
+        requested
+    };
+
+    if applied.width < minimum.width || applied.height < minimum.height {
+        return Err(format!(
+            "目标尺寸 {}x{} 适配当前显示器后仅剩 {}x{}，低于界面可用下限 {}x{}",
+            requested.width,
+            requested.height,
+            applied.width,
+            applied.height,
+            minimum.width,
+            minimum.height
+        ));
+    }
+
+    Ok(WindowSizePlan {
+        requested,
+        applied,
+        adjusted: requested != applied,
+        metrics,
+    })
+}
+
+pub fn plan_borderless_window_size(
+    window: &WebviewWindow<Wry>,
+    requested: WindowDimensions,
+    minimum: WindowDimensions,
+) -> Result<WindowSizePlan, String> {
+    plan_window_size_with_policy(window, requested, minimum, FramePolicy::BorderlessWindow)
+}
+
+pub fn plan_main_window_size(
+    window: &WebviewWindow<Wry>,
+    requested: WindowDimensions,
+) -> Result<WindowSizePlan, String> {
+    plan_window_size_with_policy(
+        window,
+        requested,
+        WindowDimensions::new(MAIN_WINDOW_MIN_WIDTH, MAIN_WINDOW_MIN_HEIGHT),
+        FramePolicy::DecoratedMainWindow,
+    )
+}
+
+pub fn recommended_main_window_size(
+    window: &WebviewWindow<Wry>,
+) -> Result<WindowDimensions, String> {
+    let Some(metrics) = work_area_metrics(window, FramePolicy::DecoratedMainWindow)? else {
+        return Ok(default_main_window_size());
+    };
+
+    let maximum = maximum_logical_inner_size(metrics);
+    let box_width = (maximum.width as f64 * 0.9).floor() as u32;
+    let box_height = (maximum.height as f64 * 0.9).floor() as u32;
+    let default_aspect = MAIN_WINDOW_DEFAULT_WIDTH as f64 / MAIN_WINDOW_DEFAULT_HEIGHT as f64;
+
+    let (width, height) = if box_width as f64 / box_height as f64 > default_aspect {
+        (
+            (box_height as f64 * default_aspect).floor() as u32,
+            box_height,
+        )
+    } else {
+        (
+            box_width,
+            (box_width as f64 / default_aspect).floor() as u32,
+        )
+    };
+
+    let requested = WindowDimensions::new(
+        width.max(MAIN_WINDOW_MIN_WIDTH),
+        height.max(MAIN_WINDOW_MIN_HEIGHT),
+    );
+    Ok(plan_main_window_size(window, requested)?.applied)
+}
+
+fn clamp_i64(value: i64, minimum: i64, maximum: i64) -> i64 {
+    value.max(minimum).min(maximum.max(minimum))
+}
+
+pub fn apply_window_size_plan(
+    window: &WebviewWindow<Wry>,
+    plan: &WindowSizePlan,
+    preferred_position: Option<PhysicalPosition<i32>>,
+) -> Result<(), String> {
+    window
+        .set_size(plan.applied.logical_size())
+        .map_err(|error| format!("调整窗口内容区尺寸失败：{error}"))?;
+
+    // Re-read the monitor and real outer size after resizing.  The window may
+    // have crossed into a display with another DPI, and estimates made before
+    // set_size are not authoritative for safe positioning.
+    let metrics = work_area_metrics(window, FramePolicy::CurrentWindow)?.or(plan.metrics);
+    let Some(metrics) = metrics else {
+        return Ok(());
+    };
+
+    let current_position = preferred_position
+        .or_else(|| window.outer_position().ok())
+        .unwrap_or_else(|| PhysicalPosition::new(metrics.x, metrics.y));
+
+    let actual_outer_size = window.outer_size().ok();
+    let outer_width = actual_outer_size.map(|size| size.width).unwrap_or_else(|| {
+        (plan.applied.width as f64 * metrics.scale_factor).round() as u32 + metrics.frame_width
+    });
+    let outer_height = actual_outer_size
+        .map(|size| size.height)
+        .unwrap_or_else(|| {
+            (plan.applied.height as f64 * metrics.scale_factor).round() as u32
+                + metrics.frame_height
+        });
+
+    let min_x = metrics.x as i64 + EDGE_MARGIN_PHYSICAL as i64;
+    let min_y = metrics.y as i64 + EDGE_MARGIN_PHYSICAL as i64;
+    let max_x =
+        metrics.x as i64 + metrics.width as i64 - outer_width as i64 - EDGE_MARGIN_PHYSICAL as i64;
+    let max_y = metrics.y as i64 + metrics.height as i64
+        - outer_height as i64
+        - EDGE_MARGIN_PHYSICAL as i64;
+    let safe_position = PhysicalPosition::new(
+        clamp_i64(current_position.x as i64, min_x, max_x) as i32,
+        clamp_i64(current_position.y as i64, min_y, max_y) as i32,
+    );
+
+    if safe_position != current_position {
+        window.set_position(safe_position).map_err(|error| {
+            format!(
+                "窗口尺寸已调整，但无法将位置安全限制到 ({}, {})：{error}",
+                safe_position.x, safe_position.y
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+pub fn set_main_window_constraints(window: &WebviewWindow<Wry>) -> Result<(), String> {
+    window
+        .set_min_size(Some(LogicalSize::new(
+            MAIN_WINDOW_MIN_WIDTH as f64,
+            MAIN_WINDOW_MIN_HEIGHT as f64,
+        )))
+        .map_err(|error| format!("设置主窗口最小尺寸失败：{error}"))
+}
+
+pub fn clear_window_minimum_size(window: &WebviewWindow<Wry>) -> Result<(), String> {
+    window
+        .set_min_size(None::<LogicalSize<f64>>)
+        .map_err(|error| format!("解除主窗口最小尺寸失败：{error}"))
+}
+
+#[derive(Clone, Debug)]
+struct MainWindowRollbackSnapshot {
+    inner_size: PhysicalSize<u32>,
+    position: PhysicalPosition<i32>,
+    fullscreen: bool,
+    maximized: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct AppliedMainWindowPlan {
+    pub plan: WindowSizePlan,
+    rollback: MainWindowRollbackSnapshot,
+}
+
+fn restore_main_window_snapshot(
+    window: &WebviewWindow<Wry>,
+    snapshot: &MainWindowRollbackSnapshot,
+) -> Result<(), String> {
+    let mut errors = Vec::new();
+
+    if let Err(error) = set_main_window_constraints(window) {
+        errors.push(error);
+    }
+    if let Err(error) = window.set_size(snapshot.inner_size) {
+        errors.push(format!("恢复调整前的窗口尺寸失败：{error}"));
+    }
+    if let Err(error) = window.set_position(snapshot.position) {
+        errors.push(format!("恢复调整前的窗口位置失败：{error}"));
+    }
+    if snapshot.maximized {
+        if let Err(error) = window.maximize() {
+            errors.push(format!("恢复调整前的最大化状态失败：{error}"));
+        }
+    }
+    if snapshot.fullscreen {
+        if let Err(error) = window.set_fullscreen(true) {
+            errors.push(format!("恢复调整前的全屏状态失败：{error}"));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("；"))
+    }
+}
+
+fn leave_display_state_and_capture_normal_bounds(
+    window: &WebviewWindow<Wry>,
+) -> Result<MainWindowRollbackSnapshot, String> {
+    let fullscreen = window
+        .is_fullscreen()
+        .map_err(|error| format!("读取调整前的全屏状态失败：{error}"))?;
+    let maximized = window
+        .is_maximized()
+        .map_err(|error| format!("读取调整前的最大化状态失败：{error}"))?;
+
+    let leave_result = (|| -> Result<(), String> {
+        if fullscreen {
+            window
+                .set_fullscreen(false)
+                .map_err(|error| format!("退出全屏以应用窗口尺寸失败：{error}"))?;
+        }
+        if maximized {
+            window
+                .unmaximize()
+                .map_err(|error| format!("取消最大化以应用窗口尺寸失败：{error}"))?;
+        }
+        Ok(())
+    })();
+
+    if let Err(error) = leave_result {
+        let mut rollback_errors = Vec::new();
+        if maximized {
+            if let Err(rollback_error) = window.maximize() {
+                rollback_errors.push(format!("恢复最大化状态失败：{rollback_error}"));
+            }
+        }
+        if fullscreen {
+            if let Err(rollback_error) = window.set_fullscreen(true) {
+                rollback_errors.push(format!("恢复全屏状态失败：{rollback_error}"));
+            }
+        }
+        return Err(if rollback_errors.is_empty() {
+            error
+        } else {
+            format!(
+                "{error}；窗口状态回滚不完整：{}",
+                rollback_errors.join("；")
+            )
+        });
+    }
+
+    let normal_bounds = (|| -> Result<MainWindowRollbackSnapshot, String> {
+        Ok(MainWindowRollbackSnapshot {
+            inner_size: window
+                .inner_size()
+                .map_err(|error| format!("读取普通窗口恢复尺寸失败：{error}"))?,
+            position: window
+                .outer_position()
+                .map_err(|error| format!("读取普通窗口恢复位置失败：{error}"))?,
+            fullscreen,
+            maximized,
+        })
+    })();
+
+    if normal_bounds.is_err() {
+        let mut state_errors = Vec::new();
+        if maximized {
+            if let Err(error) = window.maximize() {
+                state_errors.push(format!("恢复最大化状态失败：{error}"));
+            }
+        }
+        if fullscreen {
+            if let Err(error) = window.set_fullscreen(true) {
+                state_errors.push(format!("恢复全屏状态失败：{error}"));
+            }
+        }
+        if !state_errors.is_empty() {
+            tracing::error!(
+                "读取普通窗口边界失败后的状态回滚不完整：{}",
+                state_errors.join("；")
+            );
+        }
+    }
+
+    normal_bounds
+}
+
+pub fn apply_main_window_plan(
+    window: &WebviewWindow<Wry>,
+    plan: &WindowSizePlan,
+    preferred_position: Option<PhysicalPosition<i32>>,
+) -> Result<AppliedMainWindowPlan, String> {
+    // Capture normal restore bounds only after leaving fullscreen/maximized;
+    // those states otherwise report screen-sized geometry instead of the real
+    // normal-window bounds.
+    let rollback = leave_display_state_and_capture_normal_bounds(window)?;
+
+    let apply_result = (|| -> Result<WindowSizePlan, String> {
+        set_main_window_constraints(window)?;
+        // Re-plan after leaving fullscreen/maximized so frame, monitor and DPI
+        // measurements describe the state that will actually be resized.
+        let final_plan = plan_main_window_size(window, plan.requested)?;
+        apply_window_size_plan(window, &final_plan, preferred_position)?;
+        Ok(final_plan)
+    })();
+
+    match apply_result {
+        Ok(final_plan) => Ok(AppliedMainWindowPlan {
+            plan: final_plan,
+            rollback,
+        }),
+        Err(error) => match restore_main_window_snapshot(window, &rollback) {
+            Ok(()) => Err(error),
+            Err(rollback_error) => Err(format!("{error}；窗口状态回滚不完整：{rollback_error}")),
+        },
+    }
+}
+
+pub fn rollback_applied_main_window_plan(
+    window: &WebviewWindow<Wry>,
+    applied: &AppliedMainWindowPlan,
+) -> Result<(), String> {
+    restore_main_window_snapshot(window, &applied.rollback)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_integer_main_window_dimensions() {
+        assert_eq!(
+            parse_main_window_size("1500", "800").unwrap(),
+            WindowDimensions::new(1500, 800)
+        );
+        assert!(parse_main_window_size("1500.5", "800").is_err());
+        assert!(parse_main_window_size("1023", "800").is_err());
+        assert!(parse_main_window_size("1500", "639").is_err());
+    }
+
+    #[test]
+    fn clamping_uses_each_available_axis_independently() {
+        assert_eq!(
+            clamp_dimensions_to_work_area(
+                WindowDimensions::new(2560, 1440),
+                WindowDimensions::new(1900, 960),
+            ),
+            WindowDimensions::new(1900, 960)
+        );
+        assert_eq!(
+            clamp_dimensions_to_work_area(
+                WindowDimensions::new(1600, 640),
+                WindowDimensions::new(1500, 900),
+            ),
+            WindowDimensions::new(1500, 640)
+        );
+    }
+
+    #[test]
+    fn fitting_keeps_dimensions_that_already_fit() {
+        let requested = WindowDimensions::new(1500, 800);
+        assert_eq!(
+            clamp_dimensions_to_work_area(requested, WindowDimensions::new(1900, 960)),
+            requested
+        );
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,6 +15,10 @@
         "title": "LingChat",
         "width": 1500,
         "height": 800,
+        "minWidth": 1024,
+        "minHeight": 640,
+        "center": true,
+        "preventOverflow": true,
         "transparent": true,
         "shadow": false
       }


### PR DESCRIPTION
## 范围

本 PR 只处理窗口尺寸、DPI、原生窗口恢复和配置保存的 Rust 后端。

- 将主窗口宽高按逻辑像素内容区处理
- 按活动显示器工作区、DPI、边框和外窗尺寸约束窗口
- 增加窗口几何模块及独立单元测试
- 配置保存返回 applied/deferred 结果并支持失败回滚
- 修复全屏、最大化与桌宠窗口恢复边界

## 规模与依赖

- 依赖先合并 #489，以共享配置结构避免后续合并冲突
- GitHub 页面累计：8 个文件，1618 行新增、67 行删除
- 相对 #489 的本层增量：5 个文件，1482 行新增、56 行删除
- 页面累计新增严格低于 2000 行

## 验证

- `node scripts/prepare-desktop-resources.mjs`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib window_geometry`：3 passed，0 failed
- `git diff --check`