### PR TITLE
feat(window): add resolution controls and sizing helpers

### DIFF
--- a/src/api/services/config.ts
+++ b/src/api/services/config.ts
@@ -7,7 +7,36 @@ export interface ConfigItem {
   key: string
   value: string
   description: string
-  type: 'text' | 'bool' | 'textarea' | 'path'
+  type: 'text' | 'bool' | 'textarea' | 'path' | 'select'
+  options?: string[]
+}
+
+export interface WindowDimensions {
+  width: number
+  height: number
+}
+
+export interface WindowSaveResult {
+  status: 'applied' | 'deferred'
+  requested: WindowDimensions
+  applied: WindowDimensions
+  adjusted: boolean
+}
+
+export interface SaveSettingsResult {
+  status: string
+  message: string
+  window?: WindowSaveResult
+}
+
+const normalizeSaveSettingsResult = (
+  result: string | SaveSettingsResult,
+): SaveSettingsResult => {
+  // 兼容仍返回纯字符串的旧版 Rust 后端。
+  if (typeof result === 'string') {
+    return { status: 'success', message: result }
+  }
+  return result
 }
 
 export async function fetchEnvConfig(): Promise<StructuredConfig> {
@@ -16,8 +45,9 @@ export async function fetchEnvConfig(): Promise<StructuredConfig> {
 
 export async function saveEnvConfig(
   values: Record<string, string>,
-): Promise<string> {
-  return invoke('save_settings', { values })
+): Promise<SaveSettingsResult> {
+  const result = await invoke<string | SaveSettingsResult>('save_settings', { values })
+  return normalizeSaveSettingsResult(result)
 }
 
 export const getEnvConfigByKey = async (key: string): Promise<ConfigItem> => {
@@ -42,10 +72,10 @@ export const getEnvConfigSettings = async (): Promise<StructuredConfig> => {
 
 export const saveEnvConfigSettings = async (
   values: Record<string, string>,
-): Promise<{ status: string; message: string }> => {
+): Promise<SaveSettingsResult> => {
   try {
-    const message = await invoke('save_settings', { values })
-    return { status: 'success', message: message as string }
+    const result = await invoke<string | SaveSettingsResult>('save_settings', { values })
+    return normalizeSaveSettingsResult(result)
   } catch (error) {
     console.error('Error modifying config env settings:', error)
     throw error

--- a/src/components/base/items/SettingItem.vue
+++ b/src/components/base/items/SettingItem.vue
@@ -9,7 +9,7 @@
     <div class="flex align-baseline py-2.5 px-1">
       <Toggle :checked="setting.value.toLowerCase() === 'true'" @change="handleCheckboxChange">
       </Toggle>
-      <p class="text-sm text-gray-300">
+      <p v-if="showInternalKey" class="text-sm text-gray-300">
         {{ setting.key }}
       </p>
     </div>
@@ -22,7 +22,7 @@
       :for="setting.key"
       >{{ setting.description || '支持多行输入' }}</label
     >
-    <p class="text-sm mt-1 mb-2 text-gray-300">
+    <p v-if="showInternalKey" class="text-sm mt-1 mb-2 text-gray-300">
       {{ setting.key }}
     </p>
     <textarea
@@ -33,6 +33,32 @@
     ></textarea>
   </template>
 
+  <!-- Case: 下拉选择 (Select) -->
+  <template v-else-if="setting.type === 'select'">
+    <label
+      class="inline-flex items-center cursor-pointer font-medium text-brand"
+      :for="setting.key"
+      >{{ setting.description || '' }}</label
+    >
+    <p v-if="showInternalKey" class="text-sm mt-1 mb-2 text-gray-300">
+      {{ setting.key }}
+    </p>
+    <select
+      :id="setting.key"
+      v-model="localValue"
+      class="w-full px-3 py-2.5 border rounded-lg text-sm text-white bg-white/10 backdrop-blur-xl backdrop-saturate-150 border-white/10 shadow-glass focus:outline-none focus:border-brand focus:ring-2 focus:ring-brand/20 transition-all duration-200"
+    >
+      <option
+        v-for="opt in setting.options"
+        :key="opt"
+        :value="opt"
+        class="bg-slate-900 text-white"
+      >
+        {{ selectOptionLabel(opt) }}
+      </option>
+    </select>
+  </template>
+
   <!-- Case: 默认文本 (Text Input) -->
   <template v-else>
     <label
@@ -40,7 +66,7 @@
       :for="setting.key"
       >{{ setting.description || '' }}</label
     >
-    <p class="text-sm mt-1 mb-2 text-gray-300">
+    <p v-if="showInternalKey" class="text-sm mt-1 mb-2 text-gray-300">
       {{ setting.key }}
     </p>
     <!-- 如果是 path 类型，添加文件选择按钮 -->
@@ -61,32 +87,79 @@
     </div>
     <div v-else>
       <input
-        type="text"
+        :type="isWindowDimension ? 'number' : 'text'"
         :id="setting.key"
         v-model="localValue"
+        :min="dimensionMin"
+        :step="isWindowDimension ? 1 : undefined"
+        :inputmode="isWindowDimension ? 'numeric' : undefined"
+        :readonly="readonly"
+        :aria-describedby="helperText ? `${setting.key}-help` : undefined"
         class="w-full px-3 py-2.5 border rounded-lg text-sm text-white bg-white/10 backdrop-blur-xl backdrop-saturate-150 border-white/10 shadow-glass focus:outline-none focus:border-brand focus:ring-2 focus:ring-brand/20 transition-all duration-200"
+        :class="{
+          'cursor-not-allowed opacity-70 bg-slate-900/60': readonly,
+        }"
       />
+      <p
+        v-if="helperText"
+        :id="`${setting.key}-help`"
+        class="mt-2 text-sm leading-5 text-slate-200"
+      >
+        {{ helperText }}
+      </p>
     </div>
   </template>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { invoke } from '@tauri-apps/api/core'
 import Toggle from '../widget/Toggle.vue'
 
 interface Setting {
   key: string
   value: string
-  type: 'bool' | 'textarea' | 'text' | 'path'
+  type: 'bool' | 'textarea' | 'text' | 'path' | 'select'
   description?: string
+  options?: string[]
 }
+
+const presetLabelMap: Record<string, string> = {
+  fit: '适应当前显示器（推荐，保存时计算）',
+  default: '默认（内容区 1500×800）',
+  '1920x1080': '宽大（内容区 1920×1080）',
+  '2560x1440': '超大（QHD 内容区 2560×1440）',
+  '1280x720': '紧凑（内容区 1280×720）',
+  custom: '自定义',
+}
+
+const selectOptionLabel = (opt: string): string => presetLabelMap[opt] || opt
 
 interface Props {
   setting: Setting
+  readonly?: boolean
+  helperText?: string
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  readonly: false,
+  helperText: '',
+})
+
+const windowSettingKeys = new Set([
+  'ui.window_resolution_preset',
+  'ui.window_width',
+  'ui.window_height',
+])
+const showInternalKey = computed(() => !windowSettingKeys.has(props.setting.key))
+const isWindowDimension = computed(
+  () => props.setting.key === 'ui.window_width' || props.setting.key === 'ui.window_height',
+)
+const dimensionMin = computed(() => {
+  if (props.setting.key === 'ui.window_width') return 1024
+  if (props.setting.key === 'ui.window_height') return 640
+  return undefined
+})
 
 const emit = defineEmits<{
   'update:value': [value: string]

--- a/src/components/views/MainChat.vue
+++ b/src/components/views/MainChat.vue
@@ -55,6 +55,8 @@ import { GameDialog } from '../game/standard'
 import { Button } from '../base'
 import LoadingTransition from './LoadingTransition.vue'
 import { eventQueue } from '@/core/events/event-queue'
+import { useSettingsStore } from '@/stores/modules/settings'
+import { normalizePetScale, setPetWindowModeAndWait } from '@/utils/windowSizing'
 
 import GameExtraUI from '../game/standard/GameExtraUI.vue'
 
@@ -63,6 +65,7 @@ const LOADING_STORAGE_KEY = 'lingchat_loading_shown'
 const router = useRouter()
 const uiStore = useUIStore()
 const gameStore = useGameStore()
+const settingsStore = useSettingsStore()
 
 // 首次加载过渡状态（通过 localStorage 跨路由导航保持，启动时由 main.ts 清除）
 const showLoading = ref(!localStorage.getItem(LOADING_STORAGE_KEY))
@@ -74,8 +77,45 @@ function onLoadingComplete() {
   eventQueue.resume()
 }
 
-const goToPetMode = () => {
-  router.push('/pet')
+const switchingToPet = ref(false)
+
+const windowOperationErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error || '未知错误')
+
+const goToPetMode = async () => {
+  if (switchingToPet.value) return
+
+  switchingToPet.value = true
+  let petWindowRequested = false
+  try {
+    const scale = normalizePetScale(settingsStore.pet?.scale)
+    petWindowRequested = true
+    const isLatestRequest = await setPetWindowModeAndWait(true, scale)
+    if (!isLatestRequest) throw new Error('桌宠窗口切换请求已失效')
+    await router.push('/pet')
+  } catch (error) {
+    console.error('切换桌宠模式失败:', error)
+    let rollbackError: unknown = null
+    if (petWindowRequested) {
+      await setPetWindowModeAndWait(false).catch((caughtRollbackError) => {
+        rollbackError = caughtRollbackError
+        console.error('恢复主窗口失败:', caughtRollbackError)
+      })
+    }
+
+    const rollbackSuffix = rollbackError
+      ? `；恢复主窗口也失败：${windowOperationErrorMessage(rollbackError)}`
+      : ''
+    uiStore.showNotification({
+      type: 'error',
+      title: '进入桌宠模式失败',
+      message: `${windowOperationErrorMessage(error)}${rollbackSuffix}`,
+      duration: 6000,
+      skipTipsCheck: true,
+    })
+  } finally {
+    switchingToPet.value = false
+  }
 }
 
 const gameDialogRef = ref<InstanceType<typeof GameDialog> | null>(null)

--- a/src/stores/modules/ui/ui.ts
+++ b/src/stores/modules/ui/ui.ts
@@ -31,6 +31,7 @@ interface UIState {
   showCharacterThinkLine: string
   showSettings: boolean
   currentSettingsTab: string
+  advanceInitialTab: 'menu' | 'llm' | 'other'
 
   currentBackgroundTransition: number
   currentPresentPic: string
@@ -92,6 +93,7 @@ export const useUIStore = defineStore('ui', {
     showCharacterThinkLine: 'Ling Ling Thinking...',
     showSettings: false,
     currentSettingsTab: 'text',
+    advanceInitialTab: 'menu',
     currentBackgroundTransition: 300,
     currentPresentPic: '',
     currentPresentPicScale: 1,
@@ -169,9 +171,9 @@ export const useUIStore = defineStore('ui', {
     aspectRatio(): number {
       return this.viewportWidth / this.viewportHeight
     },
-    // 窄屏判断（竖屏 / 移动端）
+    // 窄屏判断：与 Tailwind 的 md 断点一致，并覆盖所有竖屏窗口。
     isNarrowScreen(): boolean {
-      return this.aspectRatio < 1.0
+      return this.viewportWidth < 768 || this.viewportHeight > this.viewportWidth
     },
     // 小屏/低分辨率判断（手机横竖屏、小窗口均覆盖）
     isSmallScreen(): boolean {
@@ -197,6 +199,9 @@ export const useUIStore = defineStore('ui', {
     },
     setSettingsTab(tab: string) {
       this.currentSettingsTab = tab
+    },
+    setAdvanceInitialTab(tab: 'menu' | 'llm' | 'other') {
+      this.advanceInitialTab = tab
     },
 
     // ========== Notification Actions ==========

--- a/src/utils/windowSizing.ts
+++ b/src/utils/windowSizing.ts
@@ -1,0 +1,173 @@
+import { invoke } from '@tauri-apps/api/core'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+
+const RESIZE_QUIET_MS = 80
+const RESIZE_MIN_WAIT_MS = 160
+const RESIZE_POLL_MS = 24
+const RESIZE_TIMEOUT_MS = 900
+const PET_SCALE_MIN = 0.7
+const PET_SCALE_MAX = 1.3
+const PET_SCALE_DEFAULT = 1
+const PET_BASE_WIDTH = 240
+const PET_AVATAR_HEIGHT = 240
+const PET_DIALOG_HEIGHT = 75
+const PET_CHAT_HEIGHT = 45
+const PET_SIZE_TOLERANCE_PHYSICAL_PX = 3
+
+let latestRequestId = 0
+let operationQueue: Promise<void> = Promise.resolve()
+let preparedMode: boolean | null = null
+let preparedScale: number | null = null
+
+const delay = (milliseconds: number) =>
+  new Promise<void>((resolve) => window.setTimeout(resolve, milliseconds))
+
+export const normalizePetScale = (scale: unknown): number => {
+  const numericScale = Number(scale)
+  if (!Number.isFinite(numericScale)) return PET_SCALE_DEFAULT
+  return Math.min(PET_SCALE_MAX, Math.max(PET_SCALE_MIN, numericScale))
+}
+
+const normalizeScale = (scale?: number) =>
+  typeof scale === 'number' ? normalizePetScale(scale) : undefined
+
+const expectedPetLogicalSize = (scale: number) => ({
+  width: Math.round(PET_BASE_WIDTH * scale),
+  height:
+    Math.round(PET_AVATAR_HEIGHT * scale) +
+    Math.round(PET_DIALOG_HEIGHT * scale) +
+    Math.round(PET_CHAT_HEIGHT * scale),
+})
+
+export function invalidatePetWindowModePreparation(): void {
+  preparedMode = null
+  preparedScale = null
+}
+
+export function isPetWindowModePrepared(scale?: number): boolean {
+  const expectedScale = normalizeScale(scale) ?? PET_SCALE_DEFAULT
+  return (
+    preparedMode === true &&
+    preparedScale !== null &&
+    Math.abs(preparedScale - expectedScale) < 0.0001
+  )
+}
+
+/**
+ * Applies a pet-window mode change and waits until Tauri has stopped reporting
+ * size changes. Requests are serialized and stale queued requests are skipped,
+ * so the last requested scale always wins during rapid slider input.
+ */
+export function setPetWindowModeAndWait(enable: boolean, scale?: number): Promise<boolean> {
+  const requestId = ++latestRequestId
+
+  const operation = operationQueue.then(async () => {
+    if (requestId !== latestRequestId) return false
+
+    const appWindow = getCurrentWindow()
+    let lastSize = await appWindow.innerSize().catch(() => null)
+    let lastChangeAt = Date.now()
+
+    const unlisten = await appWindow.onResized(({ payload }) => {
+      lastSize = payload
+      lastChangeAt = Date.now()
+    })
+
+    try {
+      if (requestId !== latestRequestId) return false
+
+      const normalizedScale = normalizeScale(scale)
+
+      // A request in flight must never be reused as an already-prepared route transition.
+      invalidatePetWindowModePreparation()
+
+      lastChangeAt = Date.now()
+      await invoke('set_pet_mode', {
+        enable,
+        ...(normalizedScale !== undefined ? { scale: normalizedScale } : {}),
+      })
+
+      const startedAt = Date.now()
+      let resizeSettled = false
+      while (requestId === latestRequestId && Date.now() - startedAt < RESIZE_TIMEOUT_MS) {
+        await delay(RESIZE_POLL_MS)
+
+        const currentSize = await appWindow.innerSize().catch(() => lastSize)
+        if (
+          currentSize &&
+          (!lastSize ||
+            currentSize.width !== lastSize.width ||
+            currentSize.height !== lastSize.height)
+        ) {
+          lastSize = currentSize
+          lastChangeAt = Date.now()
+        }
+
+        const elapsed = Date.now() - startedAt
+        if (elapsed >= RESIZE_MIN_WAIT_MS && Date.now() - lastChangeAt >= RESIZE_QUIET_MS) {
+          resizeSettled = true
+          break
+        }
+      }
+
+      const isLatestRequest = requestId === latestRequestId
+      if (!isLatestRequest) return false
+
+      if (!resizeSettled) {
+        invalidatePetWindowModePreparation()
+        throw new Error(`等待${enable ? '桌宠' : '主'}窗口尺寸稳定超时`)
+      }
+
+      if (enable) {
+        const finalScale = normalizedScale ?? PET_SCALE_DEFAULT
+        const targetLogicalSize = expectedPetLogicalSize(finalScale)
+        const [scaleFactor, finalPhysicalSize] = await Promise.all([
+          appWindow.scaleFactor(),
+          appWindow.innerSize(),
+        ])
+
+        if (!Number.isFinite(scaleFactor) || scaleFactor <= 0) {
+          invalidatePetWindowModePreparation()
+          throw new Error(`无法验证桌宠窗口尺寸：无效的 DPI 缩放系数 ${scaleFactor}`)
+        }
+
+        const expectedPhysicalWidth = targetLogicalSize.width * scaleFactor
+        const expectedPhysicalHeight = targetLogicalSize.height * scaleFactor
+        const widthDeviation = Math.abs(finalPhysicalSize.width - expectedPhysicalWidth)
+        const heightDeviation = Math.abs(finalPhysicalSize.height - expectedPhysicalHeight)
+
+        if (
+          widthDeviation > PET_SIZE_TOLERANCE_PHYSICAL_PX ||
+          heightDeviation > PET_SIZE_TOLERANCE_PHYSICAL_PX
+        ) {
+          invalidatePetWindowModePreparation()
+          throw new Error(
+            `桌宠窗口尺寸校验失败：期望约 ${Math.round(expectedPhysicalWidth)}x${Math.round(expectedPhysicalHeight)} 物理像素，实际 ${finalPhysicalSize.width}x${finalPhysicalSize.height}`,
+          )
+        }
+
+        preparedMode = true
+        preparedScale = finalScale
+      } else {
+        preparedMode = false
+        preparedScale = null
+      }
+
+      return true
+    } catch (error) {
+      if (requestId === latestRequestId) {
+        invalidatePetWindowModePreparation()
+      }
+      throw error
+    } finally {
+      unlisten()
+    }
+  })
+
+  operationQueue = operation.then(
+    () => undefined,
+    () => undefined,
+  )
+
+  return operation
+}


### PR DESCRIPTION
## 范围

本 PR 只处理分辨率设置控件、窗口尺寸工具和主界面切换入口。

- 增加逻辑尺寸归一化和桌宠尺寸计算工具
- 改进分辨率预设、数字输入与状态提示
- 补充配置保存结果的前端类型
- 调整主聊天界面的窗口切换准备流程

## 规模与依赖

- 基于 `tauri-refactor`，可独立完成前端构建
- 建议运行时合并顺序：#489 → #493 → 本 PR
- 5 个文件，338 行新增、17 行删除

## 验证

- `pnpm install --frozen-lockfile`
- `pnpm build`（包含 `vue-tsc --noEmit --skipLibCheck`）
- `git diff --check`