### PR TITLE
fix(ui): coordinate window restoration and delivery gates

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -24,8 +24,10 @@ import { useSedentaryReminder } from './composables/useSedentaryReminder'
 import { useUpdater } from './composables/useUpdater'
 import { useCanDeliver } from './composables/useCanDeliver'
 
-// 激活主动对话投放条件上报（仅在此处挂载一次）
-useCanDeliver()
+// 只有主窗口能作为主动回复投放闸门；设置/截图等辅助 WebView 不能覆盖主窗口状态。
+if (getCurrentWindow().label === 'main') {
+  useCanDeliver()
+}
 
 // ─── 久坐提醒 ────────────────────────────────────────────────
 useSedentaryReminder()

--- a/src/components/settings/pages/SettingsAdvanceOther.vue
+++ b/src/components/settings/pages/SettingsAdvanceOther.vue
@@ -22,7 +22,7 @@
         class="flex items-center gap-1 mt-2 text-sm px-5"
         style="color: white; -webkit-text-stroke: 1px black; paint-order: stroke fill"
       >
-        💡 这里的设置重启软件生效哦！
+        💡 部分设置需要重启，具体以当前页面说明为准。
       </div>
 
       <div
@@ -82,34 +82,40 @@
 
           <form @submit.prevent="saveSettings">
             <div
-              v-for="setting in selectedSubcategory.settings"
+              v-for="setting in visibleSettings"
               :key="setting.key"
               class="mb-6"
             >
               <SettingItem
                 :setting="setting"
+                :readonly="isWindowDimensionLocked(setting)"
+                :helper-text="windowDimensionHelperText(setting)"
                 @update:value="(value) => (setting.value = value)"
               />
             </div>
-          </form>
 
-          <!-- 保存操作区域 -->
-          <div
-            class="inline-flex flex-col gap-2 px-5 py-2.5 bg-brand text-white border-none rounded-lg cursor-pointer text-sm font-medium transition-colors duration-200 hover:bg-[#0056b3] min-w-30"
-            @click="saveSettings"
-          >
-            <button
-              class="bg-transparent border-none text-white cursor-pointer p-0 m-0 w-full h-full"
-            >
-              保存
-            </button>
-            <p
-              :class="saveStatus.colorClass"
-              class="text-xs whitespace-normal wrap-break-word max-w-75"
-            >
-              {{ saveStatus.message }}
-            </p>
-          </div>
+            <!-- 保存操作区域 -->
+            <div class="flex flex-col items-start gap-2">
+              <button
+                type="submit"
+                :disabled="isLoading"
+                :aria-busy="isLoading"
+                class="min-w-30 rounded-lg bg-brand px-5 py-2.5 text-sm font-semibold text-slate-950 shadow-sm transition-colors duration-200 hover:bg-[#8be3ff] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {{ isLoading ? '保存中…' : '保存' }}
+              </button>
+              <p
+                v-if="saveStatus.message"
+                role="status"
+                aria-live="polite"
+                aria-atomic="true"
+                :class="saveStatus.colorClass"
+                class="max-w-125 rounded-lg border px-3 py-2 text-sm leading-5 whitespace-normal wrap-break-word"
+              >
+                {{ saveStatus.message }}
+              </p>
+            </div>
+          </form>
         </div>
       </div>
       <div v-else-if="!isLoading && !Object.keys(configData).length" class="w-full active">
@@ -129,6 +135,7 @@ import { ref, onMounted, computed, reactive, watch, nextTick } from 'vue'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import SettingItem from '@/components/base/items/SettingItem.vue'
 import { getEnvConfigSettings, saveEnvConfigSettings } from '@/api/services/config'
+import { reloadProactiveSystem } from '@/api/services/schedule'
 
 // --- 响应式状态定义 ---
 const uiStore = useUIStore()
@@ -141,7 +148,7 @@ const activeSelection = reactive({
 })
 const saveStatus = reactive({
   message: '',
-  colorClass: 'text-green-500',
+  colorClass: 'border-emerald-400/60 bg-emerald-950/90 text-emerald-100',
 })
 
 const emit = defineEmits<{
@@ -160,6 +167,68 @@ const selectedSubcategory = computed(() => {
   return null
 })
 
+const hiddenKeysWhenFollowing = ['VD_API_KEY', 'VD_BASE_URL', 'VD_MODEL']
+const visibleSettings = computed(() => {
+  if (!selectedSubcategory.value) return []
+  const settings = selectedSubcategory.value.settings
+  const followSetting = settings.find((s: any) => s.key === 'VD_FOLLOW_CHAT_MODEL')
+  const followChatModel = followSetting?.value?.toLowerCase() === 'true'
+  return settings.filter((s: any) => {
+    if (!followChatModel) return true
+    return !hiddenKeysWhenFollowing.includes(s.key)
+  })
+})
+
+// 分辨率预设切换时自动同步宽高输入框
+const WINDOW_RESOLUTION_PRESET_KEY = 'ui.window_resolution_preset'
+const WINDOW_WIDTH_KEY = 'ui.window_width'
+const WINDOW_HEIGHT_KEY = 'ui.window_height'
+
+const presetSizeMap: Record<string, { width: string; height: string }> = {
+  default: { width: '1500', height: '800' },
+  '1920x1080': { width: '1920', height: '1080' },
+  '2560x1440': { width: '2560', height: '1440' },
+  '1280x720': { width: '1280', height: '720' },
+}
+
+const windowResolutionPreset = computed<string | undefined>(() =>
+  selectedSubcategory.value?.settings?.find(
+    (setting: any) => setting.key === WINDOW_RESOLUTION_PRESET_KEY,
+  )?.value,
+)
+
+const isWindowDimension = (setting: { key: string }) =>
+  setting.key === WINDOW_WIDTH_KEY || setting.key === WINDOW_HEIGHT_KEY
+
+const isWindowDimensionLocked = (setting: { key: string }) =>
+  isWindowDimension(setting) && windowResolutionPreset.value !== 'custom'
+
+const windowDimensionHelperText = (setting: { key: string }): string => {
+  if (!isWindowDimensionLocked(setting)) return ''
+  if (windowResolutionPreset.value === 'fit') {
+    return '保存时会根据当前显示器的可用工作区计算尺寸；这里显示的是上次保存的尺寸。'
+  }
+  return '宽高由当前分辨率预设决定；如需手动输入，请选择“自定义”。'
+}
+
+watch(
+  () =>
+    selectedSubcategory.value?.settings?.find(
+      (s: any) => s.key === WINDOW_RESOLUTION_PRESET_KEY,
+    )?.value,
+  (newPreset, oldPreset) => {
+    if (!newPreset || newPreset === oldPreset) return
+    if (newPreset === 'custom') return
+    const size = presetSizeMap[newPreset]
+    if (!size || !selectedSubcategory.value) return
+    const settings = selectedSubcategory.value.settings
+    const widthSetting = settings.find((s: any) => s.key === WINDOW_WIDTH_KEY)
+    const heightSetting = settings.find((s: any) => s.key === WINDOW_HEIGHT_KEY)
+    if (widthSetting) widthSetting.value = size.width
+    if (heightSetting) heightSetting.value = size.height
+  },
+)
+
 // --- 方法定义 ---
 
 const isActive = (category: string, subcategory: string) => {
@@ -176,7 +245,7 @@ const selectSubcategory = (category: string, subcategory: string) => {
 }
 
 const saveSettings = async () => {
-  if (!selectedSubcategory.value) return
+  if (!selectedSubcategory.value || isLoading.value) return
 
   const formData: Record<string, string> = {}
   selectedSubcategory.value.settings.forEach((setting: { key: string; value: string }) => {
@@ -184,16 +253,31 @@ const saveSettings = async () => {
   })
 
   isLoading.value = true
-  saveStatus.message = ''
+  saveStatus.message = '正在保存…'
+  saveStatus.colorClass = 'border-sky-400/60 bg-sky-950/90 text-sky-100'
 
   try {
-    saveStatus.message = (await saveEnvConfigSettings(formData)).message
-    saveStatus.colorClass = 'text-green-500'
+    const saveResult = await saveEnvConfigSettings(formData)
+
+    if (activeSelection.category === '主动对话配置') {
+      try {
+        await reloadProactiveSystem()
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error || '未知错误')
+        throw new Error(`配置已保存，但主动对话系统重载失败，当前运行实例尚未应用：${message}`)
+      }
+      saveStatus.message = `${saveResult.message} 主动对话系统已重载。`
+    } else {
+      saveStatus.message = saveResult.message
+    }
+
+    saveStatus.colorClass = 'border-emerald-400/60 bg-emerald-950/90 text-emerald-100'
 
     await loadConfig(false)
-  } catch (error: any) {
-    saveStatus.message = `错误: ${error.message}`
-    saveStatus.colorClass = 'text-red-500'
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error || '未知错误')
+    saveStatus.message = `错误: ${message}`
+    saveStatus.colorClass = 'border-red-400/60 bg-red-950/90 text-red-100'
   } finally {
     isLoading.value = false
     setTimeout(() => {
@@ -222,7 +306,7 @@ const loadConfig = async (selectFirst = true) => {
   } catch (error: any) {
     console.error(error)
     saveStatus.message = `加载配置失败: ${error.message}`
-    saveStatus.colorClass = 'text-red-500'
+    saveStatus.colorClass = 'border-red-400/60 bg-red-950/90 text-red-100'
   } finally {
     isLoading.value = false
   }

--- a/src/components/views/PetMode.vue
+++ b/src/components/views/PetMode.vue
@@ -26,6 +26,7 @@
       :style="{ width: 'var(--avatar-size)', height: 'var(--avatar-size)' }"
     >
       <GameRolesStage
+        v-if="windowReady"
         @avatar-click="handleAvatarClick"
         @open-settings="handleOpenSettings"
         @switch-auto-mode="handleSwitchAutoMode"
@@ -48,22 +49,34 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { onBeforeRouteLeave, useRouter } from 'vue-router'
 import { invoke } from '@tauri-apps/api/core'
-import { getCurrentWindow } from '@tauri-apps/api/window'
+import { currentMonitor, getCurrentWindow } from '@tauri-apps/api/window'
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { useGameStore } from '@/stores/modules/game'
 import { useSettingsStore } from '@/stores/modules/settings'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import { eventQueue } from '@/core/events/event-queue'
+import {
+  invalidatePetWindowModePreparation,
+  isPetWindowModePrepared,
+  normalizePetScale,
+  setPetWindowModeAndWait,
+} from '@/utils/windowSizing'
 
 import ChatInput from '../pet/ChatInput.vue'
 import DialogueBox from '../pet/DialogueBox.vue'
 import GameRolesStage from '../pet/GameRolesStage.vue'
+import { setExternalDeliveryBlocked } from '@/composables/useCanDeliver'
 
 const BASE_AVATAR_SIZE = 240
 const CHAT_BASE_H = 45
 const DIALOG_BASE_H = 75
+const SETTINGS_TARGET_WIDTH = 1200
+const SETTINGS_TARGET_HEIGHT = 800
+const SETTINGS_MIN_WIDTH = 720
+const SETTINGS_MIN_HEIGHT = 480
+const SETTINGS_WORK_AREA_RATIO = 0.9
 
 const router = useRouter()
 const gameStore = useGameStore()
@@ -71,6 +84,7 @@ const settingsStore = useSettingsStore()
 const uiStore = useUIStore()
 
 const showChatInput = ref(false)
+const windowReady = ref(false)
 
 const dialogContainer = ref<HTMLElement | null>(null)
 const avatarContainer = ref<HTMLElement | null>(null)
@@ -78,7 +92,7 @@ const chatContainer = ref<HTMLElement | null>(null)
 const gameDialogRef = ref<InstanceType<typeof DialogueBox> | null>(null)
 
 const appStyleVars = computed(() => {
-  const scale = settingsStore.pet?.scale || 1.0
+  const scale = normalizePetScale(settingsStore.pet?.scale)
   const layout = calcWindowLayout(scale)
   return {
     '--pet-ui-scale': scale.toString(),
@@ -97,65 +111,243 @@ const calcWindowLayout = (scale: number): { width: number; height: number } => {
   return { width: S, height: S + dialogH + chatH }
 }
 
-const applyWindowLayout = async () => {
-  try {
-    const scale = settingsStore.pet?.scale || 1.0
-    await invoke('set_pet_mode', { enable: true, scale })
-  } catch (error) {
-    console.error('调整窗口布局失败:', error)
-  }
+const applyWindowLayout = (scale = normalizePetScale(settingsStore.pet?.scale)) => {
+  return setPetWindowModeAndWait(true, scale)
 }
 
 let hitTestInterval: number | undefined
 let scaleUnlisten: (() => void) | null = null
+let scaleFactorUnlisten: (() => void) | null = null
 let effectUnlisten: (() => void) | null = null
 let volumeUnlisten: (() => void) | null = null
 let dialogHistoryUnlisten: (() => void) | null = null
+let scaleApplyTimer: number | null = null
+let scaleApplyRevision = 0
+let disposed = false
+let exitingPetMode = false
+let mainWindowRestored = false
+let restorePromise: Promise<void> | null = null
+let exitNavigationInFlight = false
+
+const isPetModeInactive = () => disposed || exitingPetMode
+
+const showPetWindowError = (title: string, error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error || '未知错误')
+  uiStore.showNotification({
+    type: 'error',
+    title,
+    message,
+    duration: 5000,
+    skipTipsCheck: true,
+  })
+}
+
+const cancelScheduledWindowLayout = () => {
+  scaleApplyRevision += 1
+  if (scaleApplyTimer !== null) {
+    window.clearTimeout(scaleApplyTimer)
+    scaleApplyTimer = null
+  }
+}
+
+const scheduleWindowLayout = (scale: number) => {
+  if (isPetModeInactive()) return
+
+  const revision = ++scaleApplyRevision
+  if (scaleApplyTimer !== null) window.clearTimeout(scaleApplyTimer)
+
+  scaleApplyTimer = window.setTimeout(async () => {
+    scaleApplyTimer = null
+    if (isPetModeInactive() || revision !== scaleApplyRevision) return
+
+    try {
+      const isLatestRequest = await applyWindowLayout(scale)
+      if (!isPetModeInactive() && revision === scaleApplyRevision && isLatestRequest) {
+        windowReady.value = true
+      }
+    } catch (error) {
+      if (isPetModeInactive() || revision !== scaleApplyRevision) return
+      windowReady.value = true
+      console.error('调整桌宠窗口布局失败:', error)
+      showPetWindowError('桌宠缩放失败', error)
+    }
+  }, 100)
+}
+
+const closeSettingsWindow = async () => {
+  try {
+    const settingsWindow = await WebviewWindow.getByLabel('settings')
+    if (settingsWindow) await settingsWindow.close()
+  } catch (error) {
+    console.warn('关闭桌宠设置窗口失败:', error)
+  } finally {
+    setExternalDeliveryBlocked(false)
+  }
+}
+
+/** Restores the main window once, sharing an in-flight restore across all exit paths. */
+const restoreMainWindow = (): Promise<void> => {
+  if (mainWindowRestored) return Promise.resolve()
+  if (restorePromise) return restorePromise
+
+  exitingPetMode = true
+  windowReady.value = false
+  cancelScheduledWindowLayout()
+
+  restorePromise = (async () => {
+    await closeSettingsWindow()
+    await invoke('update_solid_regions', { rects: [] }).catch((error) => {
+      console.warn('清除桌宠交互区域失败:', error)
+    })
+
+    const isLatestRequest = await setPetWindowModeAndWait(false)
+    if (!isLatestRequest) {
+      throw new Error('恢复主窗口的请求已被更新的窗口操作取代')
+    }
+
+    invalidatePetWindowModePreparation()
+    mainWindowRestored = true
+  })().catch((error) => {
+    restorePromise = null
+    exitingPetMode = false
+    if (!disposed) windowReady.value = true
+    throw error
+  })
+
+  return restorePromise
+}
+
+onBeforeRouteLeave(async () => {
+  try {
+    // Button-driven navigation reaches this guard after the same promise has resolved,
+    // while browser-back and redirects perform the restore here.
+    await restoreMainWindow()
+    return true
+  } catch (error) {
+    console.error('离开桌宠页面前恢复主窗口失败:', error)
+    showPetWindowError('退出桌宠模式失败', error)
+    return false
+  }
+})
+
+const retainUnlisten = (
+  unlisten: (() => void) | null,
+  assign: (value: (() => void) | null) => void,
+): boolean => {
+  if (isPetModeInactive()) {
+    unlisten?.()
+    return false
+  }
+  assign(unlisten)
+  return true
+}
 
 onMounted(async () => {
   const appWindow = getCurrentWindow()
 
-  scaleUnlisten = await appWindow.listen<{ scale: number }>('pet-scale-changed', (event) => {
-    const scale = Number(event.payload?.scale)
-    if (!Number.isNaN(scale)) {
-      settingsStore.pet.scale = scale
-      void applyWindowLayout()
+  // 设置透明背景，并先确认窗口已经稳定；正常入口复用 MainChat 已完成的切换，
+  // 直达 /pet 时才补做初始化，避免路由前后重复 set_size。
+  document.body.style.backgroundColor = 'transparent'
+  document.documentElement.style.backgroundColor = 'transparent'
+  const initialScale = normalizePetScale(settingsStore.pet?.scale)
+  if (isPetWindowModePrepared(initialScale)) {
+    windowReady.value = true
+  } else {
+    try {
+      const isLatestRequest = await applyWindowLayout(initialScale)
+      if (isPetModeInactive()) return
+      if (!isLatestRequest) throw new Error('初始化桌宠窗口的请求已失效')
+      windowReady.value = true
+    } catch (error) {
+      if (isPetModeInactive()) return
+      console.error('初始化桌宠窗口失败:', error)
+      showPetWindowError('进入桌宠模式失败', error)
+      try {
+        await restoreMainWindow()
+        if (!disposed) await router.replace('/chat')
+      } catch (restoreError) {
+        console.error('初始化失败后恢复主窗口失败:', restoreError)
+        showPetWindowError('恢复主窗口失败', restoreError)
+      }
+      return
     }
-  })
+  }
 
-  effectUnlisten = await appWindow.listen<{ effect: string }>(
-    'background-effect-changed',
-    (event) => {
+  if (isPetModeInactive()) return
+
+  const pendingScaleUnlisten = await appWindow
+    .listen<{ scale: number }>('pet-scale-changed', (event) => {
+      const rawScale = Number(event.payload?.scale)
+      if (!isPetModeInactive() && Number.isFinite(rawScale)) {
+        const scale = normalizePetScale(rawScale)
+        settingsStore.pet.scale = scale
+        scheduleWindowLayout(scale)
+      }
+    })
+    .catch((error) => {
+      console.error('监听桌宠缩放失败:', error)
+      return null
+    })
+  if (!retainUnlisten(pendingScaleUnlisten, (value) => (scaleUnlisten = value))) return
+
+  const pendingScaleFactorUnlisten = await appWindow
+    .onScaleChanged(() => {
+      if (isPetModeInactive()) return
+      invalidatePetWindowModePreparation()
+      scheduleWindowLayout(normalizePetScale(settingsStore.pet?.scale))
+    })
+    .catch((error) => {
+      console.error('监听窗口 DPI 变化失败:', error)
+      return null
+    })
+  if (!retainUnlisten(pendingScaleFactorUnlisten, (value) => (scaleFactorUnlisten = value))) return
+
+  const pendingEffectUnlisten = await appWindow
+    .listen<{ effect: string }>('background-effect-changed', (event) => {
+      if (isPetModeInactive()) return
       const effect = event.payload?.effect
       if (effect) {
         uiStore.setBackgroundEffect(effect)
       }
-    },
-  )
+    })
+    .catch((error) => {
+      console.error('监听桌宠背景特效失败:', error)
+      return null
+    })
+  if (!retainUnlisten(pendingEffectUnlisten, (value) => (effectUnlisten = value))) return
 
-  volumeUnlisten = await appWindow.listen<{ volume: number }>('pet-volume-changed', (event) => {
-    const volume = Number(event.payload?.volume)
-    if (!Number.isNaN(volume)) {
-      settingsStore.updateAudio({ characterVolume: volume })
-    }
-  })
+  const pendingVolumeUnlisten = await appWindow
+    .listen<{ volume: number }>('pet-volume-changed', (event) => {
+      if (isPetModeInactive()) return
+      const volume = Number(event.payload?.volume)
+      if (!Number.isNaN(volume)) {
+        settingsStore.updateAudio({ characterVolume: volume })
+      }
+    })
+    .catch((error) => {
+      console.error('监听桌宠音量失败:', error)
+      return null
+    })
+  if (!retainUnlisten(pendingVolumeUnlisten, (value) => (volumeUnlisten = value))) return
 
   // 响应设置窗口的初始历史数据请求
-  dialogHistoryUnlisten = await appWindow.listen('request-dialog-history', () => {
-    appWindow.emit('dialog-history-changed', {
-      dialogHistory: JSON.parse(JSON.stringify(gameStore.dialogHistory)),
+  const pendingDialogHistoryUnlisten = await appWindow
+    .listen('request-dialog-history', () => {
+      if (isPetModeInactive()) return
+      appWindow.emit('dialog-history-changed', {
+        dialogHistory: JSON.parse(JSON.stringify(gameStore.dialogHistory)),
+      })
     })
-  })
-
-  // 设置透明背景的 body 属性样式（额外防护）
-  document.body.style.backgroundColor = 'transparent'
-  document.documentElement.style.backgroundColor = 'transparent'
-
-  // 1. 初始化窗口为桌宠尺寸
-  await applyWindowLayout()
+    .catch((error) => {
+      console.error('监听对话历史请求失败:', error)
+      return null
+    })
+  if (!retainUnlisten(pendingDialogHistoryUnlisten, (value) => (dialogHistoryUnlisten = value)))
+    return
 
   // 2. 启动 100ms 一次的 solid bounds 测试
   hitTestInterval = window.setInterval(() => {
+    if (isPetModeInactive()) return
     const rects = []
 
     // 如果对话气泡正在显示，则加入 solid region 触发交互
@@ -190,17 +382,11 @@ onMounted(async () => {
   }, 100)
 })
 
-watch(
-  () => settingsStore.pet?.scale,
-  () => {
-    void applyWindowLayout()
-  },
-)
-
 // 监听 dialogHistory 变化，推送给设置窗口
 watch(
   () => gameStore.dialogHistory.length,
   () => {
+    if (isPetModeInactive()) return
     const appWindow = getCurrentWindow()
     appWindow.emit('dialog-history-changed', {
       dialogHistory: JSON.parse(JSON.stringify(gameStore.dialogHistory)),
@@ -209,17 +395,28 @@ watch(
 )
 
 onUnmounted(() => {
+  disposed = true
+  invalidatePetWindowModePreparation()
+  cancelScheduledWindowLayout()
+
   // 恢复默认背景色
   document.body.style.backgroundColor = ''
   document.documentElement.style.backgroundColor = ''
 
   if (scaleUnlisten) scaleUnlisten()
+  if (scaleFactorUnlisten) scaleFactorUnlisten()
   if (effectUnlisten) effectUnlisten()
   if (volumeUnlisten) volumeUnlisten()
   if (dialogHistoryUnlisten) dialogHistoryUnlisten()
 
   if (hitTestInterval !== undefined) {
     window.clearInterval(hitTestInterval)
+    hitTestInterval = undefined
+  }
+
+  if (timerId !== null) {
+    window.clearTimeout(timerId)
+    timerId = null
   }
 })
 
@@ -245,19 +442,71 @@ const handleAvatarClick = () => {
   resetInteraction()
 }
 
+const getSettingsWindowBounds = async () => {
+  const monitor = await currentMonitor().catch((error) => {
+    console.warn('读取当前显示器工作区失败，使用默认设置窗口尺寸:', error)
+    return null
+  })
+
+  if (!monitor || !Number.isFinite(monitor.scaleFactor) || monitor.scaleFactor <= 0) {
+    return {
+      width: SETTINGS_TARGET_WIDTH,
+      height: SETTINGS_TARGET_HEIGHT,
+      minWidth: SETTINGS_MIN_WIDTH,
+      minHeight: SETTINGS_MIN_HEIGHT,
+      maxWidth: SETTINGS_TARGET_WIDTH,
+      maxHeight: SETTINGS_TARGET_HEIGHT,
+    }
+  }
+
+  const logicalWorkWidth = monitor.workArea.size.width / monitor.scaleFactor
+  const logicalWorkHeight = monitor.workArea.size.height / monitor.scaleFactor
+  const maxWidth = Math.max(1, Math.floor(logicalWorkWidth * SETTINGS_WORK_AREA_RATIO))
+  const maxHeight = Math.max(1, Math.floor(logicalWorkHeight * SETTINGS_WORK_AREA_RATIO))
+  const width = Math.min(SETTINGS_TARGET_WIDTH, maxWidth)
+  const height = Math.min(SETTINGS_TARGET_HEIGHT, maxHeight)
+
+  return {
+    width,
+    height,
+    minWidth: Math.min(SETTINGS_MIN_WIDTH, width),
+    minHeight: Math.min(SETTINGS_MIN_HEIGHT, height),
+    maxWidth,
+    maxHeight,
+  }
+}
+
 const handleOpenSettings = async () => {
+  if (isPetModeInactive()) return
+
+  setExternalDeliveryBlocked(true)
   try {
     const existing = await WebviewWindow.getByLabel('settings')
+    if (isPetModeInactive()) {
+      setExternalDeliveryBlocked(false)
+      return
+    }
+
     if (existing) {
+      void existing.once('tauri://destroyed', () => {
+        setExternalDeliveryBlocked(false)
+      })
       await existing.setFocus()
+      return
+    }
+
+    const bounds = await getSettingsWindowBounds()
+    if (isPetModeInactive()) {
+      setExternalDeliveryBlocked(false)
       return
     }
 
     const webview = new WebviewWindow('settings', {
       url: '/second',
       title: '设置',
-      width: 1200,
-      height: 800,
+      ...bounds,
+      center: true,
+      preventOverflow: true,
       resizable: true,
       shadow: false,
       decorations: false,
@@ -266,13 +515,25 @@ const handleOpenSettings = async () => {
     })
 
     webview.once('tauri://created', () => {
+      if (isPetModeInactive()) {
+        void webview.close()
+        return
+      }
+      void webview.center().catch((error) => {
+        console.warn('居中桌宠设置窗口失败:', error)
+      })
       console.log('桌宠轻量设置窗口创建成功')
     })
 
     webview.once('tauri://error', (e) => {
+      setExternalDeliveryBlocked(false)
       console.error('创建桌宠轻量设置窗口失败:', e)
     })
+    webview.once('tauri://destroyed', () => {
+      setExternalDeliveryBlocked(false)
+    })
   } catch (error) {
+    setExternalDeliveryBlocked(false)
     console.error('打开设置窗口时出错:', error)
   }
 }
@@ -343,22 +604,19 @@ const handleSwitchAutoMode = () => {
 }
 
 const handleExitPetMode = async () => {
-  // 关闭设置窗口（如果打开的话）
-  try {
-    const settingsWindow = await WebviewWindow.getByLabel('settings')
-    if (settingsWindow) {
-      await settingsWindow.close()
-    }
-  } catch {
-    // 窗口不存在，忽略
-  }
+  if (exitNavigationInFlight) return
+  exitNavigationInFlight = true
 
-  // 退出时清除 solid region，防止残留
-  await invoke('update_solid_regions', { rects: [] })
-  // 1. 关闭桌宠窗口特性，恢复 1500x800 的正常主窗口
-  await invoke('set_pet_mode', { enable: false })
-  // 2. 路由导航回聊天主页面
-  router.push('/chat')
+  try {
+    await restoreMainWindow()
+    // The leave guard reuses the resolved restore promise instead of invoking Tauri twice.
+    await router.push('/chat')
+  } catch (error) {
+    console.error('退出桌宠模式失败:', error)
+    showPetWindowError('退出桌宠模式失败', error)
+  } finally {
+    exitNavigationInFlight = false
+  }
 }
 </script>
 

--- a/src/composables/useCanDeliver.ts
+++ b/src/composables/useCanDeliver.ts
@@ -1,4 +1,4 @@
-import { ref, watch, onMounted } from 'vue'
+import { onBeforeUnmount, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { invoke } from '@tauri-apps/api/core'
 import { useUIStore } from '@/stores/modules/ui/ui'
@@ -15,6 +15,7 @@ const CHAT_ROUTES = ['LingChat', 'PetMode']
 
 // ===== 全局输入状态（由 GameDialog / ChatInput 组件上报） =====
 let _inputHasText = false
+let _externalWindowBlocked = false
 const _inputListeners = new Set<() => void>()
 
 /** 各输入组件在 watch 中调用此函数来更新输入状态 */
@@ -24,16 +25,28 @@ export function setInputHasText(val: boolean) {
   _inputListeners.forEach((fn) => fn())
 }
 
+/** 独立设置/覆盖层窗口打开时，由主窗口显式阻止主动回复。 */
+export function setExternalDeliveryBlocked(val: boolean) {
+  if (_externalWindowBlocked === val) return
+  _externalWindowBlocked = val
+  _inputListeners.forEach((fn) => fn())
+}
+
 export function useCanDeliver() {
   const router = useRouter()
   const uiStore = useUIStore()
 
   const canDeliver = ref(false)
-  let lastInvoked: boolean | null = null
+  let acknowledged: boolean | null = null
+  let syncing = false
+  let retryTimer: number | null = null
+  let retryDelayMs = 250
+  let disposed = false
 
   function recompute() {
     const onChatRoute = CHAT_ROUTES.includes(router.currentRoute.value.name as string)
-    canDeliver.value = onChatRoute && !uiStore.showSettings && !_inputHasText
+    canDeliver.value =
+      onChatRoute && !uiStore.showSettings && !_inputHasText && !_externalWindowBlocked
   }
 
   // 监听变更
@@ -49,15 +62,51 @@ export function useCanDeliver() {
 
   // 输入状态变化时重新计算
   _inputListeners.add(recompute)
-
-  // 值翻转时通知后端
-  watch(canDeliver, (val) => {
-    if (val !== lastInvoked) {
-      lastInvoked = val
-      invoke('proactive_set_can_deliver', { canDeliver: val })
-        .catch((e) => console.error('[CanDeliver] invoke failed:', e))
-    }
+  onBeforeUnmount(() => {
+    disposed = true
+    _inputListeners.delete(recompute)
+    if (retryTimer !== null) window.clearTimeout(retryTimer)
   })
+
+  // 串行同步，避免 true/false 两次 invoke 乱序完成后把后端留在过期状态。
+  async function syncCanDeliver() {
+    if (syncing || disposed) return
+    syncing = true
+
+    try {
+      while (!disposed && acknowledged !== canDeliver.value) {
+        const target = canDeliver.value
+        try {
+          await invoke('proactive_set_can_deliver', { canDeliver: target })
+          acknowledged = target
+          retryDelayMs = 250
+          if (retryTimer !== null) {
+            window.clearTimeout(retryTimer)
+            retryTimer = null
+          }
+        } catch (error) {
+          console.error('[CanDeliver] invoke failed:', error)
+          retryTimer = window.setTimeout(() => {
+            retryTimer = null
+            void syncCanDeliver()
+          }, retryDelayMs)
+          retryDelayMs = Math.min(retryDelayMs * 2, 5000)
+          break
+        }
+      }
+    } finally {
+      syncing = false
+    }
+  }
+
+  // 值翻转时通知后端；只有调用成功后才更新 acknowledged。
+  watch(
+    canDeliver,
+    () => {
+      void syncCanDeliver()
+    },
+    { immediate: true },
+  )
 
   return { canDeliver }
 }

--- a/src/stores/modules/ui/ui.ts
+++ b/src/stores/modules/ui/ui.ts
@@ -31,6 +31,7 @@ interface UIState {
   showCharacterThinkLine: string
   showSettings: boolean
   currentSettingsTab: string
+  advanceInitialTab: 'menu' | 'llm' | 'other'
 
   currentBackgroundTransition: number
   currentPresentPic: string
@@ -92,6 +93,7 @@ export const useUIStore = defineStore('ui', {
     showCharacterThinkLine: 'Ling Ling Thinking...',
     showSettings: false,
     currentSettingsTab: 'text',
+    advanceInitialTab: 'menu',
     currentBackgroundTransition: 300,
     currentPresentPic: '',
     currentPresentPicScale: 1,
@@ -169,9 +171,9 @@ export const useUIStore = defineStore('ui', {
     aspectRatio(): number {
       return this.viewportWidth / this.viewportHeight
     },
-    // 窄屏判断（竖屏 / 移动端）
+    // 窄屏判断：与 Tailwind 的 md 断点一致，并覆盖所有竖屏窗口。
     isNarrowScreen(): boolean {
-      return this.aspectRatio < 1.0
+      return this.viewportWidth < 768 || this.viewportHeight > this.viewportWidth
     },
     // 小屏/低分辨率判断（手机横竖屏、小窗口均覆盖）
     isSmallScreen(): boolean {
@@ -197,6 +199,9 @@ export const useUIStore = defineStore('ui', {
     },
     setSettingsTab(tab: string) {
       this.currentSettingsTab = tab
+    },
+    setAdvanceInitialTab(tab: 'menu' | 'llm' | 'other') {
+      this.advanceInitialTab = tab
     },
 
     // ========== Notification Actions ==========

--- a/src/utils/windowSizing.ts
+++ b/src/utils/windowSizing.ts
@@ -1,0 +1,173 @@
+import { invoke } from '@tauri-apps/api/core'
+import { getCurrentWindow } from '@tauri-apps/api/window'
+
+const RESIZE_QUIET_MS = 80
+const RESIZE_MIN_WAIT_MS = 160
+const RESIZE_POLL_MS = 24
+const RESIZE_TIMEOUT_MS = 900
+const PET_SCALE_MIN = 0.7
+const PET_SCALE_MAX = 1.3
+const PET_SCALE_DEFAULT = 1
+const PET_BASE_WIDTH = 240
+const PET_AVATAR_HEIGHT = 240
+const PET_DIALOG_HEIGHT = 75
+const PET_CHAT_HEIGHT = 45
+const PET_SIZE_TOLERANCE_PHYSICAL_PX = 3
+
+let latestRequestId = 0
+let operationQueue: Promise<void> = Promise.resolve()
+let preparedMode: boolean | null = null
+let preparedScale: number | null = null
+
+const delay = (milliseconds: number) =>
+  new Promise<void>((resolve) => window.setTimeout(resolve, milliseconds))
+
+export const normalizePetScale = (scale: unknown): number => {
+  const numericScale = Number(scale)
+  if (!Number.isFinite(numericScale)) return PET_SCALE_DEFAULT
+  return Math.min(PET_SCALE_MAX, Math.max(PET_SCALE_MIN, numericScale))
+}
+
+const normalizeScale = (scale?: number) =>
+  typeof scale === 'number' ? normalizePetScale(scale) : undefined
+
+const expectedPetLogicalSize = (scale: number) => ({
+  width: Math.round(PET_BASE_WIDTH * scale),
+  height:
+    Math.round(PET_AVATAR_HEIGHT * scale) +
+    Math.round(PET_DIALOG_HEIGHT * scale) +
+    Math.round(PET_CHAT_HEIGHT * scale),
+})
+
+export function invalidatePetWindowModePreparation(): void {
+  preparedMode = null
+  preparedScale = null
+}
+
+export function isPetWindowModePrepared(scale?: number): boolean {
+  const expectedScale = normalizeScale(scale) ?? PET_SCALE_DEFAULT
+  return (
+    preparedMode === true &&
+    preparedScale !== null &&
+    Math.abs(preparedScale - expectedScale) < 0.0001
+  )
+}
+
+/**
+ * Applies a pet-window mode change and waits until Tauri has stopped reporting
+ * size changes. Requests are serialized and stale queued requests are skipped,
+ * so the last requested scale always wins during rapid slider input.
+ */
+export function setPetWindowModeAndWait(enable: boolean, scale?: number): Promise<boolean> {
+  const requestId = ++latestRequestId
+
+  const operation = operationQueue.then(async () => {
+    if (requestId !== latestRequestId) return false
+
+    const appWindow = getCurrentWindow()
+    let lastSize = await appWindow.innerSize().catch(() => null)
+    let lastChangeAt = Date.now()
+
+    const unlisten = await appWindow.onResized(({ payload }) => {
+      lastSize = payload
+      lastChangeAt = Date.now()
+    })
+
+    try {
+      if (requestId !== latestRequestId) return false
+
+      const normalizedScale = normalizeScale(scale)
+
+      // A request in flight must never be reused as an already-prepared route transition.
+      invalidatePetWindowModePreparation()
+
+      lastChangeAt = Date.now()
+      await invoke('set_pet_mode', {
+        enable,
+        ...(normalizedScale !== undefined ? { scale: normalizedScale } : {}),
+      })
+
+      const startedAt = Date.now()
+      let resizeSettled = false
+      while (requestId === latestRequestId && Date.now() - startedAt < RESIZE_TIMEOUT_MS) {
+        await delay(RESIZE_POLL_MS)
+
+        const currentSize = await appWindow.innerSize().catch(() => lastSize)
+        if (
+          currentSize &&
+          (!lastSize ||
+            currentSize.width !== lastSize.width ||
+            currentSize.height !== lastSize.height)
+        ) {
+          lastSize = currentSize
+          lastChangeAt = Date.now()
+        }
+
+        const elapsed = Date.now() - startedAt
+        if (elapsed >= RESIZE_MIN_WAIT_MS && Date.now() - lastChangeAt >= RESIZE_QUIET_MS) {
+          resizeSettled = true
+          break
+        }
+      }
+
+      const isLatestRequest = requestId === latestRequestId
+      if (!isLatestRequest) return false
+
+      if (!resizeSettled) {
+        invalidatePetWindowModePreparation()
+        throw new Error(`等待${enable ? '桌宠' : '主'}窗口尺寸稳定超时`)
+      }
+
+      if (enable) {
+        const finalScale = normalizedScale ?? PET_SCALE_DEFAULT
+        const targetLogicalSize = expectedPetLogicalSize(finalScale)
+        const [scaleFactor, finalPhysicalSize] = await Promise.all([
+          appWindow.scaleFactor(),
+          appWindow.innerSize(),
+        ])
+
+        if (!Number.isFinite(scaleFactor) || scaleFactor <= 0) {
+          invalidatePetWindowModePreparation()
+          throw new Error(`无法验证桌宠窗口尺寸：无效的 DPI 缩放系数 ${scaleFactor}`)
+        }
+
+        const expectedPhysicalWidth = targetLogicalSize.width * scaleFactor
+        const expectedPhysicalHeight = targetLogicalSize.height * scaleFactor
+        const widthDeviation = Math.abs(finalPhysicalSize.width - expectedPhysicalWidth)
+        const heightDeviation = Math.abs(finalPhysicalSize.height - expectedPhysicalHeight)
+
+        if (
+          widthDeviation > PET_SIZE_TOLERANCE_PHYSICAL_PX ||
+          heightDeviation > PET_SIZE_TOLERANCE_PHYSICAL_PX
+        ) {
+          invalidatePetWindowModePreparation()
+          throw new Error(
+            `桌宠窗口尺寸校验失败：期望约 ${Math.round(expectedPhysicalWidth)}x${Math.round(expectedPhysicalHeight)} 物理像素，实际 ${finalPhysicalSize.width}x${finalPhysicalSize.height}`,
+          )
+        }
+
+        preparedMode = true
+        preparedScale = finalScale
+      } else {
+        preparedMode = false
+        preparedScale = null
+      }
+
+      return true
+    } catch (error) {
+      if (requestId === latestRequestId) {
+        invalidatePetWindowModePreparation()
+      }
+      throw error
+    } finally {
+      unlisten()
+    }
+  })
+
+  operationQueue = operation.then(
+    () => undefined,
+    () => undefined,
+  )
+
+  return operation
+}


### PR DESCRIPTION
## 范围

本 PR 只处理窗口恢复流程与主动投放闸门在共享 Vue 页面中的最终协调，解决两组功能原先集中修改同一页面造成的大 PR 与冲突。

- 统一 `PetMode` 的 DPI 安全恢复和投放阻塞状态
- 在应用生命周期中初始化投放状态监听
- 协调高级设置页的分辨率预设与主动设置重载
- 提供共享的 `windowSizing` 与 `useCanDeliver`，避免模块之间互相复制逻辑

## 规模与依赖

- 基于 `tauri-refactor`，可独立完成前端构建
- 建议最后合并：#491、#492、#493、#494 → 本 PR
- 6 个文件，676 行新增、105 行删除

## 人工检查

1. 在主窗口、最大化/全屏和桌宠模式之间切换并返回。
2. 改变系统缩放或切换显示器，确认尺寸与点击穿透恢复。
3. 打开设置或进入游戏时触发主动周期，确认投放闸门不会越权插入消息。

## 验证

- `pnpm install --frozen-lockfile`
- `pnpm build`（包含 `vue-tsc --noEmit --skipLibCheck`）
- 最终组合分支前端 production build 通过
- `git diff --check`