### PR TITLE
build: add local desktop profile without updater artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vue-tsc --noEmit --skipLibCheck && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
+    "desktop:build:local": "tauri build --config src-tauri/tauri.local.conf.json",
     "android:prepare": "node scripts/prepare-bundled-resources.mjs",
     "android:build": "node scripts/prepare-bundled-resources.mjs && tauri android build --target aarch64"
   },

--- a/src-tauri/tauri.local.conf.json
+++ b/src-tauri/tauri.local.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": false
+  }
+}


### PR DESCRIPTION
## 范围

本 PR 只补充本地桌面打包配置，不改变正式发布配置。

- 增加 `src-tauri/tauri.local.conf.json`
- 增加 `pnpm desktop:build:local`
- 本地打包关闭 updater artifacts，避免没有签名私钥时失败

## 规模与依赖

- 基于 `tauri-refactor`
- 2 个文件，7 行新增
- 与视觉、主动对话和窗口 PR 独立

## 验证

- `package.json` 与 `tauri.local.conf.json` JSON 解析通过
- `pnpm desktop:build:local --help` 正确加载覆盖配置
- `git diff --check`