### PR TITLE
增强主动回复稳定性与视觉理解能力

### DIFF
--- a/docs/proactive-improvements.md
+++ b/docs/proactive-improvements.md
@@ -1,0 +1,53 @@
+# 主动回复与视觉理解增强
+
+## 当前状态
+
+- [x] 步骤 1：richer 屏幕上下文 prompt
+- [x] 步骤 2：一步式屏幕搭话决策
+- [x] 步骤 3：增加反重复机制
+- [x] `cargo test --lib` 通过（18 个测试）
+- [x] `pnpm build` 通过
+- [x] `pnpm tauri build --debug --no-bundle` 通过
+
+## 改动摘要
+
+### screen_analyzer.rs
+- 新增 `ScreenContext`：携带 `ai_name`、`user_name`、`recent_chat_summary`
+- `analyze_screen` 增加 `context` 参数
+- 新增 `analyze_screen_for_proactive`：让 VLM 直接判断说不说
+- `VISION_SYSTEM_PROMPT` 和 `build_screen_prompt` 融入角色上下文
+
+### strategy_dispatcher.rs
+- SCREEN 模式改为调用 `analyze_screen_for_proactive`
+- 模型返回 `[PASS]` 时跳过本次，降级到 TOPIC
+- 新增 `ProactiveDeduplicator`，对 ImportantDay/Todo/Screen/Topic 都进行反重复检测
+
+### proactive_system
+- 将屏幕分析移出全局锁，避免慢请求阻塞主动回复循环
+- 为日程提醒、用户状态与前端投递状态增加统一门控
+- 仅在消息成功投递后消耗兴趣值，并修复兴趣度衰减下限
+- 提供手动测试主动消息入口与主动思考状态提示
+
+### 视觉模型兼容
+- Kimi for Coding 使用 Anthropic Messages API，并解析 thinking/text 多 block 响应
+- 可选择跟随聊天模型或使用独立轻量视觉模型
+- 支持视觉优先模式、主动截图压缩和耗时日志
+
+### proactive_history.rs（新增）
+- 维护最近 10 条、1 小时内的主动搭话历史
+- 归一化 + 编辑距离相似度，阈值 0.85
+- 自动过期清理和数量限制
+
+### api/chat.rs
+- `test_screen_analyzer` 调用更新为 `analyze_screen(&prompt, None)`
+
+### mod.rs
+- 注册新模块 `proactive_history`
+
+## 后续可继续优化
+
+- 在 `ScreenContext` 中传入真实对话历史摘要
+- 把反重复历史持久化到文件（目前只存内存，重启丢失）
+- 增加 AI 正在说话 / 用户正在输入时的触发门控
+- 多屏截图和隐藏自身窗口再截图
+- 把 TODO/TOPIC/SCREEN 等做成可配置权重的 dispatcher

--- a/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
@@ -39,6 +39,8 @@ impl AIDialogueEvent {
 #[async_trait]
 impl ScriptEvent for AIDialogueEvent {
     async fn execute(&mut self, ctx: &mut ScriptContext<'_>) -> Result<Option<String>> {
+        let _generation_guard = ctx.generation_lock.clone().lock_owned().await;
+
         let script_status = ctx
             .game_status
             .lock()
@@ -97,6 +99,7 @@ impl ScriptEvent for AIDialogueEvent {
             concurrency: 1,
             god_agent: None,
             suppress_thinking: false,
+            is_proactive: false,
         };
 
         let generator = MessageGenerator::new(deps);

--- a/src-tauri/src/ai_service/game_system/script_engine/events/free_dialogue_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/free_dialogue_event.rs
@@ -117,6 +117,7 @@ impl ScriptEvent for FreeDialogueEvent {
                     concurrency: 1,
                     god_agent: None,
                     suppress_thinking: false,
+                    is_proactive: false,
                 };
                 MessageGenerator::new(deps)
             })
@@ -161,6 +162,9 @@ impl ScriptEvent for FreeDialogueEvent {
             let _ = emit(ctx.app, SCRIPT_INPUT, &payload);
 
             let user_input = rx.await.map_err(|_| anyhow!("用户输入通道已关闭"))?;
+
+            // 用户输入、剧情提示与对应 AI 回复必须保持同一生成顺序。
+            let _generation_guard = ctx.generation_lock.clone().lock_owned().await;
 
             // ---- 添加用户输入台词先 ----
             {

--- a/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
@@ -72,6 +72,8 @@ pub struct ScriptContext<'a> {
     /// Owned Arc — events lock as needed. Decoupled from AIService lock
     /// so events can safely call MessageGenerator without deadlock.
     pub game_status: Arc<Mutex<GameStatus>>,
+    /// 与普通聊天、入场问候和主动回复共用的全局生成门。
+    pub generation_lock: Arc<Mutex<()>>,
     pub config: &'a AIServiceConfig,
 
     /// Optional LLM client for `ai_dialogue`, `free_dialogue`, `chapter_end` (ai_judged).

--- a/src-tauri/src/ai_service/game_system/script_engine/script_manager.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/script_manager.rs
@@ -205,18 +205,11 @@ impl ScriptManager {
             .ok_or_else(|| anyhow!("剧本不存在: '{}'", name))?
             .clone();
 
-        self.is_running.store(true, Ordering::SeqCst);
+        self.is_running
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .map_err(|_| anyhow!("已有剧本正在运行"))?;
 
-        // Initialize: register roles, set script_status, load player
-        Self::init_script(&script, ctx).await?;
-
-        // Run the chapter loop
-        Self::run_script(ctx).await?;
-
-        // Cleanup
-        Self::on_script_end(ctx, &self.is_running).await?;
-
-        Ok(())
+        Self::execute_reserved_script(&script, ctx, &self.is_running).await
     }
 
     /// Execute a script from start to finish without needing `&self`.
@@ -227,11 +220,31 @@ impl ScriptManager {
         ctx: &mut ScriptContext<'_>,
         is_running: &AtomicBool,
     ) -> Result<()> {
-        is_running.store(true, Ordering::SeqCst);
-        Self::init_script(script, ctx).await?;
-        Self::run_script(ctx).await?;
-        Self::on_script_end(ctx, is_running).await?;
-        Ok(())
+        debug_assert!(is_running.load(Ordering::SeqCst));
+        Self::execute_reserved_script(script, ctx, is_running).await
+    }
+
+    async fn execute_reserved_script(
+        script: &ScriptStatus,
+        ctx: &mut ScriptContext<'_>,
+        is_running: &AtomicBool,
+    ) -> Result<()> {
+        let execution = async {
+            {
+                let _generation_guard = ctx.generation_lock.clone().lock_owned().await;
+                Self::init_script(script, ctx).await?;
+            }
+            Self::run_script(ctx).await
+        }
+        .await;
+
+        match execution {
+            Ok(()) => Self::on_script_end(ctx, is_running).await,
+            Err(error) => {
+                Self::abort_script(ctx, is_running).await;
+                Err(error)
+            }
+        }
     }
 
     /// Initialize a script: register its roles, set script_status, load player info.
@@ -461,6 +474,20 @@ impl ScriptManager {
         tracing::info!("[ScriptManager] 剧本状态已清除");
 
         Ok(())
+    }
+
+    /// 异常结束只清理运行态，不把失败的剧本记入 completed_scripts。
+    async fn abort_script(ctx: &mut ScriptContext<'_>, is_running: &AtomicBool) {
+        tracing::warn!("[ScriptManager] 剧本异常终止，正在清理状态");
+        let _ = emit(ctx.app, SCRIPT_END, &ScriptEndPayload {});
+
+        {
+            let mut channels = ctx.channels.lock().await;
+            channels.input_tx = None;
+            channels.choice_tx = None;
+        }
+        ctx.game_status.lock().await.script_status = None;
+        is_running.store(false, Ordering::SeqCst);
     }
 
     // ============================================================

--- a/src-tauri/src/ai_service/god_agent/core.rs
+++ b/src-tauri/src/ai_service/god_agent/core.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
+use regex::Regex;
 
 use crate::ai_service::game_system::game_status::GameStatus;
 use crate::ai_service::god_agent::config::GodAgentConfig;
@@ -201,8 +202,62 @@ impl GodAgentCore {
         // Fallback：如果 LLM 返回了文本但未调用工具，尝试从内容解析
         if let Some(ref content) = response.content {
             tracing::warn!("上帝Agent 未调用工具，返回了文本: {content}");
+            if let Some((role_id, reason)) = parse_fallback_speaker(content) {
+                if role_id == 0 || gs.present_role_ids.contains(&role_id) {
+                    tracing::info!("上帝Agent 文本回退解析成功: role_id={role_id}, reason={reason}");
+                    return Ok((role_id, reason));
+                }
+                tracing::warn!("上帝Agent 文本回退解析到不在场的角色 {role_id}，忽略");
+            }
+            // 仍无法解析时，安全降级为交给玩家，避免整轮对话失败
+            tracing::warn!("上帝Agent 无法解析发言者，降级为 role_id=0（玩家）");
+            return Ok((0, "fallback to player after unparsable response".into()));
         }
 
         Err(anyhow!("上帝Agent 无法解析下一个发言者"))
+    }
+}
+
+/// 从 LLM 文本回退解析下一个发言者。
+/// 优先匹配 `role_id = N` / `role_id=N`，其次匹配第一个独立整数。
+fn parse_fallback_speaker(content: &str) -> Option<(i32, String)> {
+    // 1. 显式的 role_id 标记
+    let re = Regex::new(r"role_id\s*=\s*(\d+)").ok()?;
+    if let Some(caps) = re.captures(content) {
+        if let Ok(id) = caps[1].parse::<i32>() {
+            return Some((id, "parsed role_id from text".into()));
+        }
+    }
+
+    // 2. 文本中的第一个独立整数
+    let re_num = Regex::new(r"\b(\d+)\b").ok()?;
+    if let Some(caps) = re_num.captures(content) {
+        if let Ok(id) = caps[1].parse::<i32>() {
+            return Some((id, "parsed first number from text".into()));
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_fallback_speaker() {
+        assert_eq!(
+            parse_fallback_speaker("我选择 role_id=3 继续发言"),
+            Some((3, "parsed role_id from text".into()))
+        );
+        assert_eq!(
+            parse_fallback_speaker("role_id = 0"),
+            Some((0, "parsed role_id from text".into()))
+        );
+        assert_eq!(
+            parse_fallback_speaker("交给玩家，选择 0"),
+            Some((0, "parsed first number from text".into()))
+        );
+        assert!(parse_fallback_speaker("I can't continue.").is_none());
     }
 }

--- a/src-tauri/src/ai_service/llm/providers/kimi_code.rs
+++ b/src-tauri/src/ai_service/llm/providers/kimi_code.rs
@@ -99,6 +99,17 @@ impl KimiCodeProvider {
             }
         }
 
+        // 转换工具定义为 Anthropic 原生格式
+        let anthropic_tools: Option<Vec<AnthropicTool>> = tools.map(|ts| {
+            ts.iter()
+                .map(|t| AnthropicTool {
+                    name: t.function.name.clone(),
+                    description: t.function.description.clone(),
+                    input_schema: t.function.parameters.clone(),
+                })
+                .collect()
+        });
+
         MessagesRequest {
             model: &self.model,
             max_tokens: 65536,
@@ -107,16 +118,17 @@ impl KimiCodeProvider {
             top_p: self.top_p,
             system: if system_text.is_empty() { None } else { Some(system_text) },
             messages: conversation,
-            tools,
+            tools: anthropic_tools,
             tool_choice,
             thinking: if self.enable_thinking {
                 Some(ThinkingConfig {
                     type_: "enabled".to_string(),
                 })
             } else {
-                Some(ThinkingConfig {
-                    type_: "disabled".to_string(),
-                })
+                // Kimi Code 后端（Fable）会拒绝显式的 thinking: {type: "disabled"}，
+                // 所以关闭思考链时直接省略该字段。参考 kimi-code 官方 anthropic provider:
+                // https://github.com/MoonshotAI/kimi-code/blob/main/packages/kosong/src/providers/anthropic.ts
+                None
             },
         }
     }
@@ -164,15 +176,32 @@ impl LlmProvider for KimiCodeProvider {
         tools: &[ToolDefinition],
         tool_choice: Option<&str>,
     ) -> Result<LlmResponseWithTools> {
-        let tool_choice_value = tool_choice.map(|tc| {
-            if tc == "auto" || tc == "none" || tc == "required" {
-                serde_json::Value::String(tc.to_string())
-            } else {
-                serde_json::from_str(tc).unwrap_or(serde_json::Value::String("auto".to_string()))
+        // Anthropic Messages API 的 tool_choice 格式与 OpenAI 不同：
+        // OpenAI: "auto" | "none" | "required" | {"type": "function", "function": {"name": "..."}}
+        // Anthropic: {"type": "auto"} | {"type": "any"} | {"type": "tool", "name": "..."}
+        let anthropic_tool_choice: Option<serde_json::Value> = tool_choice.map(|tc| {
+            match tc {
+                "auto" | "none" => serde_json::json!({"type": "auto"}),
+                "required" => serde_json::json!({"type": "any"}),
+                _ => {
+                    // 尝试解析 OpenAI 的 function 指定格式
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(tc) {
+                        if v.get("type").and_then(|t| t.as_str()) == Some("function") {
+                            if let Some(name) = v.get("function").and_then(|f| f.get("name")).and_then(|n| n.as_str()) {
+                                return serde_json::json!({"type": "tool", "name": name});
+                            }
+                        }
+                    }
+                    serde_json::json!({"type": "auto"})
+                }
             }
         });
 
-        let body = self.build_request(messages, false, Some(tools), tool_choice_value);
+        let body = self.build_request(messages, false, Some(tools), anthropic_tool_choice);
+        if let Ok(body_json) = serde_json::to_string(&body) {
+            tracing::debug!("[KimiCode] complete_with_tools request body: {}", body_json);
+        }
+
         let resp = http
             .post(self.endpoint())
             .headers(self.headers()?)
@@ -256,12 +285,11 @@ impl LlmProvider for KimiCodeProvider {
                         let Some(data) = line.strip_prefix("data:") else { continue };
                         let data = data.trim();
                         if data == "[DONE]" {
-                            // 流式响应结束前输出剩余的 thinking 内容
-                            if !thinking_buffer.is_empty() {
+                            // 流式响应结束前只输出尚未发送的 thinking 增量，避免重复。
+                            if thinking_buffer.len() > last_flush_len {
+                                let delta = &thinking_buffer[last_flush_len..];
                                 tracing::info!("[Kimi-Code Thinking] {}", thinking_buffer);
-                                yield LlmChunk::Reasoning(thinking_buffer.clone());
-                                thinking_buffer.clear();
-                                last_flush_len = 0;
+                                yield LlmChunk::Reasoning(delta.to_string());
                             }
                             // 如果 text 为空但 thinking 有内容，把 thinking 作为正式回复兜底
                             if text_buffer.is_empty() && !thinking_buffer.is_empty() {
@@ -315,10 +343,11 @@ impl LlmProvider for KimiCodeProvider {
                     last_flush_len = thinking_buffer.len();
                 }
             }
-            // 流正常结束时也输出未打印的 thinking
-            if !thinking_buffer.is_empty() {
+            // 流正常结束时也只输出尚未发送的 thinking 增量。
+            if thinking_buffer.len() > last_flush_len {
+                let delta = &thinking_buffer[last_flush_len..];
                 tracing::info!("[Kimi-Code Thinking] {}", thinking_buffer);
-                yield LlmChunk::Reasoning(thinking_buffer.clone());
+                yield LlmChunk::Reasoning(delta.to_string());
             }
             // 兜底：text 为空时使用 thinking
             if text_buffer.is_empty() && !thinking_buffer.is_empty() {
@@ -338,6 +367,14 @@ impl LlmProvider for KimiCodeProvider {
 // ============================================================
 
 #[derive(Serialize)]
+struct AnthropicTool {
+    name: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    description: String,
+    input_schema: serde_json::Value,
+}
+
+#[derive(Serialize)]
 struct MessagesRequest<'a> {
     model: &'a str,
     max_tokens: u32,
@@ -350,7 +387,7 @@ struct MessagesRequest<'a> {
     system: Option<String>,
     messages: Vec<AnthropicMessage<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tools: Option<&'a [ToolDefinition]>,
+    tools: Option<Vec<AnthropicTool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src-tauri/src/ai_service/message_system/events.rs
+++ b/src-tauri/src/ai_service/message_system/events.rs
@@ -39,8 +39,9 @@ pub fn emit<T: Serialize + Clone>(app: &AppHandle, event: &str, payload: &T) -> 
 }
 
 /// 通知前端 AI 正在思考或结束思考。
-pub fn emit_thinking(app: &AppHandle, is_thinking: bool) {
-    let payload = super::responses::ThinkingResponse::new(is_thinking);
+/// `is_proactive` 为 true 时表示这是主动回复触发的前置思考，前端可据此显示"主动回复中"。
+pub fn emit_thinking(app: &AppHandle, is_thinking: bool, is_proactive: bool) {
+    let payload = super::responses::ThinkingResponse::new(is_thinking, is_proactive);
     if let Err(e) = app.emit(super::responses::event_names::AI_THINKING, &payload) {
         tracing::warn!("emit thinking 失败: {e}");
     }
@@ -51,6 +52,14 @@ pub fn emit_thinking_progress(app: &AppHandle, thinking_length: usize) {
     let payload = super::responses::ThinkingProgressResponse::new(thinking_length);
     if let Err(e) = app.emit(super::responses::event_names::AI_THINKING_PROGRESS, &payload) {
         tracing::warn!("emit thinking_progress 失败: {e}");
+    }
+}
+
+/// 通知前端主动回复的思考状态切换。
+pub fn emit_proactive_thinking(app: &AppHandle, is_thinking: bool) {
+    let payload = super::responses::ProactiveThinkingResponse::new(is_thinking);
+    if let Err(e) = app.emit(super::responses::event_names::AI_PROACTIVE_THINKING, &payload) {
+        tracing::warn!("emit proactive_thinking 失败: {e}");
     }
 }
 

--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -45,6 +45,8 @@ pub struct GeneratorDeps {
     pub god_agent: Option<Arc<GodAgentCore>>,
     /// 抑制 ai:thinking 事件。用于系统触发的后台生成（如入场问候）。
     pub suppress_thinking: bool,
+    /// 标记本次生成是否由主动回复触发，用于前端区分思考状态文案。
+    pub is_proactive: bool,
 }
 
 /// `process_message` 各步骤间传递的用户消息上下文。
@@ -225,7 +227,7 @@ impl MessageGenerator {
         user_msg_seq: Option<u32>,
     ) -> Result<String> {
         if !self.deps.suppress_thinking {
-            events::emit_thinking(&self.deps.app, true);
+            events::emit_thinking(&self.deps.app, true, self.deps.is_proactive);
         }
 
         match self
@@ -234,14 +236,14 @@ impl MessageGenerator {
         {
             Ok(acc) => {
                 if !self.deps.suppress_thinking {
-                    events::emit_thinking(&self.deps.app, false);
+                    events::emit_thinking(&self.deps.app, false, self.deps.is_proactive);
                 }
                 Ok(acc)
             }
             Err(e) => {
                 events::emit_error(&self.deps.app, &e);
                 if !self.deps.suppress_thinking {
-                    events::emit_thinking(&self.deps.app, false);
+                    events::emit_thinking(&self.deps.app, false, self.deps.is_proactive);
                 }
                 Err(e)
             }

--- a/src-tauri/src/ai_service/message_system/responses.rs
+++ b/src-tauri/src/ai_service/message_system/responses.rs
@@ -16,6 +16,8 @@ pub mod event_names {
     pub const AI_THINKING: &str = "ai:thinking";
     /// AI 思考链字数进度（流式统计，仅在启用思考链时触发）。
     pub const AI_THINKING_PROGRESS: &str = "ai:thinking_progress";
+    /// 主动回复思考状态切换。
+    pub const AI_PROACTIVE_THINKING: &str = "ai:proactive_thinking";
     /// TTS 语音缓存（孤立文件）清理结果。
     pub const TTS_CLEANUP: &str = "tts:cleanup";
     /// AI 侧错误（鉴权失败 / 网络错误等）。
@@ -85,14 +87,17 @@ pub struct ThinkingResponse {
     pub type_: String,
     pub is_thinking: bool,
     pub duration: f64,
+    /// 标记这次思考是否来自主动回复触发，用于前端区分 placeholder 文案。
+    pub is_proactive: bool,
 }
 
 impl ThinkingResponse {
-    pub fn new(is_thinking: bool) -> Self {
+    pub fn new(is_thinking: bool, is_proactive: bool) -> Self {
         Self {
             type_: "thinking".to_string(),
             is_thinking,
             duration: 0.0,
+            is_proactive,
         }
     }
 }
@@ -111,6 +116,23 @@ impl ThinkingProgressResponse {
         Self {
             type_: "thinking_progress".to_string(),
             thinking_length,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProactiveThinkingResponse {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub is_thinking: bool,
+}
+
+impl ProactiveThinkingResponse {
+    pub fn new(is_thinking: bool) -> Self {
+        Self {
+            type_: "proactive_thinking".to_string(),
+            is_thinking,
         }
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/activity_monitor.rs
+++ b/src-tauri/src/ai_service/proactive_system/activity_monitor.rs
@@ -1,6 +1,11 @@
 use crate::ai_service::proactive_system::types::{PerceptionResult, UserState};
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
+
+const ACTIVITY_WINDOW: Duration = Duration::from_secs(20);
+const MOVE_SAMPLE_INTERVAL: Duration = Duration::from_millis(25);
+const MAX_ACTIVITY_EVENTS: usize = 4096;
 
 #[cfg(target_os = "windows")]
 use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
@@ -34,8 +39,8 @@ struct ActivityEvent {
 }
 
 struct MonitorInner {
-    events: Vec<ActivityEvent>,
-    last_mouse_pos: Option<(i32, i32)>,
+    events: VecDeque<ActivityEvent>,
+    last_move_sample_at: Option<Instant>,
 }
 
 pub struct UserActivityMonitor {
@@ -52,8 +57,8 @@ static GLOBAL_MONITOR_INNER: OnceLock<Arc<Mutex<MonitorInner>>> = OnceLock::new(
 impl UserActivityMonitor {
     pub fn new() -> Self {
         let inner = Arc::new(Mutex::new(MonitorInner {
-            events: Vec::new(),
-            last_mouse_pos: None,
+            events: VecDeque::new(),
+            last_move_sample_at: None,
         }));
 
         GLOBAL_MONITOR_INNER.get_or_init(|| inner.clone());
@@ -117,17 +122,25 @@ impl UserActivityMonitor {
     pub fn get_user_status(&self) -> PerceptionResult {
         let mut inner = self.inner.lock().unwrap();
         let now = Instant::now();
-        let cutoff = now - Duration::from_secs(20);
+        let cutoff = now - ACTIVITY_WINDOW;
 
         // Slide window
-        inner.events.retain(|e| e.timestamp >= cutoff);
+        while inner
+            .events
+            .front()
+            .is_some_and(|event| event.timestamp < cutoff)
+        {
+            inner.events.pop_front();
+        }
 
         let mut keystrokes = 0;
         let mut game_keys = 0;
         let mut clicks = 0;
         let mut mouse_distance = 0.0;
 
-        let mut running_last_pos = inner.last_mouse_pos;
+        // 只在当前滑动窗口内部计算相邻采样点距离。不能以上一轮的最新坐标作为
+        // 起点，否则会先从“最新点”跳回本轮最旧点，凭空制造一段巨大移动距离。
+        let mut running_last_pos = None;
         for event in &inner.events {
             match &event.input_type {
                 InputType::Key { is_game } => {
@@ -149,8 +162,6 @@ impl UserActivityMonitor {
                 }
             }
         }
-        inner.last_mouse_pos = running_last_pos;
-
         let game_ratio = if keystrokes > 0 {
             game_keys as f64 / keystrokes as f64
         } else {
@@ -210,6 +221,21 @@ impl UserActivityMonitor {
     }
 }
 
+fn push_activity_event(inner: &mut MonitorInner, event: ActivityEvent) {
+    let cutoff = event.timestamp - ACTIVITY_WINDOW;
+    while inner
+        .events
+        .front()
+        .is_some_and(|old| old.timestamp < cutoff)
+    {
+        inner.events.pop_front();
+    }
+    if inner.events.len() >= MAX_ACTIVITY_EVENTS {
+        inner.events.pop_front();
+    }
+    inner.events.push_back(event);
+}
+
 #[cfg(target_os = "windows")]
 unsafe extern "system" fn keyboard_hook_callback(
     code: i32,
@@ -230,10 +256,13 @@ unsafe extern "system" fn keyboard_hook_callback(
 
             if let Some(inner_arc) = GLOBAL_MONITOR_INNER.get() {
                 if let Ok(mut inner) = inner_arc.lock() {
-                    inner.events.push(ActivityEvent {
-                        timestamp: Instant::now(),
-                        input_type: InputType::Key { is_game },
-                    });
+                    push_activity_event(
+                        &mut inner,
+                        ActivityEvent {
+                            timestamp: Instant::now(),
+                            input_type: InputType::Key { is_game },
+                        },
+                    );
                 }
             }
         }
@@ -255,15 +284,35 @@ unsafe extern "system" fn mouse_hook_callback(
         if let Some(inner_arc) = GLOBAL_MONITOR_INNER.get() {
             if let Ok(mut inner) = inner_arc.lock() {
                 if msg == WM_LBUTTONDOWN || msg == WM_RBUTTONDOWN || msg == WM_MBUTTONDOWN {
-                    inner.events.push(ActivityEvent {
-                        timestamp: Instant::now(),
-                        input_type: InputType::Click,
-                    });
+                    push_activity_event(
+                        &mut inner,
+                        ActivityEvent {
+                            timestamp: Instant::now(),
+                            input_type: InputType::Click,
+                        },
+                    );
                 } else if msg == WM_MOUSEMOVE {
-                    inner.events.push(ActivityEvent {
-                        timestamp: Instant::now(),
-                        input_type: InputType::Move { x: pt.x, y: pt.y },
-                    });
+                    let now = Instant::now();
+                    let should_append = inner
+                        .last_move_sample_at
+                        .is_none_or(|last| now.duration_since(last) >= MOVE_SAMPLE_INTERVAL);
+                    if should_append {
+                        inner.last_move_sample_at = Some(now);
+                        push_activity_event(
+                            &mut inner,
+                            ActivityEvent {
+                                timestamp: now,
+                                input_type: InputType::Move { x: pt.x, y: pt.y },
+                            },
+                        );
+                    } else if let Some(last) = inner.events.back_mut() {
+                        // 在采样间隔内只更新最后一个坐标，既保留位移终点又避免
+                        // WM_MOUSEMOVE 高频事件撑大队列、拖慢低级钩子回调。
+                        if matches!(last.input_type, InputType::Move { .. }) {
+                            last.timestamp = now;
+                            last.input_type = InputType::Move { x: pt.x, y: pt.y };
+                        }
+                    }
                 }
             }
         }

--- a/src-tauri/src/ai_service/proactive_system/delivery_evaluator.rs
+++ b/src-tauri/src/ai_service/proactive_system/delivery_evaluator.rs
@@ -18,9 +18,83 @@ impl DeliveryEvaluator {
             tracing::debug!("[DeliveryEval] can_deliver=false (frontend report)");
             return false;
         }
-        /*
-        Tips: 此处可以添加更多判断逻辑，比如过滤掉无意义对话等
-         */
-        true
+
+        let allowed = match intent_type {
+            // 明确的日程闹钟优先级最高，只要前端允许即可投递。
+            IntentType::Alarm => true,
+            // 重要日子不应在全屏游戏时打断用户。
+            IntentType::ImportantDay => perception.state != UserState::GAME,
+            // TODO 在工作状态下也可能有价值，但游戏中不应弹出。
+            IntentType::Todo => perception.state != UserState::GAME,
+            // 屏幕评论只在轻度活动/浏览时投递；工作、游戏和真正挂机时容易过时或打扰。
+            IntentType::Screen => {
+                matches!(perception.state, UserState::BROWSING | UserState::CASUAL)
+            }
+            // 无明确事项的闲聊只在用户空闲或轻度活动时发起。
+            IntentType::Topic => {
+                matches!(perception.state, UserState::IDLE | UserState::CASUAL)
+            }
+        };
+
+        if !allowed {
+            tracing::debug!(
+                "[DeliveryEval] {:?} suppressed for user state {:?}",
+                intent_type,
+                perception.state
+            );
+        }
+        allowed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn perception(state: UserState) -> PerceptionResult {
+        PerceptionResult {
+            state,
+            description: String::new(),
+            interest_modifier: 0,
+            visual_change_detected: false,
+            current_screen_text: String::new(),
+        }
+    }
+
+    #[test]
+    fn frontend_gate_always_wins() {
+        assert!(!DeliveryEvaluator::can_deliver(
+            IntentType::Alarm,
+            &perception(UserState::IDLE),
+            false,
+        ));
+    }
+
+    #[test]
+    fn topic_does_not_interrupt_work_or_game() {
+        assert!(!DeliveryEvaluator::can_deliver(
+            IntentType::Topic,
+            &perception(UserState::WORK),
+            true,
+        ));
+        assert!(!DeliveryEvaluator::can_deliver(
+            IntentType::Topic,
+            &perception(UserState::GAME),
+            true,
+        ));
+        assert!(DeliveryEvaluator::can_deliver(
+            IntentType::Topic,
+            &perception(UserState::CASUAL),
+            true,
+        ));
+    }
+
+    #[test]
+    fn alarms_are_allowed_in_busy_states() {
+        assert!(DeliveryEvaluator::can_deliver(
+            IntentType::Alarm,
+            &perception(UserState::GAME),
+            true,
+        ));
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/interest_manager.rs
+++ b/src-tauri/src/ai_service/proactive_system/interest_manager.rs
@@ -1,3 +1,4 @@
+use chrono::Local;
 use rand::Rng;
 
 pub struct InterestManager {
@@ -8,18 +9,12 @@ pub struct InterestManager {
     pub max_proactive_count: i32,
     pub decay_step: f64,
     pub proactive_times: i32,
+    pub trigger_threshold: f64,
+    pub last_reset_date: String,
 }
 
 impl InterestManager {
-    pub fn new(max_proactive_count: i32) -> Self {
-        // 计算 decay_step: 50.0 / max_proactive_count
-        // 注意：需要处理 max_proactive_count 为 0 的情况，防止除以零导致 panic 或产生 NaN/Inf
-        let decay_step = if max_proactive_count > 0 {
-            50.0 / max_proactive_count as f64
-        } else {
-            0.0 // 如果最大次数为0，则不衰减
-        };
-
+    pub fn new(max_proactive_count: i32, trigger_threshold: f64, decay_step: f64) -> Self {
         Self {
             interest: 0.0,
             max_interest_cap: 100.0,
@@ -28,22 +23,32 @@ impl InterestManager {
             max_proactive_count,
             decay_step,
             proactive_times: 0,
+            trigger_threshold,
+            last_reset_date: Local::now().format("%Y-%m-%d").to_string(),
         }
     }
 
-    pub fn update_from_config(&mut self, max_proactive_count: i32) {
+    pub fn update_from_config(
+        &mut self,
+        max_proactive_count: i32,
+        trigger_threshold: f64,
+        decay_step: f64,
+    ) {
         self.max_proactive_count = max_proactive_count;
-        // 当配置更新时，同步更新 decay_step
-        self.decay_step = if max_proactive_count > 0 {
-            50.0 / max_proactive_count as f64
-        } else {
-            0.0
-        };
+        self.trigger_threshold = trigger_threshold;
+        self.decay_step = decay_step;
     }
 
-    pub fn update_interest(&mut self) {
+    /// 根据用户状态更新兴趣度。
+    /// 用户越活跃（游戏/浏览）增长越快；工作/挂机时增长更慢。
+    pub fn update_interest(&mut self, status_mod: i32) {
+        self.status_mod = status_mod;
+
         let mut rng = rand::thread_rng();
-        let growth = rng.gen_range(5.0..10.0);
+        let base_growth = rng.gen_range(5.0..10.0);
+        // 状态修正：正 modifier 加速，负 modifier 减速，但不会让增长低于 1
+        let growth = (base_growth + status_mod as f64 * 0.3).max(1.0);
+
         self.interest = (self.interest + growth).min(self.max_interest_cap);
         tracing::info!(
             "[Engagement] Interest grown by {:.2}. Current: {:.2}/{:.2}",
@@ -58,17 +63,25 @@ impl InterestManager {
             return false;
         }
 
-        if self.interest <= 50.0 {
+        if self.interest <= self.trigger_threshold {
             return false;
         }
 
         let mut rng = rand::thread_rng();
-        let prob = (self.interest + self.status_mod as f64 - 50.0) / 50.0;
+        // prob 从 0 到 1 线性增长：刚好到阈值时为 0，达到 cap 时为 1
+        let range = self.max_interest_cap - self.trigger_threshold;
+        let prob = if range <= 0.0 {
+            1.0
+        } else {
+            (self.interest + self.status_mod as f64 - self.trigger_threshold) / range
+        };
+        let prob = prob.clamp(0.0, 1.0);
         let roll = rng.gen_range(0.0..1.0);
         let triggered = roll < prob;
 
         tracing::info!(
-            "[Engagement] Trigger check: prob={:.2}, roll={:.2}, triggered={}",
+            "[Engagement] Trigger check: threshold={:.2}, prob={:.2}, roll={:.2}, triggered={}",
+            self.trigger_threshold,
             prob,
             roll,
             triggered
@@ -84,7 +97,10 @@ impl InterestManager {
     }
 
     pub fn decay_max_interest_cap(&mut self) {
-        self.max_interest_cap = (self.max_interest_cap - self.decay_step).max(50.0);
+        // 衰减后至少保留触发阈值 + 5 或 20 分，确保上限始终高于阈值，
+        // 避免 interest 永远涨不过 threshold 导致主动回复卡死
+        let floor = (self.trigger_threshold + 5.0).max(20.0);
+        self.max_interest_cap = (self.max_interest_cap - self.decay_step).max(floor);
         tracing::info!("[Engagement] Cap decayed to {:.2}", self.max_interest_cap);
     }
 
@@ -92,9 +108,22 @@ impl InterestManager {
         self.max_interest_cap = self.initial_max_cap;
         self.proactive_times = 0;
         self.interest = 0.0;
+        self.last_reset_date = Local::now().format("%Y-%m-%d").to_string();
     }
 
-    pub fn set_status_mod(&mut self, val: i32) {
-        self.status_mod = val;
+    /// 跨天时重置每日计数与上限，确保每天最多触发 `max_proactive_count` 次。
+    pub fn check_daily_reset(&mut self) {
+        let today = Local::now().format("%Y-%m-%d").to_string();
+        if self.last_reset_date != today {
+            tracing::info!(
+                "[Engagement] New day reset: {} -> {}, restoring cap and proactive count",
+                self.last_reset_date,
+                today
+            );
+            self.max_interest_cap = self.initial_max_cap;
+            self.proactive_times = 0;
+            self.interest = 0.0;
+            self.last_reset_date = today;
+        }
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/mod.rs
+++ b/src-tauri/src/ai_service/proactive_system/mod.rs
@@ -2,6 +2,7 @@ pub mod activity_monitor;
 pub mod config;
 pub mod delivery_evaluator;
 pub mod interest_manager;
+pub mod proactive_history;
 pub mod schedule_manager;
 pub mod strategy_dispatcher;
 pub mod types;
@@ -9,14 +10,17 @@ pub mod visual_monitor;
 
 use sea_orm::DatabaseConnection;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::AppHandle;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
 use tokio::task::JoinHandle;
 
+use crate::ai_service::llm::LlmClient;
 use crate::ai_service::message_system::events;
 use crate::ai_service::message_system::generator::{GeneratorDeps, MessageGenerator};
+use crate::ai_service::message_system::processor::MessageProcessor;
 use crate::ai_service::service::SharedAIService;
+use crate::ai_service::translator::Translator;
 use crate::ai_service::types::{LineAttributeExt, LineBase};
 use crate::db::entities::line::LineAttribute;
 use crate::utils::prompt::PromptRole;
@@ -28,8 +32,12 @@ use delivery_evaluator::DeliveryEvaluator;
 use interest_manager::InterestManager;
 use schedule_manager::ScheduleManager;
 use strategy_dispatcher::StrategyDispatcher;
-use types::{IntentType, PendingIntent, UserScheduleSettings};
+use types::{IntentType, PendingIntent, PerceptionResult, ProactiveContext, UserScheduleSettings};
 use visual_monitor::VisualMonitor;
+
+const MAX_PENDING_INTENTS: usize = 5;
+const MAX_SAFE_DELIVERY_ATTEMPTS: u8 = 3;
+const DELIVERY_FAILURE_BACKOFF: Duration = Duration::from_secs(60);
 
 pub struct ProactiveSystem {
     app: AppHandle,
@@ -44,7 +52,7 @@ pub struct ProactiveSystem {
     activity_monitor: UserActivityMonitor,
     visual_monitor: VisualMonitor,
     schedule_manager: ScheduleManager,
-    strategy_dispatcher: StrategyDispatcher,
+    strategy_dispatcher: Arc<StrategyDispatcher>,
 
     loop_handle: Option<JoinHandle<()>>,
     is_running: bool,
@@ -52,8 +60,161 @@ pub struct ProactiveSystem {
     /// 前端上报的“当前是否适合投放主动对话”。
     /// 条件：用户在聊天界面(/chat 或 /pet) 且 设置面板未打开 且 输入框为空。
     can_deliver: bool,
+    /// 每次用户主动发言递增；让在途视觉/闲聊结果可被识别为过期。
+    interaction_epoch: u64,
+    /// 模型/消费者失败后的全局退避，避免每轮重新污染上下文。
+    delivery_backoff_until: Option<Instant>,
     /// 暂存的主动对话意图（"小本本"）。每轮 cycle 开头尝试投放。
-    pending_intents: Vec<PendingIntent>,}
+    pending_intents: Vec<PendingIntent>,
+}
+
+/// 可以脱离 `ProactiveSystem` 大锁执行投递的只读依赖快照。
+#[derive(Clone)]
+struct DeliveryContext {
+    app: AppHandle,
+    db: DatabaseConnection,
+    ai_service: SharedAIService,
+    generation_lock: Arc<Mutex<()>>,
+    processor: Arc<MessageProcessor>,
+    translator: Arc<Translator>,
+    llm: Option<Arc<LlmClient>>,
+}
+
+/// 确保主动生成 future 被取消或任务被 abort 时也会恢复前端思考状态。
+struct ProactiveThinkingGuard {
+    app: AppHandle,
+}
+
+impl ProactiveThinkingGuard {
+    fn new(app: &AppHandle) -> Self {
+        events::emit_thinking(app, true, true);
+        events::emit_proactive_thinking(app, true);
+        Self { app: app.clone() }
+    }
+}
+
+impl Drop for ProactiveThinkingGuard {
+    fn drop(&mut self) {
+        events::emit_proactive_thinking(&self.app, false);
+        events::emit_thinking(&self.app, false, true);
+    }
+}
+
+impl DeliveryContext {
+    fn try_generation_guard(&self) -> Option<OwnedMutexGuard<()>> {
+        self.generation_lock.clone().try_lock_owned().ok()
+    }
+
+    async fn rollback_prompt_line(
+        &self,
+        game_status: &Arc<Mutex<crate::ai_service::game_system::game_status::GameStatus>>,
+        prompt_index: usize,
+        expected_prompt: &str,
+    ) {
+        let mut gs = game_status.lock().await;
+        let is_our_prompt = gs.line_list.get(prompt_index).is_some_and(|line| {
+            matches!(line.attribute(), LineAttribute::User)
+                && line.base.sender_role_id.is_none()
+                && line.base.content == expected_prompt
+        });
+        if !is_our_prompt {
+            return;
+        }
+
+        gs.line_list.remove(prompt_index);
+        if let Err(error) = gs.refresh_memories(&self.db).await {
+            tracing::error!(
+                "[ProactiveSystem] Failed to refresh memories after prompt rollback: {error:#}"
+            );
+        }
+    }
+
+    /// 调用方必须先取得 generation guard，并在取得后重新验证投放条件。
+    async fn deliver(
+        &self,
+        prompt: String,
+        _generation_guard: OwnedMutexGuard<()>,
+    ) -> anyhow::Result<String> {
+        let llm = self
+            .llm
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("LLM is not configured"))?;
+
+        let game_status = {
+            let svc = self.ai_service.lock().await;
+            svc.game_status.clone()
+        };
+        let generator = MessageGenerator::new(GeneratorDeps {
+            app: self.app.clone(),
+            db: self.db.clone(),
+            game_status: game_status.clone(),
+            processor: self.processor.clone(),
+            translator: self.translator.clone(),
+            llm,
+            concurrency: 1,
+            god_agent: None,
+            // 由本方法统一维护 thinking 状态，确保所有错误路径都能复位。
+            suppress_thinking: true,
+            is_proactive: true,
+        });
+
+        let _thinking_guard = ProactiveThinkingGuard::new(&self.app);
+
+        let expected_prompt = prompt.clone();
+        let (prompt_index, add_result) = {
+            let mut gs = game_status.lock().await;
+            let prompt_index = gs.line_list.len();
+            let result = gs
+                .add_line(
+                    &self.db,
+                    LineBase {
+                        attribute: LineAttributeExt(LineAttribute::User),
+                        content: prompt,
+                        sender_role_id: None,
+                        display_name: None,
+                        ..Default::default()
+                    },
+                )
+                .await;
+            (prompt_index, result)
+        };
+        if let Err(error) = add_result {
+            self.rollback_prompt_line(&game_status, prompt_index, &expected_prompt)
+                .await;
+            return Err(error);
+        }
+
+        let generation_result = generator.process_message(None).await;
+        let assistant_count = {
+            let gs = game_status.lock().await;
+            gs.line_list
+                .iter()
+                .skip(prompt_index + 1)
+                .filter(|line| matches!(line.attribute(), LineAttribute::Assistant))
+                .count()
+        };
+
+        match generation_result {
+            Ok(output) if assistant_count > 0 => Ok(output),
+            Ok(_) => {
+                self.rollback_prompt_line(&game_status, prompt_index, &expected_prompt)
+                    .await;
+                anyhow::bail!("proactive generation produced no persisted assistant response")
+            }
+            Err(error) if assistant_count > 0 => {
+                tracing::warn!(
+                    "[ProactiveSystem] Generator ended with an error after persisting {assistant_count} response line(s): {error:#}"
+                );
+                Ok(String::new())
+            }
+            Err(error) => {
+                self.rollback_prompt_line(&game_status, prompt_index, &expected_prompt)
+                    .await;
+                Err(error)
+            }
+        }
+    }
+}
 
 impl ProactiveSystem {
     pub fn new(
@@ -64,13 +225,17 @@ impl ProactiveSystem {
         generation_lock: Arc<Mutex<()>>,
     ) -> Self {
         let config = ProactiveConfig::load(&app);
-        let interest_manager = InterestManager::new(config.max_proactive_times);
+        let interest_manager = InterestManager::new(
+            config.max_proactive_times,
+            config.interest_trigger_threshold,
+            config.interest_decay_step,
+        );
         let activity_monitor = UserActivityMonitor::new();
         let visual_monitor = VisualMonitor::new();
         let schedule_manager = ScheduleManager::new();
-        let strategy_dispatcher = StrategyDispatcher::new(&app);
+        let strategy_dispatcher = Arc::new(StrategyDispatcher::new(&app));
 
-        let system = Self {
+        Self {
             app,
             db,
             ai_service,
@@ -86,10 +251,43 @@ impl ProactiveSystem {
             loop_handle: None,
             is_running: false,
             can_deliver: false,
+            interaction_epoch: 0,
+            delivery_backoff_until: None,
             pending_intents: Vec::new(),
-        };
+        }
+    }
 
-        system
+    fn delivery_context(&self) -> DeliveryContext {
+        DeliveryContext {
+            app: self.app.clone(),
+            db: self.db.clone(),
+            ai_service: self.ai_service.clone(),
+            generation_lock: self.generation_lock.clone(),
+            processor: self.chat.processor.clone(),
+            translator: self.chat.translator.clone(),
+            llm: self.chat.llm.clone(),
+        }
+    }
+
+    /// 只复制策略需要的少量状态，绝不把 GameStatus guard 带入 VLM 网络请求。
+    async fn read_runtime_context(ai_service: &SharedAIService) -> (ProactiveContext, bool) {
+        let game_status = {
+            let svc = ai_service.lock().await;
+            svc.game_status.clone()
+        };
+        let gs = game_status.lock().await;
+        let ai_name = gs
+            .current_role_id
+            .and_then(|rid| gs.role_manager.get_loaded(rid))
+            .and_then(|role| role.display_name.clone())
+            .unwrap_or_else(|| "你".to_string());
+        (
+            ProactiveContext {
+                user_name: gs.player.user_name.clone(),
+                ai_name,
+            },
+            gs.script_status.is_some(),
+        )
     }
 
     /// 启动主动对话的后台轮询 Loop。
@@ -107,30 +305,28 @@ impl ProactiveSystem {
         let handle = tokio::spawn(async move {
             tracing::info!("[ProactiveSystem] Loop task started.");
 
-            // Loop runs every 30 seconds
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
             loop {
-                interval.tick().await;
-
-                // Grab locks safely to avoid blocking startup or chat interaction
-                let (enabled, is_script_active) = {
+                // 每次循环从配置读取最新轮询间隔，保存后无需重启即可生效
+                let interval_secs = {
                     let sys = sys_clone.lock().await;
                     if !sys.is_running {
                         break;
                     }
+                    sys.config.proactive_interval_secs.max(1)
+                };
 
-                    let svc = sys.ai_service.lock().await;
-                    let is_script_active = svc.game_status.lock().await.script_status.is_some();
-                    (sys.config.enable_proactive_system, is_script_active)
+                tokio::time::sleep(Duration::from_secs(interval_secs)).await;
+
+                let enabled = {
+                    let sys = sys_clone.lock().await;
+                    if !sys.is_running {
+                        break;
+                    }
+                    sys.config.enable_proactive_system
                 };
 
                 if !enabled {
                     // tracing::info!("[ProactiveSystem] Disabled via settings, skipping...");
-                    continue;
-                }
-
-                if is_script_active {
-                    // tracing::info!("[ProactiveSystem] Script is currently running, bypassing proactive talk to avoid collision.");
                     continue;
                 }
 
@@ -155,12 +351,94 @@ impl ProactiveSystem {
     }
 
     /// 重新载入环境配置和日程设置。
-    pub async fn reload(&mut self) {
-        self.config = ProactiveConfig::load(&self.app);
-        self.strategy_dispatcher.update_config(&self.app);
-        self.interest_manager
-            .update_from_config(self.config.max_proactive_times);
-        self.load_schedule_settings().await;
+    pub async fn reload(system_arc: Arc<Mutex<Self>>) {
+        // ScreenAnalyzer 可能被一次较慢的 VLM 请求占用。复制依赖后先释放系统锁，
+        // 避免配置重载期间阻塞 can_deliver 上报和用户消息回调。
+        let (app, strategy) = {
+            let sys = system_arc.lock().await;
+            (sys.app.clone(), sys.strategy_dispatcher.clone())
+        };
+        let config = ProactiveConfig::load(&app);
+        {
+            let mut sys = system_arc.lock().await;
+            sys.config = config.clone();
+            sys.delivery_backoff_until = None;
+            if !config.enable_proactive_system {
+                sys.pending_intents.clear();
+            } else {
+                sys.pending_intents.retain(|intent| {
+                    Self::intent_enabled(&config, intent.intent_type)
+                        && (intent.intent_type == IntentType::Alarm
+                            || config.max_proactive_times > 0)
+                });
+            }
+            sys.interest_manager.update_from_config(
+                config.max_proactive_times,
+                config.interest_trigger_threshold,
+                config.interest_decay_step,
+            );
+        }
+
+        // 这一步可能等待正在进行的 VLM，但已不再持有 ProactiveSystem 锁。
+        strategy.update_config(&app).await;
+        system_arc.lock().await.load_schedule_settings().await;
+    }
+
+    /// 手动触发一次基于屏幕的主动搭话测试，直接截屏 → VLM → 投递到前端。
+    /// 跳过兴趣累积、投放闸门和反重复检测，用于在设置页快速验证视觉主动回复链路。
+    pub async fn test_screen_proactive(
+        system_arc: Arc<Mutex<Self>>,
+    ) -> Result<Option<String>, String> {
+        let (ai_service, strategy, delivery) = {
+            let sys = system_arc.lock().await;
+            (
+                sys.ai_service.clone(),
+                sys.strategy_dispatcher.clone(),
+                sys.delivery_context(),
+            )
+        };
+
+        tracing::info!("[ProactiveSystem] Test proactive message triggered.");
+
+        let prompt_result = async {
+            let (context, script_active) = Self::read_runtime_context(&ai_service).await;
+            if script_active {
+                return Err("剧情正在运行，暂不执行主动消息测试".to_string());
+            }
+            let (raw_prompt, _intent_type) = strategy
+                .get_screen_prompt_for_test(&context)
+                .await
+                .ok_or_else(|| {
+                    "屏幕分析未返回有效内容（API Key 为空、网络超时或模型不支持视觉）".to_string()
+                })?;
+
+            tracing::info!(
+                "[ProactiveSystem] Test screen prompt generated: {}",
+                raw_prompt
+            );
+
+            let formatted = crate::utils::prompt::PromptRole::System.build_prompt(&raw_prompt);
+            let (_, script_active) = Self::read_runtime_context(&ai_service).await;
+            if script_active {
+                return Err("视觉分析期间剧情已开始，本次测试已取消".to_string());
+            }
+            let guard = delivery
+                .try_generation_guard()
+                .ok_or_else(|| "当前有其他回复正在生成，请稍后再试".to_string())?;
+            delivery
+                .deliver(formatted, guard)
+                .await
+                .map_err(|e| format!("投递主动消息失败: {}", e))?;
+
+            Ok::<String, String>(raw_prompt)
+        }
+        .await;
+
+        if let Err(ref e) = prompt_result {
+            tracing::error!("[ProactiveSystem] Test proactive message failed: {}", e);
+        }
+
+        prompt_result.map(Some)
     }
 
     /// 重新载入日程设置文件 schedules.json。
@@ -198,7 +476,11 @@ impl ProactiveSystem {
     /// 当用户主动发送消息时触发的回调，用于恢复好感度/兴趣阈值。
     pub async fn on_user_message_received(&mut self) {
         tracing::info!("[ProactiveSystem] User message received! Restoring engagement cap.");
+        self.interaction_epoch = self.interaction_epoch.wrapping_add(1);
         self.interest_manager.restore_max_interest_cap();
+        // 用户已经主动开启了一轮新对话，旧的闲聊/屏幕观察已失去时效。
+        self.pending_intents
+            .retain(|intent| !matches!(intent.intent_type, IntentType::Screen | IntentType::Topic));
     }
 
     /// 前端通知后端当前是否具备投放条件。
@@ -219,118 +501,164 @@ impl ProactiveSystem {
     // 核心投放方法
     // ============================================================
 
-    /// 统一的主动对话投放入口。持有锁不放，直到 LLM 流式生成完毕。
-    /// 已侵入 game_status 的副作用（add_line），调用者需确保：
-    /// - generation_lock 未被持有
-    /// - prompt 已完整生成（含截图分析结果）
-    async fn deliver(&mut self, prompt: String) -> anyhow::Result<()> {
-        tracing::info!("[ProactiveSystem] Delivering proactive dialogue...");
-
-        let _lock = self.generation_lock.lock().await;
-        events::emit_thinking(&self.app, true);
-
-        let generator = {
-            let game_status = {
-                let svc = self.ai_service.lock().await;
-                svc.game_status.clone()
-            };
-            let deps = GeneratorDeps {
-                app: self.app.clone(),
-                db: self.db.clone(),
-                game_status,
-                processor: self.chat.processor.clone(),
-                translator: self.chat.translator.clone(),
-                llm: self.chat.llm.clone()
-                    .ok_or_else(|| anyhow::anyhow!("LLM is not configured"))?,
-                concurrency: 1,
-                god_agent: None,
-                suppress_thinking: false,
-            };
-            MessageGenerator::new(deps)
-        };
-
+    fn stash_intent(&mut self, intent: PendingIntent) {
+        if matches!(intent.intent_type, IntentType::Screen | IntentType::Topic)
+            && intent.interaction_epoch != self.interaction_epoch
         {
-            let svc = self.ai_service.lock().await;
-            let mut gs = svc.game_status.lock().await;
-            gs.add_line(
-                &self.db,
-                LineBase {
-                    attribute: LineAttributeExt(LineAttribute::User),
-                    content: prompt,
-                    sender_role_id: None,
-                    display_name: None,
-                    ..Default::default()
-                },
-            )
-            .await?;
+            tracing::debug!(
+                "[ProactiveSystem] Dropping stale {:?} intent from epoch {} (current {})",
+                intent.intent_type,
+                intent.interaction_epoch,
+                self.interaction_epoch
+            );
+            return;
         }
 
-        let _ = generator.process_message(None).await;
-        Ok(())
+        if intent.intent_type == IntentType::Alarm {
+            // 同一分钟可能有多个日程；闹钟逐条保留，只过滤完全相同的重复项。
+            if self.pending_intents.iter().any(|queued| {
+                queued.intent_type == IntentType::Alarm && queued.prompt == intent.prompt
+            }) {
+                return;
+            }
+        } else if let Some(existing) = self
+            .pending_intents
+            .iter_mut()
+            .find(|queued| queued.intent_type == intent.intent_type)
+        {
+            if intent.triggered_at >= existing.triggered_at {
+                tracing::debug!(
+                    "[ProactiveSystem] Replacing queued {:?} intent with newer content",
+                    intent.intent_type
+                );
+                *existing = intent;
+            }
+            return;
+        }
+
+        if self.pending_intents.len() >= MAX_PENDING_INTENTS {
+            self.pending_intents
+                .sort_by_key(|queued| (queued.intent_type, queued.triggered_at));
+            self.pending_intents.remove(0);
+        }
+        self.pending_intents.push(intent);
     }
 
-    /// 遍历暂存队列，尝试投放一个合适的意图。
-    /// 返回 `true` 表示本轮已投放（调用方应 return）。
-    async fn try_flush_pending_intent(&mut self) -> anyhow::Result<bool> {
-        if self.pending_intents.is_empty() {
-            return Ok(false);
-        }
-
-        if self.generation_lock.try_lock().is_err() {
-            tracing::debug!("[ProactiveSystem] gen_lock busy, skip flush");
-            return Ok(false);
-        }
-
-        let perception = self.activity_monitor.get_user_status();
-        let now = std::time::Instant::now();
-
-        // 按优先级降序：Alarm(4) > ImportantDay(3) > Todo(2) > Screen(1) > Topic(0)
-        self.pending_intents
-            .sort_by_key(|i| std::cmp::Reverse(i.intent_type));
-
-        // 第一步：清理过期意图
-        let before = self.pending_intents.len();
+    fn take_deliverable_pending(&mut self, perception: &PerceptionResult) -> Option<PendingIntent> {
+        let now = Instant::now();
+        let interaction_epoch = self.interaction_epoch;
+        let delivery_backoff_active = self.delivery_backoff_until.is_some_and(|until| now < until);
         self.pending_intents.retain(|intent| {
-            let elapsed = now.duration_since(intent.triggered_at).as_secs();
-            if elapsed > intent.intent_type.ttl_secs() {
-                tracing::info!(
-                    "[ProactiveSystem] Intent {:?} expired after {}s, discarding",
-                    intent.intent_type, elapsed
-                );
-                false
-            } else {
-                true
-            }
+            now.duration_since(intent.triggered_at).as_secs() <= intent.intent_type.ttl_secs()
+                && (!matches!(intent.intent_type, IntentType::Screen | IntentType::Topic)
+                    || intent.interaction_epoch == interaction_epoch)
         });
-        if before != self.pending_intents.len() {
-            tracing::info!(
-                "[ProactiveSystem] Expired discard: {} -> {}",
-                before,
-                self.pending_intents.len()
-            );
+        self.pending_intents
+            .sort_by_key(|intent| std::cmp::Reverse(intent.intent_type));
+        let index = self.pending_intents.iter().position(|intent| {
+            (!delivery_backoff_active
+                || (intent.intent_type == IntentType::Alarm && intent.delivery_attempts == 0))
+                && DeliveryEvaluator::can_deliver(intent.intent_type, perception, self.can_deliver)
+        })?;
+        Some(self.pending_intents.remove(index))
+    }
+
+    fn intent_enabled(config: &ProactiveConfig, intent_type: IntentType) -> bool {
+        match intent_type {
+            IntentType::Alarm => config.enable_schedule_reminder,
+            IntentType::ImportantDay => config.enable_important_day_reminder,
+            IntentType::Todo => config.enable_todo_perception,
+            IntentType::Screen => config.enable_visual_perception,
+            IntentType::Topic => config.enable_topic_creator,
+        }
+    }
+
+    async fn attempt_delivery(
+        system_arc: Arc<Mutex<Self>>,
+        delivery: DeliveryContext,
+        strategy: Arc<StrategyDispatcher>,
+        mut intent: PendingIntent,
+    ) -> anyhow::Result<bool> {
+        let Some(guard) = delivery.try_generation_guard() else {
+            tracing::debug!("[ProactiveSystem] generation lock busy; deferring intent");
+            system_arc.lock().await.stash_intent(intent);
+            return Ok(false);
+        };
+
+        let (_, script_active) = Self::read_runtime_context(&delivery.ai_service).await;
+        let should_defer = {
+            let sys = system_arc.lock().await;
+            if !sys.is_running || !sys.config.enable_proactive_system {
+                return Ok(false);
+            }
+            if !Self::intent_enabled(&sys.config, intent.intent_type) {
+                tracing::debug!(
+                    "[ProactiveSystem] Dropping disabled {:?} intent",
+                    intent.intent_type
+                );
+                return Ok(false);
+            }
+            if matches!(intent.intent_type, IntentType::Screen | IntentType::Topic)
+                && intent.interaction_epoch != sys.interaction_epoch
+            {
+                tracing::debug!(
+                    "[ProactiveSystem] Dropping stale {:?} result from epoch {} (current {})",
+                    intent.intent_type,
+                    intent.interaction_epoch,
+                    sys.interaction_epoch
+                );
+                return Ok(false);
+            }
+            if intent.intent_type != IntentType::Alarm
+                && sys.interest_manager.proactive_times >= sys.interest_manager.max_proactive_count
+            {
+                return Ok(false);
+            }
+            let current = sys.activity_monitor.get_user_status();
+            script_active
+                || !DeliveryEvaluator::can_deliver(intent.intent_type, &current, sys.can_deliver)
+        };
+        if should_defer {
+            system_arc.lock().await.stash_intent(intent);
+            return Ok(false);
         }
 
-        // 第二步：找第一个可投放的（索引有效，因为不在遍历中收集）
-        for (i, intent) in self.pending_intents.iter().enumerate() {
-            if DeliveryEvaluator::can_deliver(
-                intent.intent_type,
-                &perception,
-                self.can_deliver,
-            ) {
-                let intent = self.pending_intents.remove(i);
-                let waited = now.duration_since(intent.triggered_at);
-                tracing::info!(
-                    "[ProactiveSystem] Flushing deferred {:?} intent (waited {:.0}s, {} remaining in queue)",
-                    intent.intent_type,
-                    waited.as_secs(),
-                    self.pending_intents.len()
-                );
-                self.deliver(intent.prompt).await?;
-                return Ok(true);
+        tracing::info!(
+            "[ProactiveSystem] Delivering {:?} proactive intent",
+            intent.intent_type
+        );
+        match delivery.deliver(intent.prompt.clone(), guard).await {
+            Ok(_) => {
+                if let Some(raw_prompt) = intent.raw_prompt.as_deref() {
+                    strategy
+                        .record_delivered(raw_prompt, intent.intent_type)
+                        .await;
+                }
+                let mut sys = system_arc.lock().await;
+                sys.delivery_backoff_until = None;
+                // 闹钟不占用“用户回复前最多主动搭话次数”，即时与延迟投递保持一致。
+                if intent.intent_type != IntentType::Alarm {
+                    sys.interest_manager.reset_interest();
+                }
+                Ok(true)
+            }
+            Err(error) => {
+                // deliver 已确认没有持久化 assistant，并回滚了本次 prompt，才会进入这里；
+                // 因此可以在全局退避后做有限次幂等重试，避免日程提醒永久丢失。
+                intent.delivery_attempts = intent.delivery_attempts.saturating_add(1);
+                let should_retry = intent.delivery_attempts < MAX_SAFE_DELIVERY_ATTEMPTS
+                    && intent.triggered_at.elapsed().as_secs() <= intent.intent_type.ttl_secs();
+                let mut sys = system_arc.lock().await;
+                sys.delivery_backoff_until = Some(Instant::now() + DELIVERY_FAILURE_BACKOFF);
+                let cooled = (sys.interest_manager.trigger_threshold * 0.5)
+                    .min(sys.interest_manager.max_interest_cap);
+                sys.interest_manager.interest = cooled;
+                if should_retry {
+                    sys.stash_intent(intent);
+                }
+                Err(error.context("proactive intent delivery failed"))
             }
         }
-
-        Ok(false)
     }
 
     // ============================================================
@@ -339,121 +667,142 @@ impl ProactiveSystem {
 
     /// 执行单次主动对话检查周期。
     async fn run_cycle(system_arc: Arc<Mutex<Self>>) -> anyhow::Result<()> {
-        let mut sys = system_arc.lock().await;
+        let (config, settings, strategy, delivery, interaction_epoch) = {
+            let mut sys = system_arc.lock().await;
+            if !sys.is_running || !sys.config.enable_proactive_system {
+                return Ok(());
+            }
+            sys.interest_manager.check_daily_reset();
+            tracing::info!(
+                "[ProactiveSystem] Cycle start. Interest: {:.2}/{:.2}, count: {}/{}, can_deliver={}, pending={}",
+                sys.interest_manager.interest,
+                sys.interest_manager.max_interest_cap,
+                sys.interest_manager.proactive_times,
+                sys.interest_manager.max_proactive_count,
+                sys.can_deliver,
+                sys.pending_intents.len(),
+            );
+            (
+                sys.config.clone(),
+                sys.settings.clone(),
+                sys.strategy_dispatcher.clone(),
+                sys.delivery_context(),
+                sys.interaction_epoch,
+            )
+        };
 
-        tracing::info!(
-            "[ProactiveSystem] Cycle start. Interest: {:.2}/{:.2}, count today: {}/{}, can_deliver={}, pending={}",
-            sys.interest_manager.interest,
-            sys.interest_manager.max_interest_cap,
-            sys.interest_manager.proactive_times,
-            sys.interest_manager.max_proactive_count,
-            sys.can_deliver,
-            sys.pending_intents.len(),
-        );
-
-        // ─── 0. 优先清暂存队列 ───
-        if sys.try_flush_pending_intent().await? {
+        let settings_snap = settings.read().await.clone();
+        let (context, script_active) = Self::read_runtime_context(&delivery.ai_service).await;
+        if script_active {
             return Ok(());
         }
 
-        // ─── 1. 快照 ───
-        let settings_snap = {
-            let snap = sys.settings.read().await;
-            snap.clone()
+        let (perception, pending) = {
+            let mut sys = system_arc.lock().await;
+            let perception = sys.activity_monitor.get_user_status();
+            let pending = sys.take_deliverable_pending(&perception);
+            (perception, pending)
         };
+        if let Some(intent) = pending {
+            let _ = Self::attempt_delivery(
+                system_arc.clone(),
+                delivery.clone(),
+                strategy.clone(),
+                intent,
+            )
+            .await?;
+            return Ok(());
+        }
 
-        // ─── 2. 感知（提前到这里，供 Alarm 的 evaluate 使用）───
-        let perception = sys.activity_monitor.get_user_status();
-
-        // ─── 3. 日程警报（跳过兴趣累积，但走 evaluate 闸门）───
-        if sys.config.enable_schedule_reminder {
-            let user_name = {
-                let svc = sys.ai_service.lock().await;
-                let gs = svc.game_status.lock().await;
-                gs.player.user_name.clone()
+        // 日程 prompt 生成很便宜，可以直接进入统一投递/暂存流程。
+        if config.enable_schedule_reminder {
+            let alarm = {
+                let mut sys = system_arc.lock().await;
+                sys.schedule_manager
+                    .check_schedule_reminder(&context.user_name, &settings_snap)
             };
-            if let Some(raw_prompt) = sys
-                .schedule_manager
-                .check_schedule_reminder(&user_name, &settings_snap)
-            {
-                let formatted = PromptRole::System.build_prompt(&raw_prompt);
-                if DeliveryEvaluator::can_deliver(IntentType::Alarm, &perception, sys.can_deliver) {
-                    tracing::info!("[ProactiveSystem] Alarm triggered, evaluate passed, delivering");
-                    sys.deliver(formatted).await?;
-                } else {
-                    tracing::info!("[ProactiveSystem] Alarm triggered, evaluate failed, stashing");
-                    sys.pending_intents.push(PendingIntent {
-                        prompt: formatted,
-                        intent_type: IntentType::Alarm,
-                        triggered_at: std::time::Instant::now(),
-                    });
-                }
+            if let Some(raw_prompt) = alarm {
+                let intent = PendingIntent::new(
+                    PromptRole::System.build_prompt(&raw_prompt),
+                    None,
+                    IntentType::Alarm,
+                    interaction_epoch,
+                );
+                let _ = Self::attempt_delivery(
+                    system_arc.clone(),
+                    delivery.clone(),
+                    strategy.clone(),
+                    intent,
+                )
+                .await?;
                 return Ok(());
             }
         }
 
-        // ─── 4. 兴趣累积 ───
-        sys.interest_manager.update_interest();
-        sys.interest_manager
-            .set_status_mod(perception.interest_modifier);
-
-        // ─── 5. 触发检查 ───
-        if !sys.interest_manager.should_trigger_talk() {
+        if system_arc
+            .lock()
+            .await
+            .delivery_backoff_until
+            .is_some_and(|until| Instant::now() < until)
+        {
+            tracing::debug!("[ProactiveSystem] Delivery failure backoff active; skipping strategy");
             return Ok(());
         }
 
-        tracing::info!(
-            "[ProactiveSystem] Trigger fired! Interest={:.2}",
-            sys.interest_manager.interest
+        let (triggered, can_deliver, screen_eligible) = {
+            let mut sys = system_arc.lock().await;
+            let visual_pending =
+                config.enable_visual_perception && sys.visual_monitor.check_visual_change();
+            let modifier = perception
+                .interest_modifier
+                .saturating_add(if visual_pending { 20 } else { 0 });
+            sys.interest_manager.update_interest(modifier);
+            let triggered = sys.interest_manager.should_trigger_talk();
+            let can_deliver = sys.can_deliver;
+            let screen_eligible = visual_pending
+                && DeliveryEvaluator::can_deliver(IntentType::Screen, &perception, can_deliver);
+            (triggered, can_deliver, screen_eligible)
+        };
+
+        if !triggered || !can_deliver {
+            return Ok(());
+        }
+        // 用户回复正在生成时，不要先白跑一次 VLM。
+        if delivery.generation_lock.try_lock().is_err() {
+            return Ok(());
+        }
+
+        // 这里不持有 ProactiveSystem / AIService / GameStatus 锁；VLM 再慢也不会阻塞 UI 状态上报。
+        let outcome = strategy
+            .get_proactive_prompt(
+                &context,
+                &settings_snap,
+                &perception,
+                &config,
+                screen_eligible,
+            )
+            .await;
+
+        if outcome.screen_attempted {
+            system_arc.lock().await.visual_monitor.mark_analyzed();
+        }
+
+        let Some(candidate) = outcome.candidate else {
+            // PASS、重复或模型失败后退回阈值以下，避免十秒后立刻再次触发昂贵策略。
+            let mut sys = system_arc.lock().await;
+            let cooled = (sys.interest_manager.trigger_threshold * 0.5)
+                .min(sys.interest_manager.max_interest_cap);
+            sys.interest_manager.interest = cooled;
+            return Ok(());
+        };
+
+        let intent = PendingIntent::new(
+            PromptRole::System.build_prompt(&candidate.prompt),
+            Some(candidate.prompt),
+            candidate.intent_type,
+            interaction_epoch,
         );
-
-        // gen_lock 快检
-        if sys.generation_lock.try_lock().is_err() {
-            tracing::debug!("[ProactiveSystem] gen_lock busy, aborting this trigger");
-            return Ok(());
-        }
-
-        // ─── 生成 prompt（SCREEN 调用视觉模型可能耗时，先禁用前端输入）───
-        events::emit_thinking(&sys.app, true);
-        let prompt_result = {
-            let svc = sys.ai_service.lock().await;
-            let gs = svc.game_status.lock().await;
-            sys.strategy_dispatcher
-                .get_proactive_prompt(&gs, &settings_snap, &perception, &sys.config)
-                .await
-        };
-        let Some((raw_prompt, intent_type)) = prompt_result else {
-            events::emit_thinking(&sys.app, false);
-            return Ok(());
-        };
-
-        // 兴趣立刻消耗（"已经想说话了"）
-        sys.interest_manager.reset_interest();
-
-        // ─── 投放闸门 ───
-        if DeliveryEvaluator::can_deliver(intent_type, &perception, sys.can_deliver) {
-            tracing::info!(
-                "[ProactiveSystem] Evaluate passed for {:?}, delivering immediately",
-                intent_type
-            );
-            let formatted = PromptRole::System.build_prompt(&raw_prompt);
-            sys.deliver(formatted).await?;
-        } else {
-            let formatted = PromptRole::System.build_prompt(&raw_prompt);
-            tracing::info!(
-                "[ProactiveSystem] Evaluate failed for {:?}, stashing (queue size: {} -> {})",
-                intent_type,
-                sys.pending_intents.len(),
-                sys.pending_intents.len() + 1,
-            );
-            sys.pending_intents.push(PendingIntent {
-                prompt: formatted,
-                intent_type,
-                triggered_at: std::time::Instant::now(),
-            });
-            events::emit_thinking(&sys.app, false);
-        }
-
+        let _ = Self::attempt_delivery(system_arc, delivery, strategy, intent).await?;
         Ok(())
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/proactive_history.rs
+++ b/src-tauri/src/ai_service/proactive_system/proactive_history.rs
@@ -1,0 +1,213 @@
+//! 主动搭话历史记录与反重复检测。
+//!
+//! 记录最近 N 条主动搭话文本及其时间戳，使用归一化后的编辑距离相似度
+//! 判断新内容是否与近期内容重复。相似度超过阈值时建议跳过。
+
+use std::collections::VecDeque;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// 默认保留历史条数。
+const DEFAULT_MAX_HISTORY: usize = 10;
+/// 默认相似度阈值，超过此值视为重复。
+const DEFAULT_SIMILARITY_THRESHOLD: f64 = 0.85;
+/// 默认历史有效期（毫秒），超过此时间的历史不再参与重复检测。
+const DEFAULT_MAX_AGE_MS: u64 = 60 * 60 * 1000; // 1 小时
+
+/// 一条主动搭话历史记录。
+#[derive(Clone, Debug)]
+pub struct ProactiveHistoryEntry {
+    pub text: String,
+    pub ts_ms: u64,
+}
+
+/// 主动搭话反重复器。
+#[derive(Clone, Debug)]
+pub struct ProactiveDeduplicator {
+    max_history: usize,
+    similarity_threshold: f64,
+    max_age_ms: u64,
+    entries: VecDeque<ProactiveHistoryEntry>,
+}
+
+impl Default for ProactiveDeduplicator {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_MAX_HISTORY,
+            DEFAULT_SIMILARITY_THRESHOLD,
+            DEFAULT_MAX_AGE_MS,
+        )
+    }
+}
+
+impl ProactiveDeduplicator {
+    pub fn new(max_history: usize, similarity_threshold: f64, max_age_ms: u64) -> Self {
+        Self {
+            max_history: max_history.max(1),
+            similarity_threshold: similarity_threshold.clamp(0.0, 1.0),
+            max_age_ms,
+            entries: VecDeque::new(),
+        }
+    }
+
+    /// 把新内容加入历史。
+    pub fn record(&mut self, text: impl Into<String>) {
+        let text = text.into();
+        if text.trim().is_empty() || text.trim() == "[PASS]" {
+            return;
+        }
+        let ts_ms = now_ms();
+        self.entries
+            .push_back(ProactiveHistoryEntry { text, ts_ms });
+        self.evict(ts_ms);
+    }
+
+    /// 检查给定文本是否与近期历史重复。
+    /// 返回 `(is_duplicate, best_similarity)`。
+    pub fn is_duplicate(&self, text: &str) -> (bool, f64) {
+        if text.trim().is_empty() || text.trim() == "[PASS]" {
+            return (false, 0.0);
+        }
+
+        let now = now_ms();
+        let current = normalize(text);
+        if current.is_empty() {
+            return (false, 0.0);
+        }
+
+        let mut best = 0.0;
+        for entry in &self.entries {
+            if now.saturating_sub(entry.ts_ms) > self.max_age_ms {
+                continue;
+            }
+            let old = normalize(&entry.text);
+            if old.is_empty() {
+                continue;
+            }
+            let score = similarity_ratio(&current, &old);
+            if score > best {
+                best = score;
+            }
+            if best >= self.similarity_threshold {
+                return (true, best);
+            }
+        }
+        (false, best)
+    }
+
+    /// 如果内容不重复，记录并返回 false；如果重复，返回 true。
+    #[cfg(test)]
+    pub fn check_and_record(&mut self, text: impl Into<String>) -> (bool, f64) {
+        let text = text.into();
+        let (dup, score) = self.is_duplicate(&text);
+        if !dup {
+            self.record(text);
+        }
+        (dup, score)
+    }
+
+    fn evict(&mut self, now_ms: u64) {
+        // 先移除过期
+        while self
+            .entries
+            .front()
+            .is_some_and(|e| now_ms.saturating_sub(e.ts_ms) > self.max_age_ms)
+        {
+            self.entries.pop_front();
+        }
+        // 再限制数量
+        while self.entries.len() > self.max_history {
+            self.entries.pop_front();
+        }
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_millis() as u64
+}
+
+/// 归一化文本：小写、去标点、压缩空白、截断。
+fn normalize(text: &str) -> String {
+    let mut normalized = String::new();
+    let mut previous_space = false;
+    for ch in text.trim().to_lowercase().chars() {
+        if ch.is_whitespace() {
+            if !previous_space && !normalized.is_empty() {
+                normalized.push(' ');
+                previous_space = true;
+            }
+            continue;
+        }
+        if ch.is_ascii_punctuation() {
+            continue;
+        }
+        normalized.push(ch);
+        previous_space = false;
+    }
+    normalized.trim().chars().take(512).collect()
+}
+
+/// 编辑距离相似度：1 - distance / max_len，范围 [0, 1]。
+fn similarity_ratio(left: &str, right: &str) -> f64 {
+    if left == right {
+        return 1.0;
+    }
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+
+    let left_chars: Vec<char> = left.chars().collect();
+    let right_chars: Vec<char> = right.chars().collect();
+
+    let mut previous: Vec<usize> = (0..=right_chars.len()).collect();
+    let mut current = vec![0; right_chars.len() + 1];
+
+    for (i, left_ch) in left_chars.iter().enumerate() {
+        current[0] = i + 1;
+        for (j, right_ch) in right_chars.iter().enumerate() {
+            let cost = usize::from(left_ch != right_ch);
+            current[j + 1] = (previous[j + 1] + 1)
+                .min(current[j] + 1)
+                .min(previous[j] + cost);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    let distance = previous[right_chars.len()] as f64;
+    let max_len = left_chars.len().max(right_chars.len()) as f64;
+    (1.0 - distance / max_len).clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exact_duplicate() {
+        let mut dedup = ProactiveDeduplicator::default();
+        assert!(!dedup.check_and_record("你好呀").0);
+        assert!(dedup.check_and_record("你好呀").0);
+    }
+
+    #[test]
+    fn test_similar_but_not_duplicate() {
+        let mut dedup = ProactiveDeduplicator::new(10, 0.85, 60 * 60 * 1000);
+        assert!(!dedup.check_and_record("今天天气不错").0);
+        assert!(!dedup.check_and_record("今天天气很好").0);
+    }
+
+    #[test]
+    fn test_pass_is_ignored() {
+        let mut dedup = ProactiveDeduplicator::default();
+        dedup.record("[PASS]");
+        assert_eq!(dedup.len(), 0);
+        assert!(!dedup.is_duplicate("[PASS]").0);
+    }
+}

--- a/src-tauri/src/ai_service/proactive_system/schedule_manager.rs
+++ b/src-tauri/src/ai_service/proactive_system/schedule_manager.rs
@@ -1,14 +1,17 @@
 use crate::ai_service::proactive_system::types::UserScheduleSettings;
 use chrono::Local;
+use std::collections::HashSet;
 
 pub struct ScheduleManager {
-    last_triggered_key: String,
+    triggered_date: String,
+    triggered_keys: HashSet<String>,
 }
 
 impl ScheduleManager {
     pub fn new() -> Self {
         Self {
-            last_triggered_key: String::new(),
+            triggered_date: String::new(),
+            triggered_keys: HashSet::new(),
         }
     }
 
@@ -17,18 +20,33 @@ impl ScheduleManager {
         user_name: &str,
         settings: &UserScheduleSettings,
     ) -> Option<String> {
-        let schedule_groups = settings.schedule_groups.as_ref()?;
-
         let now = Local::now();
+        let current_date_str = now.format("%Y-%m-%d").to_string();
         let current_time_str = now.format("%H:%M").to_string();
 
-        for group in schedule_groups.values() {
-            for item in &group.items {
-                if item.time == current_time_str {
-                    let trigger_key = format!("{}_{}", item.time, item.name);
-                    if trigger_key != self.last_triggered_key {
-                        self.last_triggered_key = trigger_key;
+        self.check_schedule_reminder_at(user_name, settings, &current_date_str, &current_time_str)
+    }
 
+    fn check_schedule_reminder_at(
+        &mut self,
+        user_name: &str,
+        settings: &UserScheduleSettings,
+        current_date: &str,
+        current_time: &str,
+    ) -> Option<String> {
+        let schedule_groups = settings.schedule_groups.as_ref()?;
+
+        if self.triggered_date != current_date {
+            self.triggered_date.clear();
+            self.triggered_date.push_str(current_date);
+            self.triggered_keys.clear();
+        }
+
+        for (group_id, group) in schedule_groups {
+            for (item_index, item) in group.items.iter().enumerate() {
+                if item.time == current_time {
+                    let trigger_key = format!("{group_id}:{item_index}:{}", item.time);
+                    if self.triggered_keys.insert(trigger_key) {
                         tracing::info!(
                             "[ScheduleManager] Triggered alarm for schedule: {}",
                             item.name
@@ -43,5 +61,77 @@ impl ScheduleManager {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai_service::proactive_system::types::{ScheduleGroup, ScheduleItem};
+    use std::collections::HashMap;
+
+    fn settings_with_two_due_items() -> UserScheduleSettings {
+        UserScheduleSettings {
+            schedule_groups: Some(HashMap::from([
+                (
+                    "work".to_string(),
+                    ScheduleGroup {
+                        title: "工作".to_string(),
+                        items: vec![ScheduleItem {
+                            name: "开会".to_string(),
+                            time: "09:30".to_string(),
+                            content: "周会".to_string(),
+                        }],
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "health".to_string(),
+                    ScheduleGroup {
+                        title: "健康".to_string(),
+                        items: vec![ScheduleItem {
+                            name: "喝水".to_string(),
+                            time: "09:30".to_string(),
+                            content: "补充水分".to_string(),
+                        }],
+                        ..Default::default()
+                    },
+                ),
+            ])),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn each_due_item_only_triggers_once_per_day() {
+        let settings = settings_with_two_due_items();
+        let mut manager = ScheduleManager::new();
+
+        let first = manager
+            .check_schedule_reminder_at("测试用户", &settings, "2026-07-10", "09:30")
+            .expect("first reminder should trigger");
+        let second = manager
+            .check_schedule_reminder_at("测试用户", &settings, "2026-07-10", "09:30")
+            .expect("second reminder should trigger");
+
+        assert_ne!(first, second);
+        assert!(first.contains("开会") || first.contains("喝水"));
+        assert!(second.contains("开会") || second.contains("喝水"));
+        assert!(manager
+            .check_schedule_reminder_at("测试用户", &settings, "2026-07-10", "09:30")
+            .is_none());
+    }
+
+    #[test]
+    fn reminders_reset_on_the_next_day() {
+        let settings = settings_with_two_due_items();
+        let mut manager = ScheduleManager::new();
+
+        assert!(manager
+            .check_schedule_reminder_at("测试用户", &settings, "2026-07-10", "09:30")
+            .is_some());
+        assert!(manager
+            .check_schedule_reminder_at("测试用户", &settings, "2026-07-11", "09:30")
+            .is_some());
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
+++ b/src-tauri/src/ai_service/proactive_system/strategy_dispatcher.rs
@@ -1,40 +1,92 @@
-use crate::ai_service::game_system::game_status::GameStatus;
 use crate::ai_service::proactive_system::config::ProactiveConfig;
+use crate::ai_service::proactive_system::proactive_history::ProactiveDeduplicator;
 use crate::ai_service::proactive_system::types::{
-    IntentType, PerceptionResult, UserScheduleSettings, UserState,
+    DispatchOutcome, IntentType, PerceptionResult, ProactiveCandidate, ProactiveContext,
+    UserScheduleSettings, UserState,
 };
-use crate::ai_service::screen_analyzer::{ScreenAnalyzer, ScreenAnalyzerConfig};
+use crate::ai_service::screen_analyzer::{
+    build_screen_analyzer_config, ScreenAnalyzer, ScreenContext,
+};
 use chrono::Local;
 use rand::Rng;
+use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
+
+const SCREEN_ATTEMPT_COOLDOWN: Duration = Duration::from_secs(60);
 
 pub struct StrategyDispatcher {
     screen_analyzer: Mutex<ScreenAnalyzer>,
+    deduplicator: Mutex<ProactiveDeduplicator>,
+    last_screen_attempt: Mutex<Option<Instant>>,
+    last_important_day_date: Mutex<Option<String>>,
 }
 
 impl StrategyDispatcher {
     pub fn new(app_handle: &tauri::AppHandle) -> Self {
         let config = ProactiveConfig::load(app_handle);
-        let sa_config = ScreenAnalyzerConfig {
-            vd_api_key: config.vd_api_key.clone(),
-            vd_base_url: config.vd_base_url.clone(),
-            vd_model: config.vd_model.clone(),
-        };
+        let sa_config = build_screen_analyzer_config(app_handle, &config);
         Self {
             screen_analyzer: Mutex::new(ScreenAnalyzer::new(sa_config)),
+            deduplicator: Mutex::new(ProactiveDeduplicator::default()),
+            last_screen_attempt: Mutex::new(None),
+            last_important_day_date: Mutex::new(None),
         }
     }
 
-    /// 更新配置（同时同步 ScreenAnalyzer 的配置，同步执行无需 async）。
-    pub fn update_config(&self, app_handle: &tauri::AppHandle) {
+    /// 更新配置，同时可靠地同步 ScreenAnalyzer。不能因视觉请求正在占锁而静默丢失更新。
+    pub async fn update_config(&self, app_handle: &tauri::AppHandle) {
         let config = ProactiveConfig::load(app_handle);
-        // try_lock: update_config 不涉及 async，用同步锁即可
-        if let Ok(mut sa) = self.screen_analyzer.try_lock() {
-            sa.update_config(ScreenAnalyzerConfig {
-                vd_api_key: config.vd_api_key,
-                vd_base_url: config.vd_base_url,
-                vd_model: config.vd_model,
-            });
+        self.screen_analyzer
+            .lock()
+            .await
+            .update_config(build_screen_analyzer_config(app_handle, &config));
+    }
+
+    async fn is_duplicate(&self, prompt: &str) -> bool {
+        let dedup = self.deduplicator.lock().await;
+        let (dup, score) = dedup.is_duplicate(prompt);
+        if dup {
+            tracing::info!(
+                "[StrategyDispatcher] Duplicate proactive prompt detected (score={:.2}), skipping.",
+                score
+            );
+            true
+        } else {
+            false
+        }
+    }
+
+    /// 只有真正生成出非空回复并成功投递后才提交去重历史。
+    pub async fn record_delivered(&self, prompt: &str, intent_type: IntentType) {
+        self.deduplicator.lock().await.record(prompt.to_string());
+        if intent_type == IntentType::ImportantDay {
+            *self.last_important_day_date.lock().await =
+                Some(Local::now().format("%Y-%m-%d").to_string());
+        }
+    }
+
+    async fn reserve_screen_attempt(&self) -> bool {
+        let mut last = self.last_screen_attempt.lock().await;
+        let now = Instant::now();
+        if last.is_some_and(|at| now.duration_since(at) < SCREEN_ATTEMPT_COOLDOWN) {
+            return false;
+        }
+        *last = Some(now);
+        true
+    }
+
+    async fn candidate_if_new(
+        &self,
+        prompt: String,
+        intent_type: IntentType,
+    ) -> Option<ProactiveCandidate> {
+        if self.is_duplicate(&prompt).await {
+            None
+        } else {
+            Some(ProactiveCandidate {
+                prompt,
+                intent_type,
+            })
         }
     }
 
@@ -42,47 +94,64 @@ impl StrategyDispatcher {
     /// 优先顺序: ImportantDay (每天仅一次) > Todo > Screen Observation > Topic
     pub async fn get_proactive_prompt(
         &self,
-        game_status: &GameStatus,
+        context: &ProactiveContext,
         settings: &UserScheduleSettings,
         perception: &PerceptionResult,
         config: &ProactiveConfig,
-    ) -> Option<(String, IntentType)> {
+        screen_eligible: bool,
+    ) -> DispatchOutcome {
+        let mut outcome = DispatchOutcome::default();
         let now = Local::now();
         let today_str = now.format("%m-%d").to_string();
+        let today_full = now.format("%Y-%m-%d").to_string();
 
-        // 1. 检查 ImportantDay (如果是今天且今天未触发过)
-        if config.enable_important_day_reminder {
+        // 1. 检查 ImportantDay。重复候选只跳过本策略，不能阻断后续策略。
+        let important_day_already_delivered =
+            self.last_important_day_date.lock().await.as_deref() == Some(today_full.as_str());
+        if config.enable_important_day_reminder && !important_day_already_delivered {
             if let Some(important_days) = &settings.important_days {
-                let last_talk_date = game_status
-                    .last_dialog_time
-                    .map(|dt| dt.format("%m-%d").to_string())
-                    .unwrap_or_default();
-
-                if last_talk_date != today_str {
-                    for day in important_days {
-                        if day.date.ends_with(&today_str) {
-                            let desc = day.desc.as_deref().unwrap_or("");
-                            let char_name = game_status
-                                .current_role_id
-                                .and_then(|rid| game_status.role_manager.get_loaded(rid))
-                                .and_then(|role| role.display_name.clone())
-                                .unwrap_or_else(|| "小灵".to_string());
-
+                for day in important_days {
+                    if day.date.ends_with(&today_str) {
+                        let desc = day.desc.as_deref().unwrap_or("");
+                        let prompt = format!(
+                            "{{今天是特殊的一天：{}，{}。可以和{}聊聊哦}}",
+                            day.title, desc, context.ai_name
+                        );
+                        if let Some(candidate) = self
+                            .candidate_if_new(prompt, IntentType::ImportantDay)
+                            .await
+                        {
                             tracing::info!(
                                 "[StrategyDispatcher] Triggered important day reminder: {}",
                                 day.title
                             );
-                            return Some((
-                                format!(
-                                    "{{今天是特殊的一天：{}，{}。可以和{}聊聊哦}}",
-                                    day.title, desc, char_name
-                                ),
-                                IntentType::ImportantDay,
-                            ));
+                            outcome.candidate = Some(candidate);
+                            return outcome;
                         }
                     }
                 }
             }
+        }
+
+        // 如果开启视觉理解优先模式，优先尝试 SCREEN，失败再按原逻辑随机
+        if config.enable_visual_perception
+            && config.visual_perception_priority
+            && screen_eligible
+            && self.reserve_screen_attempt().await
+        {
+            tracing::info!(
+                "[StrategyDispatcher] Visual perception priority enabled, trying SCREEN first."
+            );
+            outcome.screen_attempted = true;
+            if let Some((prompt, intent)) = self.get_screen_prompt(context).await {
+                if let Some(candidate) = self.candidate_if_new(prompt, intent).await {
+                    outcome.candidate = Some(candidate);
+                    return outcome;
+                }
+            }
+            tracing::info!(
+                "[StrategyDispatcher] SCREEN priority failed, falling back to weighted random."
+            );
         }
 
         // 2. 随机模式选择，根据启用状态动态构建候选列表
@@ -90,53 +159,59 @@ impl StrategyDispatcher {
         let mut weights = Vec::new();
 
         // 获取权重（如果配置文件有设置，否则基于 UserState 动态决定）
-        let mut todo_w = config.todo_weight;
-        let mut topic_w = config.topic_weight;
-        let mut screen_w = config.screen_weight;
+        let todo_default = if perception.state == UserState::WORK {
+            60.0
+        } else {
+            10.0
+        };
+        let topic_default = if perception.state == UserState::IDLE {
+            80.0
+        } else {
+            60.0
+        };
+        let screen_default = if perception.state == UserState::GAME {
+            60.0
+        } else {
+            30.0
+        };
+        let todo_w = normalized_weight(config.todo_weight, todo_default);
+        let topic_w = normalized_weight(config.topic_weight, topic_default);
+        // 有尚未消费的画面变化时提高 SCREEN 权重，但仍保留其他策略的机会。
+        let screen_w = normalized_weight(config.screen_weight, screen_default)
+            * if screen_eligible { 2.0 } else { 1.0 };
 
-        if todo_w <= 0.0 {
-            todo_w = if perception.state == UserState::WORK {
-                60.0
-            } else {
-                10.0
-            };
-        }
-        if topic_w <= 0.0 {
-            topic_w = if perception.state == UserState::IDLE {
-                80.0
-            } else {
-                60.0
-            };
-        }
-        if screen_w <= 0.0 {
-            screen_w = if perception.state == UserState::GAME {
-                60.0
-            } else {
-                30.0
-            };
-        }
-
-        if config.enable_todo_perception {
+        if config.enable_todo_perception && todo_w > 0.0 {
             modes.push("TODO");
             weights.push(todo_w);
         }
-        if config.enable_topic_creator {
+        if config.enable_topic_creator && topic_w > 0.0 {
             modes.push("TOPIC");
             weights.push(topic_w);
         }
-        if config.enable_visual_perception {
+        // priority 已经尝试过 SCREEN 时，本轮不能再次把 SCREEN 放回随机池。
+        if config.enable_visual_perception
+            && screen_eligible
+            && !outcome.screen_attempted
+            && screen_w > 0.0
+        {
             modes.push("SCREEN");
             weights.push(screen_w);
         }
 
         if modes.is_empty() {
-            return None;
+            return outcome;
         }
 
         // 轮盘赌/加权随机选择
         let selected_mode = {
             let mut rng = rand::thread_rng();
             let total_weight: f64 = weights.iter().sum();
+            if !total_weight.is_finite() || total_weight <= 0.0 {
+                tracing::warn!(
+                    "[StrategyDispatcher] Invalid total strategy weight: {total_weight}"
+                );
+                return outcome;
+            }
             let mut roll = rng.gen_range(0.0..total_weight);
             let mut selected = modes[0];
             for (i, &w) in weights.iter().enumerate() {
@@ -156,32 +231,47 @@ impl StrategyDispatcher {
 
         match selected_mode {
             "TODO" => {
-                if let Some(prompt) = self.get_todo_prompt(game_status, settings) {
-                    return Some((prompt, IntentType::Todo));
+                if let Some(prompt) = self.get_todo_prompt(context, settings) {
+                    if let Some(candidate) = self.candidate_if_new(prompt, IntentType::Todo).await {
+                        outcome.candidate = Some(candidate);
+                        return outcome;
+                    }
                 }
-                // 没有 Todo 时降级到 TOPIC
+                // 没有 Todo 或候选重复时降级到 TOPIC。
                 if config.enable_topic_creator {
-                    return Some((self.get_topic_prompt(game_status), IntentType::Topic));
+                    let prompt = self.get_topic_prompt(context);
+                    outcome.candidate = self.candidate_if_new(prompt, IntentType::Topic).await;
                 }
-                None
+                outcome
             }
             "SCREEN" => {
-                if let Some(prompt) = self.get_screen_prompt(game_status).await {
-                    return Some((prompt, IntentType::Screen));
+                if self.reserve_screen_attempt().await {
+                    outcome.screen_attempted = true;
+                    if let Some((prompt, intent)) = self.get_screen_prompt(context).await {
+                        if let Some(candidate) = self.candidate_if_new(prompt, intent).await {
+                            outcome.candidate = Some(candidate);
+                            return outcome;
+                        }
+                    }
                 }
-                // SCREEN 抓取失败或接口失败时降级到 TOPIC
+                // SCREEN 抓取失败、PASS、重复或仍在冷却时降级到 TOPIC。
                 if config.enable_topic_creator {
-                    return Some((self.get_topic_prompt(game_status), IntentType::Topic));
+                    let prompt = self.get_topic_prompt(context);
+                    outcome.candidate = self.candidate_if_new(prompt, IntentType::Topic).await;
                 }
-                None
+                outcome
             }
-            _ => Some((self.get_topic_prompt(game_status), IntentType::Topic)),
+            _ => {
+                let prompt = self.get_topic_prompt(context);
+                outcome.candidate = self.candidate_if_new(prompt, IntentType::Topic).await;
+                outcome
+            }
         }
     }
 
     fn get_todo_prompt(
         &self,
-        game_status: &GameStatus,
+        context: &ProactiveContext,
         settings: &UserScheduleSettings,
     ) -> Option<String> {
         let todo_groups = settings.todo_groups.as_ref()?;
@@ -202,44 +292,128 @@ impl StrategyDispatcher {
         let mut rng = rand::thread_rng();
         let idx = rng.gen_range(0..candidates.len());
         let selected = candidates[idx];
-        let user_name = &game_status.player.user_name;
-
         Some(format!(
             "{{你想起来{}有一个未完成的任务：'{} '。提醒一下吧？}}",
-            user_name, selected.text
+            context.user_name, selected.text
         ))
     }
 
-    async fn get_screen_prompt(&self, game_status: &GameStatus) -> Option<String> {
-        let analyze_prompt = "你是一个图像信息转述者，你将需要把你看到的画面描述给另一个AI让他理解用户的图片内容。用户开放了那个AI的自主窥屏功能，请获取桌面画面中的重点内容，用200字描述主体部分即可。如果你看到一个聊天窗口，有角色的立绘和对话框，不要描述这部分，只描述桌面上的其他内容。因为那部分是玩家与AI的聊天窗口。";
+    pub(crate) async fn get_screen_prompt_for_test(
+        &self,
+        proactive_context: &ProactiveContext,
+    ) -> Option<(String, IntentType)> {
+        let screen_context = ScreenContext {
+            ai_name: Some(proactive_context.ai_name.clone()),
+            user_name: Some(proactive_context.user_name.clone()),
+            recent_chat_summary: None,
+        };
 
-        let analysis = self
+        // 测试专用：强制评论屏幕，不允许 [PASS]。
+        let test_prompt = "你刚刚看了一眼主人的电脑屏幕。请用一句简短自然的话（不超过30字）评论屏幕上最有趣或最新的内容，像不经意间看到的那样。不要解释，直接说出这句话。";
+
+        let reply = self
             .screen_analyzer
             .lock()
             .await
-            .analyze_screen(analyze_prompt)
+            .analyze_screen(test_prompt, Some(&screen_context))
             .await?;
 
-        let user_name = &game_status.player.user_name;
-        let ai_name = game_status
-            .current_role_id
-            .and_then(|rid| game_status.role_manager.get_loaded(rid))
-            .and_then(|role| role.display_name.clone())
-            .unwrap_or_else(|| "你".to_string());
+        let cleaned = clean_screen_reply(&reply)?;
 
-        Some(format!(
-            "{{ {} 偷看了一眼 {} 的电脑桌面: {} }}",
-            ai_name, user_name, analysis
-        ))
+        Some((format!("{{ {}}}", cleaned), IntentType::Screen))
     }
 
-    fn get_topic_prompt(&self, game_status: &GameStatus) -> String {
-        let ai_name = game_status
-            .current_role_id
-            .and_then(|rid| game_status.role_manager.get_loaded(rid))
-            .and_then(|role| role.display_name.clone())
-            .unwrap_or_else(|| "你".to_string());
+    pub(crate) async fn get_screen_prompt(
+        &self,
+        proactive_context: &ProactiveContext,
+    ) -> Option<(String, IntentType)> {
+        let screen_context = ScreenContext {
+            ai_name: Some(proactive_context.ai_name.clone()),
+            user_name: Some(proactive_context.user_name.clone()),
+            recent_chat_summary: None,
+        };
 
-        format!("{{ {} 想继续说话了}}", ai_name)
+        let reply = self
+            .screen_analyzer
+            .lock()
+            .await
+            .analyze_screen_for_proactive(Some(&screen_context))
+            .await?;
+
+        let Some(cleaned) = clean_screen_reply(&reply) else {
+            tracing::info!("[StrategyDispatcher] Screen proactive returned [PASS], falling back.");
+            return None;
+        };
+
+        Some((format!("{{ {}}}", cleaned), IntentType::Screen))
+    }
+
+    fn get_topic_prompt(&self, context: &ProactiveContext) -> String {
+        // 加入随机变体，避免 deduplicator 把每次 TOPIC 都判为重复
+        let templates = [
+            format!("{{ {} 想找主人说说话}}", context.ai_name),
+            format!("{{ {} 突然想到一件事}}", context.ai_name),
+            format!("{{ {} 有话想对主人说}}", context.ai_name),
+            format!("{{ {} 想继续陪主人聊天}}", context.ai_name),
+            format!("{{ {} 看着主人，忍不住想开口}}", context.ai_name),
+        ];
+
+        let mut rng = rand::thread_rng();
+        let idx = rng.gen_range(0..templates.len());
+        templates[idx].clone()
+    }
+}
+
+fn normalized_weight(configured: f64, fallback: f64) -> f64 {
+    if configured.is_finite() && configured >= 0.0 {
+        configured
+    } else if fallback.is_finite() && fallback >= 0.0 {
+        fallback
+    } else {
+        0.0
+    }
+}
+
+fn clean_screen_reply(reply: &str) -> Option<String> {
+    let mut cleaned = reply.trim().trim_matches(['"', '\'', '“', '”']).trim();
+    for prefix in ["AI:", "Ai:", "ai:", "AI：", "Ai：", "ai："] {
+        if let Some(rest) = cleaned.strip_prefix(prefix) {
+            cleaned = rest.trim();
+            break;
+        }
+    }
+    cleaned = cleaned.trim_matches(['"', '\'', '“', '”']).trim();
+    if cleaned.is_empty() || cleaned.to_ascii_uppercase().starts_with("[PASS]") {
+        None
+    } else {
+        Some(cleaned.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_weights_fall_back_to_positive_values() {
+        assert_eq!(normalized_weight(f64::NAN, 30.0), 30.0);
+        assert_eq!(normalized_weight(f64::INFINITY, 30.0), 30.0);
+        assert_eq!(normalized_weight(-10.0, 30.0), 30.0);
+        assert_eq!(normalized_weight(0.0, 30.0), 0.0);
+        assert_eq!(normalized_weight(f64::NAN, 0.0), 0.0);
+    }
+
+    #[test]
+    fn pass_variants_are_never_delivered() {
+        assert!(clean_screen_reply("[PASS]").is_none());
+        assert!(clean_screen_reply(" [pass]：画面没有变化").is_none());
+        assert!(clean_screen_reply("[PASS].").is_none());
+        assert!(clean_screen_reply("\"[PASS]\"").is_none());
+        assert!(clean_screen_reply("AI: [PASS]").is_none());
+        assert!(clean_screen_reply("“AI： [PASS]”").is_none());
+        assert_eq!(
+            clean_screen_reply("AI：挺有意思的").as_deref(),
+            Some("挺有意思的")
+        );
     }
 }

--- a/src-tauri/src/ai_service/proactive_system/types.rs
+++ b/src-tauri/src/ai_service/proactive_system/types.rs
@@ -33,6 +33,15 @@ pub struct PerceptionResult {
     pub current_screen_text: String,
 }
 
+/// 主动对话调度所需的最小只读上下文。
+///
+/// 这里刻意不持有 `GameStatus` 的锁，避免屏幕分析的网络请求阻塞正常聊天。
+#[derive(Clone, Debug, Default)]
+pub struct ProactiveContext {
+    pub user_name: String,
+    pub ai_name: String,
+}
+
 // ==========================================
 // 日程与待办配置结构 (schedules.json 映射)
 // ==========================================
@@ -124,7 +133,46 @@ impl IntentType {
 pub struct PendingIntent {
     /// 已格式化的系统旁白（PromptRole::System.build_prompt 的结果）
     pub prompt: String,
+    /// 去重使用的原始提示词。只有真正投递成功后才写入主动对话历史。
+    pub raw_prompt: Option<String>,
     pub intent_type: IntentType,
+    /// 创建策略时的用户交互代次；用于丢弃用户发言前启动的过期屏幕/闲聊结果。
+    pub interaction_epoch: u64,
+    /// 已进入生成阶段但未产出任何持久化回复的次数。
+    pub delivery_attempts: u8,
     /// 生成时间，用于 TTL 过期判断
     pub triggered_at: Instant,
+}
+
+impl PendingIntent {
+    pub fn new(
+        prompt: String,
+        raw_prompt: Option<String>,
+        intent_type: IntentType,
+        interaction_epoch: u64,
+    ) -> Self {
+        let now = Instant::now();
+        Self {
+            prompt,
+            raw_prompt,
+            intent_type,
+            interaction_epoch,
+            delivery_attempts: 0,
+            triggered_at: now,
+        }
+    }
+}
+
+/// 调度器生成的候选意图。prompt 仍是未经过 PromptRole 包装的原始文本。
+#[derive(Clone, Debug)]
+pub struct ProactiveCandidate {
+    pub prompt: String,
+    pub intent_type: IntentType,
+}
+
+/// 一轮策略选择的结果，同时告诉主循环本轮是否真的调用过视觉模型。
+#[derive(Clone, Debug, Default)]
+pub struct DispatchOutcome {
+    pub candidate: Option<ProactiveCandidate>,
+    pub screen_attempted: bool,
 }

--- a/src-tauri/src/ai_service/proactive_system/visual_monitor.rs
+++ b/src-tauri/src/ai_service/proactive_system/visual_monitor.rs
@@ -5,11 +5,15 @@ use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_
 
 pub struct VisualMonitor {
     last_hash: Option<u64>,
+    pending_change: bool,
 }
 
 impl VisualMonitor {
     pub fn new() -> Self {
-        Self { last_hash: None }
+        Self {
+            last_hash: None,
+            pending_change: false,
+        }
     }
 
     /// 执行快速的 GDI 像素网格采样并检测画面是否变化。
@@ -72,15 +76,19 @@ impl VisualMonitor {
                     // Hamming distance >= 6 means change detected (threshold matching Python dhash difference)
                     let change_detected = diff >= 6;
                     if change_detected {
+                        self.pending_change = true;
                         tracing::info!(
                             "[VisualMonitor] Screen change detected! Hamming distance: {}",
                             diff
                         );
                     }
-                    change_detected
+                    self.pending_change
                 } else {
                     self.last_hash = Some(hash);
-                    false
+                    // 首次采样也需要分析一次，否则用户在启动后画面不变化时永远不会进入视觉路径。
+                    self.pending_change = true;
+                    tracing::debug!("[VisualMonitor] Initial screen sample marked for analysis");
+                    true
                 }
             }
         }
@@ -89,5 +97,10 @@ impl VisualMonitor {
         {
             false
         }
+    }
+
+    /// 视觉模型已经消费了当前变化，清除待分析标记。
+    pub fn mark_analyzed(&mut self) {
+        self.pending_change = false;
     }
 }

--- a/src-tauri/src/ai_service/screen_analyzer.rs
+++ b/src-tauri/src/ai_service/screen_analyzer.rs
@@ -1,11 +1,32 @@
 //! 桌面截图分析器。
 //! 独立的屏幕捕获与视觉语言模型(VLM)分析模块，可在多处复用（主动对话、脚本事件等）。
 //!
-//! 设计参考 Python 原版 `ling_chat_python/core/pic_analyzer.py` 的 DesktopAnalyzer。
+//! 设计参考 Python 原版 `ling_chat_python/core/pic_analyzer.py` 的 DesktopAnalyzer，
+//! 并参考 N.E.K.O 与 Kimi Code 的截图清晰度、图片验证、窗口标题上下文等做法。
 
 use reqwest::Client;
 use serde_json::Value;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+
+use crate::ai_service::llm::provider_config::resolve_chat_provider;
+use crate::config::proactive::ProactiveConfig;
+
+/// 安全限制：原始图片最大 10MB（base64 后约 13.3MB）。
+const MAX_IMAGE_SIZE_BYTES: usize = 10 * 1024 * 1024;
+const MAX_BASE64_SIZE: usize = MAX_IMAGE_SIZE_BYTES * 4 / 3 + 100;
+const MAX_IMAGE_DIMENSION: u32 = 32_768;
+const MAX_IMAGE_DECODE_BYTES: u64 = 192 * 1024 * 1024;
+/// 屏幕识别只需要一句短回复；限制输出，避免推理模型为简单视觉任务生成很长的思考链。
+const VISION_MAX_TOKENS: u32 = 256;
+/// Kimi Coding 目前无法可靠关闭长思考；过小预算会在最终正文前截断。
+/// 对该兼容路径保留足够输出空间，并依靠请求总超时止损。
+const KIMICODE_VISION_MAX_TOKENS: u32 = 4096;
+const SCREEN_ANALYZER_USER_AGENT: &str =
+    concat!("LingChat/", env!("CARGO_PKG_VERSION"), " screen-analyzer");
+const VISION_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const VISION_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+/// 图片像素数安全上限（避免超大图片耗尽内存）。
+const MAX_IMAGE_PIXELS: u64 = 100_000_000;
 
 /// 屏幕分析器的配置（从环境/Store 加载）。
 #[derive(Clone, Debug)]
@@ -13,6 +34,9 @@ pub struct ScreenAnalyzerConfig {
     pub vd_api_key: String,
     pub vd_base_url: String,
     pub vd_model: String,
+    /// 提供者协议类型，例如 `"openai"` 或 `"kimicode"`。
+    /// 用于决定使用 OpenAI Chat Completions 还是 Anthropic Messages API。
+    pub provider: String,
 }
 
 impl Default for ScreenAnalyzerConfig {
@@ -20,7 +44,41 @@ impl Default for ScreenAnalyzerConfig {
         Self {
             vd_api_key: String::new(),
             vd_base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1".to_string(),
-            vd_model: "qwen3.5-plus".to_string(),
+            vd_model: "qwen3-vl-flash".to_string(),
+            provider: "openai".to_string(),
+        }
+    }
+}
+
+/// 屏幕分析时的角色/对话上下文，让 VLM 以角色视角描述屏幕。
+#[derive(Clone, Debug, Default)]
+pub struct ScreenContext {
+    pub ai_name: Option<String>,
+    pub user_name: Option<String>,
+    pub recent_chat_summary: Option<String>,
+}
+
+/// 图片压缩目标参数。
+/// 参考 Kimi Code 的 `compressImageForModel`：在视觉可接受的前提下控制 token 消耗。
+#[derive(Clone, Debug)]
+pub struct CompressionTarget {
+    /// 长边最大像素（默认 896）。
+    pub max_dimension: u32,
+    /// JPEG 编码后目标最大字节数（默认 512 KiB）。
+    pub max_bytes: usize,
+    /// 最低 JPEG 质量（默认 60）。
+    pub min_quality: u8,
+    /// 首选 JPEG 质量（默认 78）；只有该质量超限时才继续降质。
+    pub max_quality: u8,
+}
+
+impl Default for CompressionTarget {
+    fn default() -> Self {
+        Self {
+            max_dimension: 896,
+            max_bytes: 512 * 1024,
+            min_quality: 60,
+            max_quality: 78,
         }
     }
 }
@@ -37,14 +95,22 @@ pub struct ScreenAnalyzer {
     config: ScreenAnalyzerConfig,
     client: Client,
     last_report: AnalysisReport,
+    compression: CompressionTarget,
 }
 
 impl ScreenAnalyzer {
     pub fn new(config: ScreenAnalyzerConfig) -> Self {
+        let client = Client::builder()
+            .connect_timeout(VISION_CONNECT_TIMEOUT)
+            .timeout(VISION_REQUEST_TIMEOUT)
+            .build()
+            .expect("static screen-analyzer HTTP client configuration should be valid");
+
         Self {
             config,
-            client: Client::new(),
+            client,
             last_report: AnalysisReport::default(),
+            compression: CompressionTarget::default(),
         }
     }
 
@@ -58,19 +124,76 @@ impl ScreenAnalyzer {
         &self.last_report
     }
 
+    /// 主动搭话专用：让 VLM 直接看图决定"说不说"。
+    /// 返回 `[PASS]` 表示不说话；否则返回要说出的话语。
+    pub async fn analyze_screen_for_proactive(
+        &mut self,
+        context: Option<&ScreenContext>,
+    ) -> Option<String> {
+        let prompt = "你刚刚偷偷看了一眼主人的电脑屏幕。请根据屏幕内容和当前窗口标题，判断是否要主动和主人搭话。\
+规则：\
+1. 如果屏幕上有任何有趣、新鲜、奇怪或值得讨论的内容，请一定要说一句简短自然的话；\
+2. 如果内容与你们之前的对话、主人的兴趣或当前窗口标题相关，更应该提起；\
+3. 只有当屏幕内容真的无聊、重复，或者主人明显在全屏游戏/视频会议/紧急工作时，才回复\"[PASS]\"；\
+4. 不要描述聊天窗口或角色立绘区域，只关注桌面上的其他内容；\
+5. 回复要简短自然，像不经意间看到的，不超过50字。\
+\
+回复格式：\
+- 如果要搭话，直接说出你想说的话；\
+- 如果确定不要搭话，只回复\"[PASS]\"，不要解释。";
+
+        self.analyze_screen(prompt, context).await
+    }
+
     /// 核心方法：截屏 → 发送给 VLM 分析 → 返回文本描述。
     /// 这是策略分发器和主动对话系统的主要入口。
-    pub async fn analyze_screen(&mut self, prompt: &str) -> Option<String> {
+    pub async fn analyze_screen(
+        &mut self,
+        prompt: &str,
+        context: Option<&ScreenContext>,
+    ) -> Option<String> {
+        let total_started = Instant::now();
         let api_key = &self.config.vd_api_key;
         if api_key.is_empty() {
             tracing::warn!("[ScreenAnalyzer] VD_API_KEY is empty, skipping screenshot analysis.");
             return None;
         }
 
-        let jpeg_bytes = capture_screen_as_jpeg()?;
+        let capture_started = Instant::now();
+        let compression = self.compression.clone();
+        let jpeg_bytes = match tokio::task::spawn_blocking(move || {
+            capture_screen_as_jpeg_with_compression(&compression)
+        })
+        .await
+        {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => return None,
+            Err(e) => {
+                tracing::error!("[ScreenAnalyzer] Screenshot worker failed: {}", e);
+                return None;
+            }
+        };
+        let capture_elapsed = capture_started.elapsed();
+        tracing::info!(
+            "[ScreenAnalyzer] Captured screenshot: {} bytes in {:.0}ms",
+            jpeg_bytes.len(),
+            capture_elapsed.as_secs_f64() * 1000.0
+        );
 
+        let window_title = get_active_window_title();
+        let enriched_prompt = build_screen_prompt(prompt, window_title.as_deref(), context);
+
+        let vlm_started = Instant::now();
         let (base64, mime) = encode_image_base64(&jpeg_bytes, "jpeg");
-        self.call_vlm(prompt, &base64, &mime).await
+        let result = self.call_vlm(&enriched_prompt, &base64, &mime).await;
+        let vlm_elapsed = vlm_started.elapsed();
+        tracing::info!(
+            "[ScreenAnalyzer] Stage timings: capture={:.0}ms, vlm={:.0}ms, total={:.0}ms",
+            capture_elapsed.as_secs_f64() * 1000.0,
+            vlm_elapsed.as_secs_f64() * 1000.0,
+            total_started.elapsed().as_secs_f64() * 1000.0,
+        );
+        result
     }
 
     /// 分析任意图片字节（支持 JPEG / PNG / WebP 等格式）。
@@ -82,7 +205,42 @@ impl ScreenAnalyzer {
             return None;
         }
 
-        let (base64, mime) = encode_image_base64(image_bytes, "png");
+        if image_bytes.len() > MAX_IMAGE_SIZE_BYTES {
+            tracing::error!(
+                "[ScreenAnalyzer] Image too large: {} bytes > {}",
+                image_bytes.len(),
+                MAX_IMAGE_SIZE_BYTES
+            );
+            return None;
+        }
+
+        let image_bytes = image_bytes.to_vec();
+        let compression = self.compression.clone();
+        let compressed = match tokio::task::spawn_blocking(move || {
+            compress_image_bytes(&image_bytes, &compression)
+        })
+        .await
+        {
+            Ok(Ok(bytes)) => bytes,
+            Ok(Err(error)) => {
+                tracing::error!("[ScreenAnalyzer] Image compression failed: {error:#}");
+                return None;
+            }
+            Err(error) => {
+                tracing::error!("[ScreenAnalyzer] Image worker failed: {error}");
+                return None;
+            }
+        };
+        let mime_type = if matches!(
+            image::guess_format(&compressed).ok(),
+            Some(image::ImageFormat::Png)
+        ) {
+            "png"
+        } else {
+            "jpeg"
+        };
+
+        let (base64, mime) = encode_image_base64(&compressed, mime_type);
         self.call_vlm(prompt, &base64, &mime).await
     }
 
@@ -95,33 +253,87 @@ impl ScreenAnalyzer {
         }
 
         let bytes = std::fs::read(image_path).ok()?;
-
-        // 根据扩展名推断 MIME
-        let mime_type = if image_path.ends_with(".png") {
-            "png"
-        } else if image_path.ends_with(".webp") {
-            "webp"
-        } else {
-            "jpeg"
-        };
-
-        let (base64, mime) = encode_image_base64(&bytes, mime_type);
-        self.call_vlm(prompt, &base64, &mime).await
+        self.analyze_image(&bytes, prompt).await
     }
 
     /// 调用视觉语言模型 API。
+    /// 根据 provider 字段自动选择 OpenAI Chat Completions 或 Anthropic Messages API。
     async fn call_vlm(
         &mut self,
         prompt: &str,
         base64_image: &str,
         mime_type: &str,
     ) -> Option<String> {
+        if base64_image.len() > MAX_BASE64_SIZE {
+            tracing::error!(
+                "[ScreenAnalyzer] Base64 image too large: {} bytes > {}",
+                base64_image.len(),
+                MAX_BASE64_SIZE
+            );
+            return None;
+        }
+
+        let provider = self.config.provider.to_lowercase();
+        let is_anthropic = provider == "kimicode" || provider == "anthropic";
+        let model = &self.config.vd_model;
+
+        tracing::info!(
+            "[ScreenAnalyzer] Sending image to VLM ({}, provider={}) for analysis...",
+            model,
+            self.config.provider
+        );
+
+        let start = Instant::now();
+
+        let result = if is_anthropic {
+            self.call_vlm_anthropic(prompt, base64_image, mime_type)
+                .await
+        } else {
+            self.call_vlm_openai(prompt, base64_image, mime_type).await
+        };
+
+        let elapsed = start.elapsed().as_secs_f64();
+
+        match result {
+            Ok(content) => {
+                self.last_report.response_time_secs = elapsed;
+                if content.is_some() {
+                    tracing::info!("[ScreenAnalyzer] Analysis success in {:.2}s", elapsed);
+                }
+                content
+            }
+            Err(e) => {
+                tracing::error!(
+                    "[ScreenAnalyzer] VLM request failed after {:.2}s: {}",
+                    elapsed,
+                    e
+                );
+                self.last_report = AnalysisReport {
+                    response_time_secs: elapsed,
+                    ..Default::default()
+                };
+                None
+            }
+        }
+    }
+
+    /// OpenAI 兼容协议调用路径。
+    async fn call_vlm_openai(
+        &mut self,
+        prompt: &str,
+        base64_image: &str,
+        mime_type: &str,
+    ) -> Result<Option<String>, String> {
         let image_url = format!("data:image/{};base64,{}", mime_type, base64_image);
         let model = &self.config.vd_model;
 
-        let payload = serde_json::json!({
+        let mut payload = serde_json::json!({
             "model": model,
             "messages": [
+                {
+                    "role": "system",
+                    "content": VISION_SYSTEM_PROMPT
+                },
                 {
                     "role": "user",
                     "content": [
@@ -130,69 +342,278 @@ impl ScreenAnalyzer {
                     ]
                 }
             ],
-            "max_tokens": 512
+            "max_tokens": VISION_MAX_TOKENS
         });
-
-        tracing::info!(
-            "[ScreenAnalyzer] Sending image to VLM ({}) for analysis...",
-            model
+        apply_fast_vision_options(
+            &mut payload,
+            &self.config.vd_model,
+            &self.config.vd_base_url,
         );
 
-        let start = Instant::now();
+        let endpoint = normalize_endpoint(&self.config.vd_base_url);
 
-        let api_key = &self.config.vd_api_key;
-        let endpoint = format!("{}/chat/completions", self.config.vd_base_url);
-
-        let res = self
+        let response = self
             .client
             .post(&endpoint)
-            .bearer_auth(api_key)
+            .bearer_auth(&self.config.vd_api_key)
+            .header(reqwest::header::USER_AGENT, SCREEN_ANALYZER_USER_AGENT)
             .json(&payload)
             .send()
-            .await;
+            .await
+            .map_err(|e| format!("request failed: {:?}", e))?;
 
-        let elapsed = start.elapsed().as_secs_f64();
-
-        match res {
-            Ok(response) => {
-                if response.status().is_success() {
-                    if let Ok(json_res) = response.json::<Value>().await {
-                        let content = json_res["choices"][0]["message"]["content"]
-                            .as_str()
-                            .map(|s| s.to_string());
-
-                        let usage = &json_res["usage"];
-                        self.last_report = AnalysisReport {
-                            response_time_secs: elapsed,
-                            input_tokens: usage["prompt_tokens"].as_u64().map(|n| n as u32),
-                            output_tokens: usage["completion_tokens"].as_u64().map(|n| n as u32),
-                        };
-
-                        if let Some(ref c) = content {
-                            tracing::info!("[ScreenAnalyzer] Analysis success: {}", c);
-                        }
-
-                        return content;
-                    }
-                } else {
-                    let err_text = response.text().await.unwrap_or_default();
-                    tracing::error!(
-                        "[ScreenAnalyzer] VLM API returned error status: {}",
-                        err_text
-                    );
-                }
-            }
-            Err(e) => {
-                tracing::error!("[ScreenAnalyzer] Failed to send request to VLM: {:?}", e);
-            }
+        let status = response.status();
+        if !status.is_success() {
+            let err_text = response
+                .text()
+                .await
+                .unwrap_or_else(|error| format!("<failed to read error body: {error}>"));
+            return Err(format!(
+                "VLM API returned error status {}: {}",
+                status, err_text
+            ));
         }
 
+        let json_res = response
+            .json::<Value>()
+            .await
+            .map_err(|e| format!("failed to parse VLM JSON response: {:?}", e))?;
+
+        let content = json_res["choices"][0]["message"]["content"]
+            .as_str()
+            .map(|s| s.to_string());
+
+        let usage = &json_res["usage"];
         self.last_report = AnalysisReport {
-            response_time_secs: elapsed,
-            ..Default::default()
+            response_time_secs: 0.0,
+            input_tokens: usage["prompt_tokens"].as_u64().map(|n| n as u32),
+            output_tokens: usage["completion_tokens"].as_u64().map(|n| n as u32),
         };
 
+        if content.is_none() {
+            tracing::warn!(
+                "[ScreenAnalyzer] VLM response missing content (choices={})",
+                json_res["choices"].as_array().map_or(0, Vec::len)
+            );
+        }
+
+        Ok(content)
+    }
+
+    /// Anthropic Messages API 调用路径（用于 Kimi Code / kimi-for-coding 等）。
+    async fn call_vlm_anthropic(
+        &mut self,
+        prompt: &str,
+        base64_image: &str,
+        mime_type: &str,
+    ) -> Result<Option<String>, String> {
+        let model = &self.config.vd_model;
+        let media_type = format!("image/{}", mime_type);
+
+        let payload = serde_json::json!({
+            "model": model,
+            "max_tokens": if self.config.provider.eq_ignore_ascii_case("kimicode") {
+                KIMICODE_VISION_MAX_TOKENS
+            } else {
+                VISION_MAX_TOKENS
+            },
+            "system": VISION_SYSTEM_PROMPT,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": media_type,
+                                "data": base64_image
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let endpoint = normalize_anthropic_endpoint(&self.config.vd_base_url);
+
+        let response = self
+            .client
+            .post(&endpoint)
+            .header("x-api-key", self.config.vd_api_key.clone())
+            .header("anthropic-version", "2023-06-01")
+            .header(reqwest::header::USER_AGENT, SCREEN_ANALYZER_USER_AGENT)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() && self.config.provider.eq_ignore_ascii_case("kimicode") {
+                    "Kimi Coding 视觉分析超过 20 秒，已取消；建议为主动屏幕识别配置独立的轻量视觉模型"
+                        .to_string()
+                } else {
+                    format!("request failed: {:?}", e)
+                }
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let err_text = response
+                .text()
+                .await
+                .unwrap_or_else(|error| format!("<failed to read error body: {error}>"));
+            return Err(format!(
+                "VLM API returned error status {}: {}",
+                status, err_text
+            ));
+        }
+
+        let json_res = response.json::<Value>().await.map_err(|e| {
+            if e.is_timeout() && self.config.provider.eq_ignore_ascii_case("kimicode") {
+                "Kimi Coding 视觉分析超过 20 秒，已取消；建议为主动屏幕识别配置独立的轻量视觉模型"
+                    .to_string()
+            } else {
+                format!("failed to parse VLM JSON response: {:?}", e)
+            }
+        })?;
+
+        // Anthropic 响应的 content 是数组，可能同时包含 thinking 和 text 块。
+        // kimi-for-coding 默认会输出 thinking，需要遍历所有 block 提取文本。
+        let (content, thinking_chars) = extract_anthropic_text(&json_res);
+
+        if thinking_chars > 0 {
+            tracing::debug!(
+                "[ScreenAnalyzer] VLM thinking received ({} chars)",
+                thinking_chars
+            );
+        }
+
+        let usage = &json_res["usage"];
+        self.last_report = AnalysisReport {
+            response_time_secs: 0.0,
+            input_tokens: usage["input_tokens"].as_u64().map(|n| n as u32),
+            output_tokens: usage["output_tokens"].as_u64().map(|n| n as u32),
+        };
+
+        if content.is_none() {
+            tracing::warn!(
+                "[ScreenAnalyzer] VLM response missing text content (blocks={}, stop_reason={:?})",
+                json_res["content"].as_array().map_or(0, Vec::len),
+                json_res["stop_reason"].as_str()
+            );
+        }
+
+        Ok(content)
+    }
+}
+
+/// 从 Anthropic Messages API 响应中提取可读的文本内容。
+/// 返回 `(text_content, thinking_char_count)`，其中 text_content 会把所有 text block 拼接起来。
+/// 思考链只计数而不复制，避免为不会展示的长文本额外分配内存。
+fn extract_anthropic_text(json_res: &Value) -> (Option<String>, usize) {
+    let mut text_parts = Vec::new();
+    let mut thinking_chars = 0;
+
+    if let Some(content) = json_res["content"].as_array() {
+        for block in content {
+            match block["type"].as_str() {
+                Some("text") => {
+                    if let Some(t) = block["text"].as_str() {
+                        text_parts.push(t.to_string());
+                    }
+                }
+                Some("thinking") => {
+                    if let Some(t) = block["thinking"].as_str() {
+                        thinking_chars += t.chars().count();
+                    }
+                }
+                Some(other) => {
+                    tracing::debug!(
+                        "[ScreenAnalyzer] Unhandled Anthropic content block type: {}",
+                        other
+                    );
+                }
+                None => {}
+            }
+        }
+    }
+
+    let text = if text_parts.is_empty() {
         None
+    } else {
+        Some(text_parts.join("\n"))
+    };
+
+    (text, thinking_chars)
+}
+
+/// VLM 系统提示：让模型知道自己在做什么，以及忽略聊天窗口。
+const VISION_SYSTEM_PROMPT: &str = "你是一个桌面画面观察者，也是用户的AI伙伴。用户授权你查看他的屏幕截图，请用简洁的中文描述画面主体内容。\
+如果截图里包含用户与 AI 的聊天窗口或角色立绘对话框，请不要描述这部分，只描述桌面上的其他内容。\
+如果提供了当前窗口标题，可以结合标题理解用户正在做什么。\
+如果提供了角色身份或近期对话摘要，请结合这些信息理解用户当前可能在做什么。";
+
+/// 把用户提示与当前窗口标题、角色上下文结合，给 VLM 更丰富的上下文。
+fn build_screen_prompt(
+    base_prompt: &str,
+    window_title: Option<&str>,
+    context: Option<&ScreenContext>,
+) -> String {
+    let mut sections = vec![base_prompt.to_string()];
+
+    if let Some(title) = window_title.filter(|t| !t.is_empty()) {
+        sections.push(format!("\n\n[当前焦点窗口标题]：{}", title));
+    }
+
+    if let Some(ctx) = context {
+        let ai_name = ctx.ai_name.as_deref().unwrap_or("AI");
+        let user_name = ctx.user_name.as_deref().unwrap_or("用户");
+        sections.push(format!(
+            "\n\n[角色身份]：你是{}，正在陪伴{}。",
+            ai_name, user_name
+        ));
+
+        if let Some(summary) = ctx.recent_chat_summary.as_deref().filter(|s| !s.is_empty()) {
+            sections.push(format!("\n[近期对话摘要]：{}", summary));
+        }
+    }
+
+    sections.concat()
+}
+
+/// 根据 ProactiveConfig 构建 ScreenAnalyzerConfig。
+/// 当 `VD_FOLLOW_CHAT_MODEL` 为 true 时，复用当前对话模型（chat provider）的 API Key、Base URL、模型名和提供者协议；
+/// 如果对话模型未配置或不可用，则回退到独立的视觉模型配置并记录警告。
+pub fn build_screen_analyzer_config(
+    app_handle: &tauri::AppHandle,
+    config: &ProactiveConfig,
+) -> ScreenAnalyzerConfig {
+    if config.vd_follow_chat_model {
+        if let Some(provider) = resolve_chat_provider(app_handle) {
+            tracing::info!(
+                "[ScreenAnalyzer] VD follows chat model: {} ({}) provider={}",
+                provider.label,
+                provider.model,
+                provider.provider
+            );
+            return ScreenAnalyzerConfig {
+                vd_api_key: provider.api_key,
+                vd_base_url: provider.base_url,
+                vd_model: provider.model,
+                provider: provider.provider,
+            };
+        } else {
+            tracing::warn!(
+                "[ScreenAnalyzer] VD_FOLLOW_CHAT_MODEL is enabled but no usable chat provider found, falling back to dedicated VD config"
+            );
+        }
+    }
+
+    ScreenAnalyzerConfig {
+        vd_api_key: config.vd_api_key.clone(),
+        vd_base_url: config.vd_base_url.clone(),
+        vd_model: config.vd_model.clone(),
+        provider: "openai".to_string(),
     }
 }
 
@@ -202,85 +623,436 @@ fn encode_image_base64(bytes: &[u8], mime_type: &str) -> (String, String) {
     (b64, mime_type.to_string())
 }
 
-/// 捕获整个桌面并返回 JPEG 格式的字节。
+/// Disable long reasoning for OpenAI-compatible models known to support this option.
+fn apply_fast_vision_options(payload: &mut Value, model: &str, base_url: &str) {
+    let Some(object) = payload.as_object_mut() else {
+        return;
+    };
+
+    let base_url = base_url.to_ascii_lowercase();
+    let is_dashscope = base_url.contains("dashscope.aliyuncs.com")
+        || base_url.contains("dashscope-intl.aliyuncs.com");
+    if is_dashscope && model.to_ascii_lowercase().contains("qwen3") {
+        object.insert("enable_thinking".to_string(), Value::Bool(false));
+    }
+}
+
+/// 确保 Base URL 末尾没有斜杠，以便正确拼接 `/chat/completions`。
+fn normalize_endpoint(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions".to_string()
+    } else if trimmed.ends_with("/chat/completions") {
+        trimmed.to_string()
+    } else {
+        format!("{}/chat/completions", trimmed)
+    }
+}
+
+/// 为 Anthropic Messages API 规范化 endpoint：base_url 末尾去斜杠后拼接 `/v1/messages`。
+fn normalize_anthropic_endpoint(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "https://api.kimi.com/coding/v1/messages".to_string()
+    } else if trimmed.ends_with("/v1/messages") {
+        trimmed.to_string()
+    } else {
+        format!("{}/v1/messages", trimmed)
+    }
+}
+
+/// 验证并加载图片，检查尺寸与完整性。
+fn validate_image_bytes(bytes: &[u8]) -> anyhow::Result<image::DynamicImage> {
+    if bytes.len() > MAX_IMAGE_SIZE_BYTES {
+        anyhow::bail!(
+            "image too large: {} bytes > {}",
+            bytes.len(),
+            MAX_IMAGE_SIZE_BYTES
+        );
+    }
+
+    let make_reader = || {
+        image::ImageReader::new(std::io::Cursor::new(bytes))
+            .with_guessed_format()
+            .map_err(|e| anyhow::anyhow!("invalid image header: {e}"))
+    };
+
+    // 先只读取尺寸，再决定是否允许完整解码，避免超大压缩图抢占大量内存。
+    let (width, height) = make_reader()?
+        .into_dimensions()
+        .map_err(|e| anyhow::anyhow!("invalid image dimensions: {e}"))?;
+    let pixels = u64::from(width).saturating_mul(u64::from(height));
+    if pixels > MAX_IMAGE_PIXELS {
+        anyhow::bail!(
+            "image too large: {}x{} = {} pixels > {}",
+            width,
+            height,
+            pixels,
+            MAX_IMAGE_PIXELS
+        );
+    }
+
+    let mut reader = make_reader()?;
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(MAX_IMAGE_DIMENSION);
+    limits.max_image_height = Some(MAX_IMAGE_DIMENSION);
+    limits.max_alloc = Some(MAX_IMAGE_DECODE_BYTES);
+    reader.limits(limits);
+    let img = reader
+        .decode()
+        .map_err(|e| anyhow::anyhow!("invalid or oversized image: {e}"))?;
+
+    Ok(img)
+}
+
+/// 压缩图片字节到目标尺寸与大小。
+/// 先按 `max_dimension` 等比缩放，再用 JPEG 质量迭代控制文件大小。
+fn compress_image_bytes(bytes: &[u8], target: &CompressionTarget) -> anyhow::Result<Vec<u8>> {
+    let img = validate_image_bytes(bytes)?;
+    compress_dynamic_image(&img, target)
+}
+
+/// 压缩 `DynamicImage` 到目标尺寸与大小。
+fn compress_dynamic_image(
+    img: &image::DynamicImage,
+    target: &CompressionTarget,
+) -> anyhow::Result<Vec<u8>> {
+    let (orig_w, orig_h) = (img.width(), img.height());
+    let max_dim = target.max_dimension.max(1);
+
+    // 先缩小再转 RGB，避免 4K 截图在压缩前产生一次完整尺寸的额外 RGB 副本。
+    let resized_source = if orig_w.max(orig_h) > max_dim {
+        img.resize(max_dim, max_dim, image::imageops::FilterType::Triangle)
+    } else {
+        img.clone()
+    };
+    // 统一转换为 RGB8，避免 RGBA/P 模式带来的 JPEG 兼容性问题。
+    let resized = image::DynamicImage::ImageRgb8(resized_source.to_rgb8());
+
+    let (new_w, new_h) = (resized.width(), resized.height());
+
+    let encode_at_quality = |quality: u8| -> anyhow::Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        let mut cursor = std::io::Cursor::new(&mut buf);
+        let mut encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut cursor, quality);
+        encoder.encode_image(&resized)?;
+        Ok(buf)
+    };
+
+    let min_quality = target.min_quality.clamp(1, 100);
+    let preferred_quality = target.max_quality.clamp(min_quality, 100);
+
+    // 主动屏幕识别的默认尺寸下，q78 通常远低于 512 KiB。先只编码一次，
+    // 避免旧实现为了找到最高质量而无条件重复编码 5 次。
+    let preferred = encode_at_quality(preferred_quality)?;
+    let (selected_quality, best) = if preferred.len() <= target.max_bytes {
+        (preferred_quality, preferred)
+    } else {
+        let mut low = min_quality;
+        let mut high = preferred_quality.saturating_sub(1);
+        let mut best_under_limit: Option<(u8, Vec<u8>)> = None;
+        let mut smallest = (preferred_quality, preferred);
+
+        while low <= high {
+            let mid = low + (high - low) / 2;
+            let buf = encode_at_quality(mid)?;
+            if buf.len() < smallest.1.len() {
+                smallest = (mid, buf.clone());
+            }
+
+            if buf.len() <= target.max_bytes {
+                best_under_limit = Some((mid, buf));
+                low = mid.saturating_add(1);
+            } else {
+                if mid == 0 {
+                    break;
+                }
+                high = mid - 1;
+            }
+        }
+
+        best_under_limit.unwrap_or(smallest)
+    };
+
+    if best.len() > target.max_bytes {
+        let current_dimension = new_w.max(new_h);
+        if current_dimension <= 1 {
+            anyhow::bail!(
+                "cannot compress image below {} bytes (smallest result: {})",
+                target.max_bytes,
+                best.len()
+            );
+        }
+        let estimated_ratio = (target.max_bytes as f64 / best.len() as f64).sqrt() * 0.92;
+        let next_dimension =
+            ((current_dimension as f64 * estimated_ratio) as u32).clamp(1, current_dimension - 1);
+        let mut smaller_target = target.clone();
+        smaller_target.max_dimension = next_dimension;
+        return compress_dynamic_image(img, &smaller_target);
+    }
+
+    tracing::info!(
+        "[ScreenAnalyzer] Compressed image: {}x{} -> {}x{}, q{}, {} bytes",
+        orig_w,
+        orig_h,
+        new_w,
+        new_h,
+        selected_quality,
+        best.len()
+    );
+
+    Ok(best)
+}
+
+/// 获取当前前台窗口标题（Windows）。
+/// 用于给 VLM 提供“用户正在看什么窗口”的上下文。
+#[cfg(target_os = "windows")]
+fn get_active_window_title() -> Option<String> {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW,
+    };
+
+    unsafe {
+        let hwnd = GetForegroundWindow();
+        if hwnd == HWND(std::ptr::null_mut()) {
+            return None;
+        }
+
+        let len = GetWindowTextLengthW(hwnd);
+        if len <= 0 {
+            return None;
+        }
+
+        let mut buffer = vec![0u16; (len + 1) as usize];
+        let written = GetWindowTextW(hwnd, &mut buffer);
+        if written <= 0 {
+            return None;
+        }
+
+        // 去掉末尾的 null
+        buffer.truncate(written as usize);
+        String::from_utf16(&buffer).ok()
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn get_active_window_title() -> Option<String> {
+    None
+}
+
+/// 捕获整个桌面并返回经过压缩的 JPEG 字节。
 /// Windows: 使用 GDI (BitBlt + GetDIBits) 捕获，然后压缩为 1024x768 JPEG。
 /// 其他平台: 返回 None。
+#[allow(dead_code)]
 pub fn capture_screen_as_jpeg() -> Option<Vec<u8>> {
+    capture_screen_as_jpeg_with_compression(&CompressionTarget::default())
+}
+
+fn capture_screen_as_jpeg_with_compression(target: &CompressionTarget) -> Option<Vec<u8>> {
     #[cfg(target_os = "windows")]
     {
-        use windows::Win32::Graphics::Gdi::{
-            BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC,
-            GetDIBits, ReleaseDC, SelectObject, BITMAPINFOHEADER, DIB_RGB_COLORS, SRCCOPY,
-        };
-        use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
-
-        unsafe {
-            let hdc_screen = GetDC(None);
-            if hdc_screen.is_invalid() {
-                return None;
+        let dynamic_img = capture_active_monitor_image()?;
+        match compress_dynamic_image(&dynamic_img, target) {
+            Ok(bytes) => Some(bytes),
+            Err(e) => {
+                tracing::error!("[ScreenAnalyzer] Failed to compress screenshot: {:?}", e);
+                None
             }
-            let w = GetSystemMetrics(SM_CXSCREEN);
-            let h = GetSystemMetrics(SM_CYSCREEN);
-            if w <= 0 || h <= 0 {
-                ReleaseDC(None, hdc_screen);
-                return None;
-            }
-
-            let hdc_mem = CreateCompatibleDC(Some(hdc_screen));
-            let hbitmap = CreateCompatibleBitmap(hdc_screen, w, h);
-
-            let old_obj = SelectObject(hdc_mem, hbitmap.into());
-            let _ = BitBlt(hdc_mem, 0, 0, w, h, Some(hdc_screen), 0, 0, SRCCOPY);
-
-            let mut bmi = windows::Win32::Graphics::Gdi::BITMAPINFO::default();
-            bmi.bmiHeader.biSize = std::mem::size_of::<BITMAPINFOHEADER>() as u32;
-            bmi.bmiHeader.biWidth = w;
-            bmi.bmiHeader.biHeight = -h;
-            bmi.bmiHeader.biPlanes = 1;
-            bmi.bmiHeader.biBitCount = 24;
-            bmi.bmiHeader.biCompression = 0;
-
-            let mut buffer = vec![0u8; (w * h * 3) as usize];
-
-            let lines = GetDIBits(
-                hdc_screen,
-                hbitmap,
-                0,
-                h as u32,
-                Some(buffer.as_mut_ptr() as *mut _),
-                &mut bmi,
-                DIB_RGB_COLORS,
-            );
-
-            SelectObject(hdc_mem, old_obj);
-            let _ = DeleteObject(hbitmap.into());
-            let _ = DeleteDC(hdc_mem);
-            ReleaseDC(None, hdc_screen);
-
-            if lines <= 0 {
-                return None;
-            }
-
-            for chunk in buffer.chunks_exact_mut(3) {
-                chunk.swap(0, 2);
-            }
-
-            let img =
-                image::ImageBuffer::<image::Rgb<u8>, _>::from_raw(w as u32, h as u32, buffer)?;
-            let dynamic_img = image::DynamicImage::ImageRgb8(img);
-            let resized = dynamic_img.resize(1024, 768, image::imageops::FilterType::Triangle);
-
-            let mut jpeg_bytes = Vec::new();
-            let mut cursor = std::io::Cursor::new(&mut jpeg_bytes);
-            let _ = resized.write_to(&mut cursor, image::ImageFormat::Jpeg);
-
-            Some(jpeg_bytes)
         }
     }
 
     #[cfg(not(target_os = "windows"))]
     {
+        tracing::warn!("[ScreenAnalyzer] Screen capture is only supported on Windows.");
         None
+    }
+}
+
+/// 捕获前台窗口所在显示器；获取失败时回退到主显示器。
+#[cfg(target_os = "windows")]
+fn capture_active_monitor_image() -> Option<image::DynamicImage> {
+    use windows::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MonitorFromWindow, MONITORINFO, MONITOR_DEFAULTTONEAREST,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
+
+    unsafe {
+        let hwnd = GetForegroundWindow();
+        if !hwnd.0.is_null() {
+            let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+            if !monitor.0.is_null() {
+                let mut info = MONITORINFO {
+                    cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+                    ..Default::default()
+                };
+                if GetMonitorInfoW(monitor, &mut info).as_bool() {
+                    let rect = info.rcMonitor;
+                    let width = rect.right.saturating_sub(rect.left);
+                    let height = rect.bottom.saturating_sub(rect.top);
+                    if width > 0 && height > 0 {
+                        return capture_screen_region_image(rect.left, rect.top, width, height);
+                    }
+                }
+            }
+        }
+    }
+
+    capture_primary_screen_image()
+}
+
+#[cfg(target_os = "windows")]
+fn capture_primary_screen_image() -> Option<image::DynamicImage> {
+    use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
+
+    let width = unsafe { GetSystemMetrics(SM_CXSCREEN) };
+    let height = unsafe { GetSystemMetrics(SM_CYSCREEN) };
+    capture_screen_region_image(0, 0, width, height)
+}
+
+/// Capture a desktop region using a 32-bpp top-down DIB.
+///
+/// 32 bpp avoids the row-padding hazard of 24-bpp DIBs. The bitmap is restored out of the
+/// memory DC before `GetDIBits`, as required by GDI, and every allocation is overflow checked.
+#[cfg(target_os = "windows")]
+fn capture_screen_region_image(
+    source_x: i32,
+    source_y: i32,
+    w: i32,
+    h: i32,
+) -> Option<image::DynamicImage> {
+    use windows::Win32::Graphics::Gdi::{
+        BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC,
+        GetDIBits, ReleaseDC, SelectObject, BITMAPINFO, BITMAPINFOHEADER, DIB_RGB_COLORS, SRCCOPY,
+    };
+
+    unsafe {
+        let hdc_screen = GetDC(None);
+        if hdc_screen.is_invalid() {
+            tracing::error!("[ScreenAnalyzer] Failed to get screen DC.");
+            return None;
+        }
+
+        if w <= 0 || h <= 0 {
+            tracing::error!("[ScreenAnalyzer] Invalid screen size: {}x{}", w, h);
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        let pixel_count = match (w as usize).checked_mul(h as usize) {
+            Some(count) if count as u64 <= MAX_IMAGE_PIXELS => count,
+            _ => {
+                tracing::error!(
+                    "[ScreenAnalyzer] Screen dimensions are too large: {}x{}",
+                    w,
+                    h
+                );
+                ReleaseDC(None, hdc_screen);
+                return None;
+            }
+        };
+        let bgra_len = match pixel_count.checked_mul(4) {
+            Some(len) => len,
+            None => {
+                tracing::error!("[ScreenAnalyzer] Screenshot buffer size overflow.");
+                ReleaseDC(None, hdc_screen);
+                return None;
+            }
+        };
+
+        let hdc_mem = CreateCompatibleDC(Some(hdc_screen));
+        if hdc_mem.is_invalid() {
+            tracing::error!("[ScreenAnalyzer] CreateCompatibleDC failed.");
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        let hbitmap = CreateCompatibleBitmap(hdc_screen, w, h);
+        if hbitmap.is_invalid() {
+            tracing::error!("[ScreenAnalyzer] CreateCompatibleBitmap failed.");
+            let _ = DeleteDC(hdc_mem);
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        let old_obj = SelectObject(hdc_mem, hbitmap.into());
+        if old_obj.0.is_null() || old_obj.0 as isize == -1 {
+            tracing::error!("[ScreenAnalyzer] SelectObject failed.");
+            let _ = DeleteDC(hdc_mem);
+            let _ = DeleteObject(hbitmap.into());
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        if let Err(e) = BitBlt(
+            hdc_mem,
+            0,
+            0,
+            w,
+            h,
+            Some(hdc_screen),
+            source_x,
+            source_y,
+            SRCCOPY,
+        ) {
+            tracing::error!("[ScreenAnalyzer] BitBlt failed: {}", e);
+            let _ = SelectObject(hdc_mem, old_obj);
+            let _ = DeleteDC(hdc_mem);
+            let _ = DeleteObject(hbitmap.into());
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        // GetDIBits requires the bitmap not to be selected into a DC.
+        let restored = SelectObject(hdc_mem, old_obj);
+        if restored.0.is_null() || restored.0 as isize == -1 {
+            tracing::error!("[ScreenAnalyzer] Failed to restore memory DC bitmap.");
+            let _ = DeleteDC(hdc_mem);
+            let _ = DeleteObject(hbitmap.into());
+            ReleaseDC(None, hdc_screen);
+            return None;
+        }
+
+        let mut bmi = BITMAPINFO::default();
+        bmi.bmiHeader.biSize = std::mem::size_of::<BITMAPINFOHEADER>() as u32;
+        bmi.bmiHeader.biWidth = w;
+        bmi.bmiHeader.biHeight = -h;
+        bmi.bmiHeader.biPlanes = 1;
+        bmi.bmiHeader.biBitCount = 32;
+        bmi.bmiHeader.biCompression = 0;
+        bmi.bmiHeader.biSizeImage = bgra_len as u32;
+
+        let mut bgra = vec![0u8; bgra_len];
+        let lines = GetDIBits(
+            hdc_mem,
+            hbitmap,
+            0,
+            h as u32,
+            Some(bgra.as_mut_ptr() as *mut _),
+            &mut bmi,
+            DIB_RGB_COLORS,
+        );
+
+        let _ = DeleteDC(hdc_mem);
+        let _ = DeleteObject(hbitmap.into());
+        ReleaseDC(None, hdc_screen);
+
+        if lines != h {
+            tracing::error!(
+                "[ScreenAnalyzer] GetDIBits returned {} of {} lines.",
+                lines,
+                h
+            );
+            return None;
+        }
+
+        for pixel in bgra.chunks_exact_mut(4) {
+            pixel.swap(0, 2);
+            pixel[3] = u8::MAX;
+        }
+
+        let image = image::ImageBuffer::<image::Rgba<u8>, _>::from_raw(w as u32, h as u32, bgra)?;
+        Some(image::DynamicImage::ImageRgba8(image))
     }
 }
 
@@ -289,77 +1061,117 @@ pub fn capture_screen_as_jpeg() -> Option<Vec<u8>> {
 pub fn capture_screen_raw_jpeg() -> Option<Vec<u8>> {
     #[cfg(target_os = "windows")]
     {
-        use windows::Win32::Graphics::Gdi::{
-            BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC,
-            GetDIBits, ReleaseDC, SelectObject, BITMAPINFOHEADER, DIB_RGB_COLORS, SRCCOPY,
-        };
-        use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN};
-
-        unsafe {
-            let hdc_screen = GetDC(None);
-            if hdc_screen.is_invalid() {
-                return None;
-            }
-            let w = GetSystemMetrics(SM_CXSCREEN);
-            let h = GetSystemMetrics(SM_CYSCREEN);
-            if w <= 0 || h <= 0 {
-                ReleaseDC(None, hdc_screen);
-                return None;
-            }
-
-            let hdc_mem = CreateCompatibleDC(Some(hdc_screen));
-            let hbitmap = CreateCompatibleBitmap(hdc_screen, w, h);
-
-            let old_obj = SelectObject(hdc_mem, hbitmap.into());
-            let _ = BitBlt(hdc_mem, 0, 0, w, h, Some(hdc_screen), 0, 0, SRCCOPY);
-
-            let mut bmi = windows::Win32::Graphics::Gdi::BITMAPINFO::default();
-            bmi.bmiHeader.biSize = std::mem::size_of::<BITMAPINFOHEADER>() as u32;
-            bmi.bmiHeader.biWidth = w;
-            bmi.bmiHeader.biHeight = -h;
-            bmi.bmiHeader.biPlanes = 1;
-            bmi.bmiHeader.biBitCount = 24;
-            bmi.bmiHeader.biCompression = 0;
-
-            let mut buffer = vec![0u8; (w * h * 3) as usize];
-
-            let lines = GetDIBits(
-                hdc_screen,
-                hbitmap,
-                0,
-                h as u32,
-                Some(buffer.as_mut_ptr() as *mut _),
-                &mut bmi,
-                DIB_RGB_COLORS,
-            );
-
-            SelectObject(hdc_mem, old_obj);
-            let _ = DeleteObject(hbitmap.into());
-            let _ = DeleteDC(hdc_mem);
-            ReleaseDC(None, hdc_screen);
-
-            if lines <= 0 {
-                return None;
-            }
-
-            for chunk in buffer.chunks_exact_mut(3) {
-                chunk.swap(0, 2);
-            }
-
-            let img =
-                image::ImageBuffer::<image::Rgb<u8>, _>::from_raw(w as u32, h as u32, buffer)?;
-            let dynamic_img = image::DynamicImage::ImageRgb8(img);
-
-            let mut jpeg_bytes = Vec::new();
-            let mut cursor = std::io::Cursor::new(&mut jpeg_bytes);
-            let _ = dynamic_img.write_to(&mut cursor, image::ImageFormat::Jpeg);
-
-            Some(jpeg_bytes)
+        let dynamic_img = capture_primary_screen_image()?;
+        let rgb_img = image::DynamicImage::ImageRgb8(dynamic_img.to_rgb8());
+        let mut jpeg_bytes = Vec::new();
+        let mut cursor = std::io::Cursor::new(&mut jpeg_bytes);
+        if let Err(e) = rgb_img.write_to(&mut cursor, image::ImageFormat::Jpeg) {
+            tracing::error!("[ScreenAnalyzer] Failed to encode raw screenshot: {}", e);
+            return None;
         }
+        Some(jpeg_bytes)
     }
 
     #[cfg(not(target_os = "windows"))]
     {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fast_vision_defaults() {
+        let target = CompressionTarget::default();
+        assert_eq!(target.max_dimension, 896);
+        assert_eq!(target.max_bytes, 512 * 1024);
+        assert_eq!(target.min_quality, 60);
+        assert_eq!(target.max_quality, 78);
+        assert_eq!(VISION_MAX_TOKENS, 256);
+        assert_eq!(KIMICODE_VISION_MAX_TOKENS, 4096);
+        assert_eq!(VISION_CONNECT_TIMEOUT, Duration::from_secs(5));
+        assert_eq!(VISION_REQUEST_TIMEOUT, Duration::from_secs(20));
+    }
+
+    #[test]
+    fn test_qwen3_disables_thinking_without_affecting_kimi() {
+        let mut qwen_payload = serde_json::json!({ "model": "qwen3.5-plus" });
+        apply_fast_vision_options(
+            &mut qwen_payload,
+            "qwen3.5-plus",
+            "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        );
+        assert_eq!(qwen_payload["enable_thinking"], Value::Bool(false));
+
+        let mut kimi_payload = serde_json::json!({ "model": "kimi-for-coding-highspeed" });
+        apply_fast_vision_options(
+            &mut kimi_payload,
+            "kimi-for-coding-highspeed",
+            "https://api.kimi.com/coding",
+        );
+        assert!(kimi_payload.get("enable_thinking").is_none());
+        assert!(kimi_payload.get("thinking").is_none());
+
+        let mut third_party_qwen = serde_json::json!({ "model": "qwen3-vl-flash" });
+        apply_fast_vision_options(
+            &mut third_party_qwen,
+            "qwen3-vl-flash",
+            "https://example.test/v1",
+        );
+        assert!(third_party_qwen.get("enable_thinking").is_none());
+    }
+
+    #[test]
+    fn test_endpoint_normalization_does_not_duplicate_suffixes() {
+        assert_eq!(
+            normalize_endpoint("https://example.test/v1/chat/completions/"),
+            "https://example.test/v1/chat/completions"
+        );
+        assert_eq!(
+            normalize_anthropic_endpoint("https://api.kimi.com/coding/v1/messages/"),
+            "https://api.kimi.com/coding/v1/messages"
+        );
+    }
+
+    #[test]
+    fn test_anthropic_extraction_keeps_text_without_copying_thinking() {
+        let response = serde_json::json!({
+            "content": [
+                { "type": "thinking", "thinking": "先观察画面" },
+                { "type": "text", "text": "看到你在写代码。" }
+            ]
+        });
+        let (text, thinking_chars) = extract_anthropic_text(&response);
+        assert_eq!(text.as_deref(), Some("看到你在写代码。"));
+        assert_eq!(thinking_chars, "先观察画面".chars().count());
+    }
+
+    /// 冒烟测试：验证 Windows 下能成功截屏并压缩到目标大小以内。
+    /// 该测试不需要调用任何外部 API，因此可以在没有 API Key 的情况下运行。
+    #[test]
+    fn test_capture_and_compress_smoke() {
+        #[cfg(target_os = "windows")]
+        {
+            let target = CompressionTarget::default();
+            let jpeg = capture_screen_as_jpeg_with_compression(&target)
+                .expect("screen capture should succeed on Windows");
+            assert!(!jpeg.is_empty(), "captured JPEG should not be empty");
+            assert!(
+                jpeg.len() <= target.max_bytes,
+                "captured JPEG ({} bytes) should not exceed target size ({} bytes)",
+                jpeg.len(),
+                target.max_bytes
+            );
+            let decoded = image::load_from_memory(&jpeg).expect("captured JPEG should decode");
+            assert!(decoded.width().max(decoded.height()) <= target.max_dimension);
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            // 非 Windows 平台该功能直接返回 None，验证行为即可。
+            assert!(capture_screen_as_jpeg().is_none());
+        }
     }
 }

--- a/src-tauri/src/api/adventure.rs
+++ b/src-tauri/src/api/adventure.rs
@@ -194,12 +194,16 @@ pub async fn start_adventure(app: AppHandle, adventure_folder: String) -> Result
         let is_running = service.script_manager.is_running.clone();
         (script, game_status, config, is_running)
     };
+    is_running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .map_err(|_| "已有剧本正在运行，请先结束当前剧情".to_string())?;
 
     let ai_service = state.ai_service.clone();
     let channels = state.script_channels.clone();
     let db = state.db.clone();
     let data_dir = state.ai_service.lock().await.data_dir.clone();
     let llm = state.chat.llm.clone();
+    let generation_lock = state.generation_lock.clone();
     let achievement_manager = state.achievement_manager.clone();
 
     tokio::spawn(async move {
@@ -208,6 +212,7 @@ pub async fn start_adventure(app: AppHandle, adventure_folder: String) -> Result
             data_dir: &data_dir,
             app: &app,
             game_status,
+            generation_lock,
             config: &config,
             llm: llm.as_ref(),
             channels,

--- a/src-tauri/src/api/chat.rs
+++ b/src-tauri/src/api/chat.rs
@@ -44,12 +44,24 @@ pub async fn send_chat_message(
         svc.game_status.clone()
     };
 
+    // 从收到用户消息起就预留生成权；截图 VLM 期间也不能让旧的主动回复插队。
+    let generation_guard = state.generation_lock.clone().lock_owned().await;
+    if game_status.lock().await.script_status.is_some() {
+        return Err("剧情正在运行，请使用剧情输入框继续".to_string());
+    }
+
+    // 在截图分析前推进交互代次，让已经在途的旧 Screen/Topic 结果失效。
+    if let Some(proactive) = &state.proactive_system {
+        proactive.lock().await.on_user_message_received().await;
+    }
+
     let user_name = game_status.lock().await.player.user_name.clone();
 
     // 发送思考事件
-    events::emit_thinking(&app, true);
+    events::emit_thinking(&app, true, false);
 
-    // 截图分析：在创建 GeneratorDeps 之前，确保旁白台词已写入 line_list
+    // 截图分析：先异步获取旁白文本，实际写入 line_list 推迟到 generation_lock 内
+    let mut narration_opt: Option<String> = None;
     if let Some(ref b64) = screenshot_base64 {
         if let Ok(image_bytes) = base64::Engine::decode(&base64::prelude::BASE64_STANDARD, b64) {
             let prompt = format!(
@@ -63,19 +75,8 @@ pub async fn send_chat_message(
             };
 
             if let Some(narration) = analysis {
-                let mut gs = game_status.lock().await;
-                gs.add_line(
-                    &state.db,
-                    LineBase {
-                        content: PromptRole::Narrator.build_prompt(&narration),
-                        attribute: LineAttributeExt(LineAttribute::User),
-                        display_name: Some("旁白".to_string()),
-                        ..Default::default()
-                    },
-                )
-                .await
-                .map_err(|e| format!("添加旁白台词失败: {}", e))?;
-                tracing::info!("[Chat] Screenshot analysis narration added to game_status.");
+                narration_opt = Some(PromptRole::Narrator.build_prompt(&narration));
+                tracing::info!("[Chat] Screenshot analysis narration ready.");
             }
         }
     }
@@ -83,23 +84,15 @@ pub async fn send_chat_message(
     let deps = GeneratorDeps {
         app: app.clone(),
         db: state.db.clone(),
-        game_status,
+        game_status: game_status.clone(),
         processor: state.chat.processor.clone(),
         translator: state.chat.translator.clone(),
         llm,
         concurrency,
         god_agent: state.god_agent.clone(),
         suppress_thinking: false,
+        is_proactive: false,
     };
-
-    // Notify proactive system of user input
-    if let Some(proactive) = &state.proactive_system {
-        let proactive_clone = proactive.clone();
-        tokio::spawn(async move {
-            let mut sys = proactive_clone.lock().await;
-            sys.on_user_message_received().await;
-        });
-    }
 
     // 成就触发检查
     let achievement_manager = state.achievement_manager.clone();
@@ -147,10 +140,32 @@ pub async fn send_chat_message(
     });
 
     let generator = MessageGenerator::new(deps);
-    let gen_lock = state.generation_lock.clone();
+    let db_for_narration = state.db.clone();
 
     tokio::spawn(async move {
-        let _lock = gen_lock.lock().await;
+        let _generation_guard = generation_guard;
+
+        // 在 generation_lock 保护下按顺序写入旁白行，避免被主动回复插队覆盖
+        if let Some(narration) = narration_opt {
+            let mut gs = game_status.lock().await;
+            if let Err(e) = gs
+                .add_line(
+                    &db_for_narration,
+                    LineBase {
+                        content: narration,
+                        attribute: LineAttributeExt(LineAttribute::User),
+                        display_name: Some("旁白".to_string()),
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
+                tracing::error!("[Chat] 添加旁白台词失败: {}", e);
+            } else {
+                tracing::info!("[Chat] Screenshot analysis narration added to game_status.");
+            }
+        }
+
         match generator.process_message(Some(text)).await {
             Ok(acc) => tracing::info!("消息生成完成，长度: {}", acc.len()),
             Err(e) => tracing::error!("消息生成失败: {:#}", e),
@@ -158,6 +173,38 @@ pub async fn send_chat_message(
     });
 
     Ok(())
+}
+
+#[tauri::command]
+pub async fn test_screen_analyzer(
+    app: AppHandle,
+    prompt: Option<String>,
+) -> Result<String, String> {
+    let state = app.state::<AppState>();
+
+    let default_prompt = "你是一个图像信息转述者，请用200字描述你看到的桌面主要内容。".to_string();
+    let prompt = prompt.unwrap_or(default_prompt);
+
+    let mut sa = state.screen_analyzer.lock().await;
+    match sa.analyze_screen(&prompt, None).await {
+        Some(result) => {
+            let report = sa.get_report();
+            tracing::info!(
+                "[TestScreenAnalyzer] success in {:.2}s, input_tokens={:?}, output_tokens={:?}",
+                report.response_time_secs,
+                report.input_tokens,
+                report.output_tokens
+            );
+            Ok(result)
+        }
+        None => {
+            let report = sa.get_report();
+            Err(format!(
+                "视觉理解测试失败。可能原因：API Key 为空、模型不支持视觉、网络超时或 Base URL 错误。耗时 {:.2}s",
+                report.response_time_secs
+            ))
+        }
+    }
 }
 
 /// 处理以 "/" 开头的调试指令（仅在后端日志输出，不发往前端）。

--- a/src-tauri/src/api/game.rs
+++ b/src-tauri/src/api/game.rs
@@ -746,16 +746,29 @@ pub async fn remove_role_from_scene(app: AppHandle, role_id: i32) -> Result<Json
 #[tauri::command]
 pub async fn notify_player_entry(app: AppHandle) -> Result<(), String> {
     let state = app.state::<AppState>();
+    let llm = state
+        .chat
+        .llm
+        .clone()
+        .ok_or_else(|| "LLM 未配置".to_string())?;
+    let concurrency = AppConfig::load(&app)
+        .map(|c| c.consumers as usize)
+        .unwrap_or(1)
+        .max(1);
+    let game_status = {
+        let svc = state.ai_service.lock().await;
+        svc.game_status.clone()
+    };
+    // 入场旁白和对应生成必须是一个原子顺序，不能被主动回复插到中间。
+    let generation_guard = state.generation_lock.clone().lock_owned().await;
 
     // Phase 1: 去重 & 添加旁白台词
     {
-        let svc = state.ai_service.lock().await;
-        let mut gs = svc.game_status.lock().await;
+        let mut gs = game_status.lock().await;
 
         if gs.player_entered {
             return Ok(());
         }
-        gs.player_entered = true;
 
         let current_role_id = match gs.current_role_id {
             Some(id) => id,
@@ -764,6 +777,7 @@ pub async fn notify_player_entry(app: AppHandle) -> Result<(), String> {
                 return Ok(());
             }
         };
+        gs.player_entered = true;
 
         let ai_name = gs
             .role_manager
@@ -806,20 +820,6 @@ pub async fn notify_player_entry(app: AppHandle) -> Result<(), String> {
     } // 释放锁
 
     // Phase 2: 触发 AI 响应（suppress_thinking=true，不显示思考指示器）
-    let llm = state
-        .chat
-        .llm
-        .clone()
-        .ok_or_else(|| "LLM 未配置".to_string())?;
-    let concurrency = AppConfig::load(&app)
-        .map(|c| c.consumers as usize)
-        .unwrap_or(1)
-        .max(1);
-    let game_status = {
-        let svc = state.ai_service.lock().await;
-        svc.game_status.clone()
-    };
-
     let deps = GeneratorDeps {
         app: app.clone(),
         db: state.db.clone(),
@@ -830,13 +830,13 @@ pub async fn notify_player_entry(app: AppHandle) -> Result<(), String> {
         concurrency,
         god_agent: state.god_agent.clone(),
         suppress_thinking: true,
+        is_proactive: false,
     };
 
     let generator = MessageGenerator::new(deps);
-    let gen_lock = state.generation_lock.clone();
 
     tokio::spawn(async move {
-        let _lock = gen_lock.lock().await;
+        let _generation_guard = generation_guard;
         match generator.process_message(None).await {
             Ok(acc) => tracing::info!("[Entry] 入场问候生成完成，长度: {}", acc.len()),
             Err(e) => tracing::error!("[Entry] 入场问候生成失败: {:#}", e),

--- a/src-tauri/src/api/schedule.rs
+++ b/src-tauri/src/api/schedule.rs
@@ -61,21 +61,52 @@ pub async fn save_schedules(app: AppHandle, data: UserScheduleSettings) -> Resul
 
     // Reload settings in the proactive system
     if let Some(proactive) = &state.proactive_system {
-        let mut sys = proactive.lock().await;
-        sys.reload().await;
+        crate::ai_service::proactive_system::ProactiveSystem::reload(proactive.clone()).await;
     }
 
     Ok("日程设置已保存！".to_string())
 }
 
 #[tauri::command]
+pub async fn test_proactive_message(app: AppHandle) -> Result<String, String> {
+    let state = app.state::<AppState>();
+
+    if let Some(ps) = &state.proactive_system {
+        match crate::ai_service::proactive_system::ProactiveSystem::test_screen_proactive(
+            ps.clone(),
+        )
+        .await
+        {
+            Ok(Some(prompt)) => Ok(format!("已触发主动搭话: {}", prompt)),
+            Ok(None) => Ok("屏幕分析返回 [PASS]，未触发搭话".to_string()),
+            Err(e) => Err(e),
+        }
+    } else {
+        Err("主动对话系统未初始化".to_string())
+    }
+}
+
+#[tauri::command]
 pub async fn reload_proactive_system(app: AppHandle) -> Result<String, String> {
     let state = app.state::<AppState>();
+    let proactive_running = state.proactive_system.is_some();
+
+    // 先应用主动系统的开关/闸门；即便视觉请求仍在收尾，在途结果也会按新配置复核。
     if let Some(proactive) = &state.proactive_system {
-        let mut sys = proactive.lock().await;
-        sys.reload().await;
+        crate::ai_service::proactive_system::ProactiveSystem::reload(proactive.clone()).await;
+    }
+
+    // 无论主动系统是否已启动，都刷新共享屏幕分析器，让“看桌面”等路径使用最新设置。
+    let pconfig = crate::config::proactive::ProactiveConfig::load(&app);
+    let sa_config =
+        crate::ai_service::screen_analyzer::build_screen_analyzer_config(&app, &pconfig);
+    let mut sa = state.screen_analyzer.lock().await;
+    sa.update_config(sa_config);
+    drop(sa);
+
+    if proactive_running {
         Ok("主动对话系统配置已重载！".to_string())
     } else {
-        Err("主动对话系统未运行！".to_string())
+        Ok("设置已保存，主动对话系统当前未运行，将在启动后自动生效。".to_string())
     }
 }

--- a/src-tauri/src/api/script.rs
+++ b/src-tauri/src/api/script.rs
@@ -7,6 +7,7 @@ use crate::ai_service::game_system::script_engine::events::ScriptContext;
 use crate::ai_service::game_system::script_engine::ScriptManager;
 use crate::AppState;
 use serde::Serialize;
+use std::sync::atomic::Ordering;
 use tauri::{AppHandle, Manager};
 
 // ============================================================
@@ -81,6 +82,7 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
     let db = state.db.clone();
     let data_dir = state.ai_service.lock().await.data_dir.clone();
     let llm = state.chat.llm.clone();
+    let generation_lock = state.generation_lock.clone();
     let achievement_manager = state.achievement_manager.clone();
 
     // Lock AIService briefly to validate and extract needed data
@@ -97,6 +99,9 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
         let is_running = service.script_manager.is_running.clone();
         (script, game_status, config, is_running)
     };
+    is_running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .map_err(|_| "已有剧本正在运行，请先结束当前剧情".to_string())?;
 
     // Run script in background task (does NOT hold AIService lock across awaits)
     tokio::spawn(async move {
@@ -105,6 +110,7 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
             data_dir: &data_dir,
             app: &app,
             game_status,
+            generation_lock,
             config: &config,
             llm: llm.as_ref(),
             channels,

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -642,6 +642,24 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         description: "MAX_PROACTIVE_TIMES — 在用户响应之前，能主动对话的次数".to_string(),
                         setting_type: "text".to_string(),
                     },
+                    ConfigSetting {
+                        key: proactive::keys::PROACTIVE_INTERVAL_SECS.to_string(),
+                        value: read_setting(app, proactive::keys::PROACTIVE_INTERVAL_SECS, "10"),
+                        description: "PROACTIVE_INTERVAL_SECS — 主动对话轮询间隔（秒，默认 10，最小 2）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::INTEREST_TRIGGER_THRESHOLD.to_string(),
+                        value: read_setting(app, proactive::keys::INTEREST_TRIGGER_THRESHOLD, "30.0"),
+                        description: "INTEREST_TRIGGER_THRESHOLD — 兴趣度触发阈值（默认 30，越低越容易被触发）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::INTEREST_DECAY_STEP.to_string(),
+                        value: read_setting(app, proactive::keys::INTEREST_DECAY_STEP, "15.0"),
+                        description: "INTEREST_DECAY_STEP — 每次主动对话后兴趣度上限衰减量（默认 15，设为 0 则不衰减）".to_string(),
+                        setting_type: "text".to_string(),
+                    },
                 ],
             },
         );
@@ -652,6 +670,12 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
             Subcategory {
                 description: "主动对话时调用的 Vision LLM 视觉分析模型以及截图分析设置".to_string(),
                 settings: vec![
+                    ConfigSetting {
+                        key: proactive::keys::VD_FOLLOW_CHAT_MODEL.to_string(),
+                        value: read_setting(app, proactive::keys::VD_FOLLOW_CHAT_MODEL, "true"),
+                        description: "VD_FOLLOW_CHAT_MODEL — 跟随当前对话模型；若当前是不可关闭长思考的模型，视觉识别也会明显变慢。低延迟建议关闭并配置独立轻量视觉模型".to_string(),
+                        setting_type: "bool".to_string(),
+                    },
                     ConfigSetting {
                         key: proactive::keys::VD_API_KEY.to_string(),
                         value: read_setting(app, proactive::keys::VD_API_KEY, ""),
@@ -670,8 +694,10 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                     },
                     ConfigSetting {
                         key: proactive::keys::VD_MODEL.to_string(),
-                        value: read_setting(app, proactive::keys::VD_MODEL, "qwen3.5-plus"),
-                        description: "VD_MODEL — 视觉模型型号".to_string(),
+                        value: read_setting(app, proactive::keys::VD_MODEL, "qwen3-vl-flash"),
+                        description:
+                            "VD_MODEL — 独立视觉模型型号（低延迟推荐非思考型 VL/Flash，例如 qwen3-vl-flash）"
+                                .to_string(),
                         setting_type: "text".to_string(),
                     },
                     ConfigSetting {
@@ -689,6 +715,14 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             "SCREEN_WEIGHT — 视觉模式触发权重（越大越容易偷看屏幕聊天，默认 30）"
                                 .to_string(),
                         setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: proactive::keys::VISUAL_PERCEPTION_PRIORITY.to_string(),
+                        value: read_setting(app, proactive::keys::VISUAL_PERCEPTION_PRIORITY, "false"),
+                        description:
+                            "VISUAL_PERCEPTION_PRIORITY — 视觉理解优先模式（开启后每次主动回复优先看屏幕，失败才找话题）"
+                                .to_string(),
+                        setting_type: "bool".to_string(),
                     },
                 ],
             },

--- a/src-tauri/src/config/proactive.rs
+++ b/src-tauri/src/config/proactive.rs
@@ -5,11 +5,16 @@ use tauri_plugin_store::StoreExt;
 pub mod keys {
     pub const ENABLE_PROACTIVE_SYSTEM: &str = "ENABLE_PROACTIVE_SYSTEM";
     pub const MAX_PROACTIVE_TIMES: &str = "MAX_PROACTIVE_TIMES";
+    pub const PROACTIVE_INTERVAL_SECS: &str = "PROACTIVE_INTERVAL_SECS";
+    pub const INTEREST_TRIGGER_THRESHOLD: &str = "INTEREST_TRIGGER_THRESHOLD";
+    pub const INTEREST_DECAY_STEP: &str = "INTEREST_DECAY_STEP";
+    pub const VD_FOLLOW_CHAT_MODEL: &str = "VD_FOLLOW_CHAT_MODEL";
     pub const VD_API_KEY: &str = "VD_API_KEY";
     pub const VD_BASE_URL: &str = "VD_BASE_URL";
     pub const VD_MODEL: &str = "VD_MODEL";
     pub const ENABLE_VISUAL_PRECEPTION: &str = "ENABLE_VISUAL_PRECEPTION";
     pub const SCREEN_WEIGHT: &str = "SCREEN_WEIGHT";
+    pub const VISUAL_PERCEPTION_PRIORITY: &str = "VISUAL_PERCEPTION_PRIORITY";
     pub const ENABLE_TOPIC_CREATER: &str = "ENABLE_TOPIC_CREATER";
     pub const TOPIC_WEIGHT: &str = "TOPIC_WEIGHT";
     pub const ENABLE_TODO_PRECEPTION: &str = "ENABLE_TODO_PRECEPTION";
@@ -22,11 +27,16 @@ pub mod keys {
 pub struct ProactiveConfig {
     pub enable_proactive_system: bool,
     pub max_proactive_times: i32,
+    pub proactive_interval_secs: u64,
+    pub interest_trigger_threshold: f64,
+    pub interest_decay_step: f64,
+    pub vd_follow_chat_model: bool,
     pub vd_api_key: String,
     pub vd_base_url: String,
     pub vd_model: String,
     pub enable_visual_perception: bool,
     pub screen_weight: f64,
+    pub visual_perception_priority: bool,
     pub enable_topic_creator: bool,
     pub topic_weight: f64,
     pub enable_todo_perception: bool,
@@ -86,21 +96,46 @@ impl ProactiveConfig {
                 .unwrap_or(default)
         };
 
+        let get_bounded_f64 = |key: &str, default: f64, min: f64, max: f64| -> f64 {
+            let value = get_f64(key, default);
+            if value.is_finite() {
+                value.clamp(min, max)
+            } else {
+                tracing::warn!(
+                    "[ProactiveConfig] {} is not finite, falling back to {}",
+                    key,
+                    default
+                );
+                default
+            }
+        };
+
         Self {
             enable_proactive_system: get_bool(keys::ENABLE_PROACTIVE_SYSTEM, false),
-            max_proactive_times: get_i32(keys::MAX_PROACTIVE_TIMES, 3),
+            max_proactive_times: get_i32(keys::MAX_PROACTIVE_TIMES, 3).clamp(0, 1_000),
+            proactive_interval_secs: get_i32(keys::PROACTIVE_INTERVAL_SECS, 10).clamp(2, 3_600)
+                as u64,
+            interest_trigger_threshold: get_bounded_f64(
+                keys::INTEREST_TRIGGER_THRESHOLD,
+                30.0,
+                0.0,
+                95.0,
+            ),
+            interest_decay_step: get_bounded_f64(keys::INTEREST_DECAY_STEP, 15.0, 0.0, 100.0),
+            vd_follow_chat_model: get_bool(keys::VD_FOLLOW_CHAT_MODEL, true),
             vd_api_key: get_string(keys::VD_API_KEY, ""),
             vd_base_url: get_string(
                 keys::VD_BASE_URL,
                 "https://dashscope.aliyuncs.com/compatible-mode/v1",
             ),
-            vd_model: get_string(keys::VD_MODEL, "qwen3.5-plus"),
+            vd_model: get_string(keys::VD_MODEL, "qwen3-vl-flash"),
             enable_visual_perception: get_bool(keys::ENABLE_VISUAL_PRECEPTION, true),
-            screen_weight: get_f64(keys::SCREEN_WEIGHT, 30.0),
+            screen_weight: get_bounded_f64(keys::SCREEN_WEIGHT, 30.0, 0.0, 10_000.0),
+            visual_perception_priority: get_bool(keys::VISUAL_PERCEPTION_PRIORITY, false),
             enable_topic_creator: get_bool(keys::ENABLE_TOPIC_CREATER, true),
-            topic_weight: get_f64(keys::TOPIC_WEIGHT, 60.0),
+            topic_weight: get_bounded_f64(keys::TOPIC_WEIGHT, 60.0, 0.0, 10_000.0),
             enable_todo_perception: get_bool(keys::ENABLE_TODO_PRECEPTION, true),
-            todo_weight: get_f64(keys::TODO_WEIGHT, 10.0),
+            todo_weight: get_bounded_f64(keys::TODO_WEIGHT, 10.0, 0.0, 10_000.0),
             enable_schedule_reminder: get_bool(keys::ENABLE_SCHEDULE_REMINDER, true),
             enable_important_day_reminder: get_bool(keys::ENABLE_IMPORTANT_DAY_REMINDER, true),
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,7 +25,7 @@ use ai_service::god_agent::config::resolve_god_agent_provider;
 use ai_service::god_agent::GodAgentCore;
 use ai_service::llm::LlmClient;
 use ai_service::message_system::processor::MessageProcessor;
-use ai_service::screen_analyzer::{ScreenAnalyzer, ScreenAnalyzerConfig};
+use ai_service::screen_analyzer::{ScreenAnalyzer, build_screen_analyzer_config};
 use ai_service::service::SharedAIService;
 use ai_service::translator::Translator;
 
@@ -158,12 +158,8 @@ pub fn run() {
             ));
 
             let screen_analyzer = {
-                let pconfig = config::proactive::ProactiveConfig::load(&app.handle());
-                let sa_config = ScreenAnalyzerConfig {
-                    vd_api_key: pconfig.vd_api_key,
-                    vd_base_url: pconfig.vd_base_url,
-                    vd_model: pconfig.vd_model,
-                };
+                let pconfig = config::proactive::ProactiveConfig::load(app.handle());
+                let sa_config = build_screen_analyzer_config(app.handle(), &pconfig);
                 std::sync::Arc::new(tokio::sync::Mutex::new(ScreenAnalyzer::new(sa_config)))
             };
 
@@ -343,6 +339,7 @@ pub fn run() {
             api::game::notify_player_entry,
             api::chat::send_chat_message,
             api::chat::rollback_conversation,
+            api::chat::test_screen_analyzer,
             api::screenshot::start_screenshot,
             api::screenshot::get_overlay_data,
             api::screenshot::confirm_screenshot,
@@ -365,6 +362,7 @@ pub fn run() {
             api::schedule::get_schedules,
             api::schedule::save_schedules,
             api::schedule::reload_proactive_system,
+            api::schedule::test_proactive_message,
             api::proactive_set_can_deliver,
             api::achievement::get_achievement_list,
             api::achievement::unlock_achievement,

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,8 +24,10 @@ import { useSedentaryReminder } from './composables/useSedentaryReminder'
 import { useUpdater } from './composables/useUpdater'
 import { useCanDeliver } from './composables/useCanDeliver'
 
-// 激活主动对话投放条件上报（仅在此处挂载一次）
-useCanDeliver()
+// 只有主窗口能作为主动回复投放闸门；设置/截图等辅助 WebView 不能覆盖主窗口状态。
+if (getCurrentWindow().label === 'main') {
+  useCanDeliver()
+}
 
 // ─── 久坐提醒 ────────────────────────────────────────────────
 useSedentaryReminder()

--- a/src/api/services/schedule.ts
+++ b/src/api/services/schedule.ts
@@ -34,3 +34,13 @@ export const reloadProactiveSystem = async (): Promise<void> => {
     throw error
   }
 }
+
+export const testProactiveMessage = async (): Promise<string> => {
+  try {
+    const result = await invoke<string>('test_proactive_message')
+    return result
+  } catch (error: any) {
+    console.error('测试主动消息错误:', error.message)
+    throw error
+  }
+}

--- a/src/api/tauri-events.ts
+++ b/src/api/tauri-events.ts
@@ -18,7 +18,14 @@ export function initializeTauriEventListeners() {
 
   listen('ai:thinking', (event) => {
     console.log('[Tauri] ai:thinking', event.payload)
-    eventQueue.addEvent(asEvent(event.payload, { type: 'thinking', duration: 0 }))
+    const payload = event.payload as { isThinking?: boolean; isProactive?: boolean }
+    eventQueue.addEvent(
+      asEvent(event.payload, {
+        type: 'thinking',
+        duration: 0,
+        isProactive: Boolean(payload.isProactive),
+      }),
+    )
   })
 
   listen('ai:thinking_progress', (event) => {
@@ -27,6 +34,16 @@ export function initializeTauriEventListeners() {
     const gameStore = useGameStore()
     if (typeof payload.thinkingLength === 'number') {
       gameStore.thinkingLength = payload.thinkingLength
+    }
+  })
+
+  listen('ai:proactive_thinking', (event) => {
+    const payload = event.payload as { isThinking?: boolean }
+    console.log('[Tauri] ai:proactive_thinking', payload)
+    const gameStore = useGameStore()
+    gameStore.isProactiveThinking = Boolean(payload.isThinking)
+    if (!payload.isThinking) {
+      gameStore.thinkingLength = 0
     }
   })
 

--- a/src/components/game/standard/GameDialog.vue
+++ b/src/components/game/standard/GameDialog.vue
@@ -21,22 +21,24 @@
           </div>
           <div
             v-show="!uiStore.isNarrowScreen"
-            class="text-xl font-bold text-[#6eb4ff] font-[inherit] text-shadow-[inherit]"
+            class="text-xl font-bold text-[#6eb4ff] font-[inherit] text-shadow-[inherit] mr-3.75"
           >
             <div id="character-sub">{{ uiStore.showCharacterSubtitle }}</div>
           </div>
 
-          <!-- 右侧区域：情绪标签 + 操作按钮组（窄屏时占据剩余全部宽度，优先显示） -->
+          <!-- 情绪标签，放在名称与操作按钮组之间 -->
+          <div
+            v-show="!uiStore.isNarrowScreen"
+            class="text-xl font-bold text-[#ff77dd] font-[inherit] text-shadow-[inherit] shrink-0"
+          >
+            <div id="character-emotion">{{ uiStore.showCharacterEmotion }}</div>
+          </div>
+
+          <!-- 右侧区域：操作按钮组（窄屏时占据剩余全部宽度，优先显示） -->
           <div
             class="flex items-baseline ml-auto min-w-0"
             :class="{ 'flex-1 shrink-0': uiStore.isNarrowScreen }"
           >
-            <div
-              class="text-xl font-bold text-[#ff77dd] font-[inherit] text-shadow-[inherit] shrink-0"
-            >
-              <div id="character-emotion">{{ uiStore.showCharacterEmotion }}</div>
-            </div>
-
             <!-- 操作按钮组（窄屏时占据右侧容器剩余空间，可横向滚动） -->
             <div
               class="overflow-x-auto custom-scroll"
@@ -291,17 +293,42 @@ const placeholderText = computed(() => {
   switch (gameStore.currentStatus) {
     case 'input':
       return uiStore.showPlayerHintLine || '在这里输入消息...'
-    case 'thinking':
+    case 'thinking': {
+      const len = gameStore.thinkingLength
+      if (gameStore.isProactiveThinking) {
+        if (len > 0) {
+          const stageHint =
+            len < 300
+              ? '正在观察屏幕'
+              : len < 1000
+                ? '正在组织语言'
+                : len < 2500
+                  ? '正在检查细节'
+                  : '正在深入构思'
+          return `主动回复中（${stageHint}，已思考 ${len} 字）`
+        }
+        return '主动回复中...'
+      }
+
       const currentInteractRole = gameStore.currentInteractRole
       if (currentInteractRole) {
         const baseMessage = currentInteractRole.thinkMessage
-        if (gameStore.thinkingLength > 0) {
-          return `${baseMessage}（已深度思考 ${gameStore.thinkingLength} 字）`
+        if (len > 0) {
+          const stageHint =
+            len < 300
+              ? '正在理解主人的话'
+              : len < 1000
+                ? '正在组织语言'
+                : len < 2500
+                  ? '正在检查细节'
+                  : '正在深入构思'
+          return `${baseMessage}（${stageHint}，已思考 ${len} 字）`
         }
         return baseMessage
       } else {
         return '等待回应中...'
       }
+    }
     case 'responding':
     case 'presenting':
       return ''

--- a/src/components/pet/ChatInput.vue
+++ b/src/components/pet/ChatInput.vue
@@ -61,17 +61,43 @@ const placeholderText = computed(() => {
   switch (gameStore.currentStatus) {
     case 'input':
       return uiStore.showPlayerHintLine || '输入消息...'
-    case 'thinking':
+    case 'thinking': {
+      const len = gameStore.thinkingLength
+      if (gameStore.isProactiveThinking) {
+        if (len > 0) {
+          const stageHint =
+            len < 300
+              ? '正在观察屏幕'
+              : len < 1000
+                ? '正在组织语言'
+                : len < 2500
+                  ? '正在检查细节'
+                  : '正在深入构思'
+          return `主动回复中（${stageHint}，已思考 ${len} 字）`
+        }
+        return '主动回复中...'
+      }
+
       const currentInteractRole = gameStore.currentInteractRole
       if (currentInteractRole) {
         const baseMessage = currentInteractRole.thinkMessage
-        if (gameStore.thinkingLength > 0) {
-          return `${baseMessage}（已深度思考 ${gameStore.thinkingLength} 字）`
+        if (len > 0) {
+          // 根据思考字数给出更生动的阶段提示
+          const stageHint =
+            len < 300
+              ? '正在理解主人的话'
+              : len < 1000
+                ? '正在组织语言'
+                : len < 2500
+                  ? '正在检查细节'
+                  : '正在深入构思'
+          return `${baseMessage}（${stageHint}，已思考 ${len} 字）`
         }
         return baseMessage
       } else {
         return '等待回应中...'
       }
+    }
     case 'responding':
       return '聊天ing~'
     case 'presenting':

--- a/src/components/schedule/pages/ProactivePage.vue
+++ b/src/components/schedule/pages/ProactivePage.vue
@@ -4,86 +4,239 @@
     v-if="uiStore.scheduleView === 'proactive_settings'"
     class="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-1 p-1"
   >
-    <div v-for="setting in settings" :key="setting.key" class="mb-6">
-      <!-- 使用 SettingItem 组件渲染不同类型的输入控件 -->
-      <SettingItem :setting="setting" @update:value="(value) => (setting.value = value)" />
+    <div v-if="settings['ENABLE_PROACTIVE_SYSTEM']" class="mb-5">
+      <SettingItem
+        :setting="settings['ENABLE_PROACTIVE_SYSTEM']"
+        @update:value="(value) => (settings['ENABLE_PROACTIVE_SYSTEM'].value = value)"
+      />
     </div>
 
-    <div class="flex gap-2 align-text-bottom w-auto h-auto items-center">
-      <div
-        class="w-18 px-5 py-2.5 bg-brand text-white border-none rounded-lg cursor-pointer text-sm font-medium transition-colors duration-200 hover:bg-[#0056b3]"
-      >
-        <button @click="saveSettings">保存</button>
+    <div class="grid grid-cols-1 gap-x-8 gap-y-5 md:grid-cols-2 mb-5">
+      <template v-for="key in performanceSettingKeys" :key="key">
+        <div v-if="settings[key]" class="min-w-0">
+          <SettingItem
+            :setting="settings[key]"
+            @update:value="(value) => (settings[key].value = value)"
+          />
+        </div>
+      </template>
+    </div>
+
+    <p v-if="configLoading" class="mb-4 text-sm text-white/65">正在加载主动对话配置...</p>
+
+    <div class="flex flex-col gap-3">
+      <p class="max-w-[72ch] text-xs leading-5 text-amber-200/80">
+        速度提示：跟随开启思考的聊天模型会更慢；追求响应速度时，可关闭“跟随当前对话模型”，并在「更多设置」中配置独立的轻量视觉模型。
+      </p>
+
+      <div class="flex flex-wrap gap-3 align-text-bottom w-auto h-auto items-center">
+        <button
+          class="px-5 py-2.5 bg-brand text-white border-none rounded-lg cursor-pointer text-sm font-medium transition-colors duration-200 hover:bg-[#0056b3] disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="saving || testStatus.loading || configLoading"
+          @click="saveSettings"
+        >
+          {{ saving ? '保存并应用中...' : '保存并应用' }}
+        </button>
+        <button
+          class="px-5 py-2.5 bg-[#6366f1] text-white border-none rounded-lg cursor-pointer text-sm font-medium transition-colors duration-200 hover:bg-[#4f46e5] disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="testStatus.loading || saving || configLoading"
+          @click="handleTestProactive"
+        >
+          {{
+            testStatus.loading
+              ? `测试中 ${testStatus.elapsedSeconds.toFixed(1)}s`
+              : '测试主动消息'
+          }}
+        </button>
+        <button
+          class="px-5 py-2.5 bg-slate-600 text-white border-none rounded-lg cursor-pointer text-sm font-medium transition-colors duration-200 hover:bg-slate-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="saving || testStatus.loading"
+          @click="openAdvancedSettings"
+        >
+          更多设置
+        </button>
       </div>
-      <p :style="{ color: saveStatus.color }">
+
+      <p v-if="testStatus.loading" class="text-sm text-indigo-200">
+        阶段：{{ testStatus.stage }}，已耗时 {{ testStatus.elapsedSeconds.toFixed(1) }} 秒
+      </p>
+      <p v-if="saveStatus.message" :style="{ color: saveStatus.color }" class="text-sm">
         {{ saveStatus.message }}
+      </p>
+      <p v-if="testStatus.message" :style="{ color: testStatus.color }" class="text-sm">
+        {{ testStatus.message }}
+      </p>
+      <p class="text-xs text-white/60">
+        更多主动对话参数（视觉模型、兴趣度阈值、话题权重等）请前往「更多设置」调整。
       </p>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, reactive } from 'vue'
+import { ref, onMounted, onUnmounted, reactive } from 'vue'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import { getEnvConfigByKey, saveEnvConfigSettings } from '@/api/services/config'
-import { reloadProactiveSystem } from '@/api/services/schedule'
+import { reloadProactiveSystem, testProactiveMessage } from '@/api/services/schedule'
 import type { ConfigItem } from '@/api/services/config'
 import SettingItem from '@/components/base/items/SettingItem.vue'
 const uiStore = useUIStore()
 const settings = ref<Record<string, ConfigItem>>({})
+const SUCCESS_COLOR = '#4ade80'
+const ERROR_COLOR = '#ef4444'
+const quickSettingKeys = [
+  'ENABLE_PROACTIVE_SYSTEM',
+  'PROACTIVE_INTERVAL_SECS',
+  'VD_FOLLOW_CHAT_MODEL',
+  'VISUAL_PERCEPTION_PRIORITY',
+  'SCREEN_WEIGHT',
+] as const
+const performanceSettingKeys = quickSettingKeys.slice(1)
+const saving = ref(false)
+const configLoading = ref(false)
+let saveStatusTimer: number | null = null
+let testStatusTimer: number | null = null
+let testProgressTimer: number | null = null
+
 const saveStatus = reactive({
   message: '',
-  color: 'var(--success-color)',
+  color: SUCCESS_COLOR,
 })
 
-const saveSettings = async () => {
-  // 将 settings 转换为 Record<string, string> 格式
+const testStatus = reactive({
+  message: '',
+  color: SUCCESS_COLOR,
+  loading: false,
+  stage: '',
+  elapsedSeconds: 0,
+})
+
+const errorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error || '未知错误')
+
+const clearSaveStatusLater = () => {
+  if (saveStatusTimer !== null) window.clearTimeout(saveStatusTimer)
+  saveStatusTimer = window.setTimeout(() => {
+    saveStatus.message = ''
+    saveStatusTimer = null
+  }, 8000)
+}
+
+const persistAndReloadSettings = async () => {
   const formData: Record<string, string> = {}
   Object.entries(settings.value).forEach(([key, config]) => {
     formData[key] = config.value
   })
 
-  saveStatus.message = ''
+  await saveEnvConfigSettings(formData)
 
   try {
-    saveStatus.message = (await saveEnvConfigSettings(formData)).message
-    saveStatus.color = 'var(--success-color)'
-    reloadProactiveSystem()
+    await reloadProactiveSystem()
+  } catch (error) {
+    throw new Error(`配置已保存，但主动对话系统重载失败，当前运行实例尚未应用：${errorMessage(error)}`)
+  }
 
-    await loadConfig()
-  } catch (error: any) {
-    saveStatus.message = `错误: ${error.message}`
-    saveStatus.color = 'red'
+  await loadConfig()
+}
+
+const saveSettings = async () => {
+  if (saving.value || testStatus.loading) return
+
+  saving.value = true
+  saveStatus.message = '正在保存并重载主动对话系统...'
+  saveStatus.color = '#a5b4fc'
+
+  try {
+    await persistAndReloadSettings()
+    saveStatus.message = '配置已保存，主动对话系统已应用最新设置'
+    saveStatus.color = SUCCESS_COLOR
+  } catch (error) {
+    saveStatus.message = `应用失败：${errorMessage(error)}`
+    saveStatus.color = ERROR_COLOR
   } finally {
-    setTimeout(() => {
-      saveStatus.message = ''
-    }, 5000)
+    saving.value = false
+    clearSaveStatusLater()
   }
 }
 
-const loadConfig = async () => {
-  const configKeys = [
-    'ENABLE_PROACTIVE_SYSTEM',
-    'MAX_PROACTIVE_TIMES',
-    'VD_API_KEY',
-    'VD_BASE_URL',
-    'VD_MODEL',
-    'ENABLE_VISUAL_PRECEPTION',
-    'SCREEN_WEIGHT',
-    'ENABLE_TOPIC_CREATER',
-    'TOPIC_WEIGHT',
-    'ENABLE_TODO_PRECEPTION',
-    'TODO_WEIGHT',
-    'ENABLE_SCHEDULE_REMINDER',
-    'ENABLE_IMPORTANT_DAY_REMINDER',
-  ]
+const openAdvancedSettings = () => {
+  // 打开高级设置并直接切换到"其他高级设置"页签，方便用户找到主动对话配置
+  uiStore.setAdvanceInitialTab('other')
+  uiStore.setSettingsTab('advance')
+  uiStore.toggleSettings(true)
+}
 
-  for (const key of configKeys) {
-    settings.value[key] = await getEnvConfigByKey(key)
+const loadConfig = async () => {
+  configLoading.value = true
+  try {
+    const entries = await Promise.all(
+      quickSettingKeys.map(async (key) => [key, await getEnvConfigByKey(key)] as const),
+    )
+    settings.value = Object.fromEntries(entries)
+  } finally {
+    configLoading.value = false
+  }
+}
+
+const handleTestProactive = async () => {
+  if (testStatus.loading || saving.value) return
+
+  testStatus.loading = true
+  testStatus.message = ''
+  testStatus.color = SUCCESS_COLOR
+  testStatus.stage = '正在应用当前页面的设置'
+  testStatus.elapsedSeconds = 0
+
+  if (testStatusTimer !== null) {
+    window.clearTimeout(testStatusTimer)
+    testStatusTimer = null
+  }
+
+  const startedAt = performance.now()
+  const updateElapsed = () => {
+    testStatus.elapsedSeconds = (performance.now() - startedAt) / 1000
+  }
+  testProgressTimer = window.setInterval(updateElapsed, 100)
+
+  try {
+    await persistAndReloadSettings()
+    testStatus.stage = '完整链路处理中（截图 → 视觉识别 → 回复生成）'
+    const result = await testProactiveMessage()
+    updateElapsed()
+    testStatus.stage = '测试完成'
+    testStatus.message = `${result}（总耗时 ${testStatus.elapsedSeconds.toFixed(1)} 秒）`
+    testStatus.color = SUCCESS_COLOR
+  } catch (error) {
+    updateElapsed()
+    testStatus.stage = '测试失败'
+    testStatus.message = `测试失败（${testStatus.elapsedSeconds.toFixed(1)} 秒）：${errorMessage(error)}`
+    testStatus.color = ERROR_COLOR
+  } finally {
+    if (testProgressTimer !== null) {
+      window.clearInterval(testProgressTimer)
+      testProgressTimer = null
+    }
+    testStatus.loading = false
+    testStatusTimer = window.setTimeout(() => {
+      testStatus.message = ''
+      testStatus.stage = ''
+      testStatusTimer = null
+    }, 12000)
   }
 }
 
 onMounted(async () => {
-  loadConfig()
+  try {
+    await loadConfig()
+  } catch (error) {
+    saveStatus.message = `加载主动对话配置失败：${errorMessage(error)}`
+    saveStatus.color = ERROR_COLOR
+  }
+})
+
+onUnmounted(() => {
+  if (saveStatusTimer !== null) window.clearTimeout(saveStatusTimer)
+  if (testStatusTimer !== null) window.clearTimeout(testStatusTimer)
+  if (testProgressTimer !== null) window.clearInterval(testProgressTimer)
 })
 </script>

--- a/src/components/settings/pages/SettingsAdvance.vue
+++ b/src/components/settings/pages/SettingsAdvance.vue
@@ -54,13 +54,31 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
+import { useUIStore } from '@/stores/modules/ui/ui'
 import { MenuPage } from '../../ui'
 import SettingsLlmProviders from './SettingsLlmProviders.vue'
 import SettingsAdvanceMenu from './SettingsAdvanceMenu.vue'
 import SettingsAdvanceOther from './SettingsAdvanceOther.vue'
 
-const advanceTab = ref<'menu' | 'llm' | 'other'>('menu')
+const uiStore = useUIStore()
+
+const advanceTab = ref<'menu' | 'llm' | 'other'>(uiStore.advanceInitialTab)
+
+// 当通过外部入口（如日程弹窗的"更多设置"）指定了初始页签时，
+// 打开高级设置后自动切到对应页签，并重置状态避免影响后续操作。
+watch(
+  () => uiStore.advanceInitialTab,
+  (newTab) => {
+    // `menu` is the consumed/default state.  Ignore the reset notification so
+    // it does not immediately overwrite an externally requested destination.
+    if (newTab === 'menu') return
+
+    advanceTab.value = newTab
+    uiStore.advanceInitialTab = 'menu'
+  },
+  { immediate: true },
+)
 
 const advanceOtherRef = ref<InstanceType<typeof SettingsAdvanceOther> | null>(null)
 

--- a/src/components/settings/pages/SettingsAdvanceOther.vue
+++ b/src/components/settings/pages/SettingsAdvanceOther.vue
@@ -82,7 +82,7 @@
 
           <form @submit.prevent="saveSettings">
             <div
-              v-for="setting in selectedSubcategory.settings"
+              v-for="setting in visibleSettings"
               :key="setting.key"
               class="mb-6"
             >
@@ -129,6 +129,7 @@ import { ref, onMounted, computed, reactive, watch, nextTick } from 'vue'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import SettingItem from '@/components/base/items/SettingItem.vue'
 import { getEnvConfigSettings, saveEnvConfigSettings } from '@/api/services/config'
+import { reloadProactiveSystem } from '@/api/services/schedule'
 
 // --- 响应式状态定义 ---
 const uiStore = useUIStore()
@@ -160,6 +161,18 @@ const selectedSubcategory = computed(() => {
   return null
 })
 
+const hiddenKeysWhenFollowing = ['VD_API_KEY', 'VD_BASE_URL', 'VD_MODEL']
+const visibleSettings = computed(() => {
+  if (!selectedSubcategory.value) return []
+  const settings = selectedSubcategory.value.settings
+  const followSetting = settings.find((s: any) => s.key === 'VD_FOLLOW_CHAT_MODEL')
+  const followChatModel = followSetting?.value?.toLowerCase() === 'true'
+  return settings.filter((s: any) => {
+    if (!followChatModel) return true
+    return !hiddenKeysWhenFollowing.includes(s.key)
+  })
+})
+
 // --- 方法定义 ---
 
 const isActive = (category: string, subcategory: string) => {
@@ -187,12 +200,22 @@ const saveSettings = async () => {
   saveStatus.message = ''
 
   try {
-    saveStatus.message = (await saveEnvConfigSettings(formData)).message
+    const saveResult = await saveEnvConfigSettings(formData)
+
+    try {
+      await reloadProactiveSystem()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error || '未知错误')
+      throw new Error(`配置已保存，但主动对话系统重载失败，当前运行实例尚未应用：${message}`)
+    }
+
+    saveStatus.message = `${saveResult.message} 主动对话系统已重载。`
     saveStatus.colorClass = 'text-green-500'
 
     await loadConfig(false)
-  } catch (error: any) {
-    saveStatus.message = `错误: ${error.message}`
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error || '未知错误')
+    saveStatus.message = `错误: ${message}`
     saveStatus.colorClass = 'text-red-500'
   } finally {
     isLoading.value = false

--- a/src/components/settings_pet/components/tabs/WindowTab.vue
+++ b/src/components/settings_pet/components/tabs/WindowTab.vue
@@ -30,7 +30,7 @@
     <div class="flex flex-col pb-4 flex-1 gap-3">
       <!-- 渲染设置项卡片 (复刻原图 1、2 号卡片风格) -->
       <SettingItem
-        v-for="setting in settings"
+        v-for="setting in visibleSettings"
         :key="setting.key"
         :setting="setting"
         :is-dark-mode="isDarkMode"
@@ -95,7 +95,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, reactive } from "vue";
+import { ref, onMounted, reactive, computed } from "vue";
 import { Save } from "lucide-vue-next";
 import {
   getEnvConfigByKey,
@@ -110,6 +110,16 @@ defineProps<{
 }>();
 
 const settings = ref<Record<string, ConfigItem>>({});
+const hiddenKeysWhenFollowing = ['VD_API_KEY', 'VD_BASE_URL', 'VD_MODEL']
+const visibleSettings = computed(() => {
+  const followChatModel = settings.value['VD_FOLLOW_CHAT_MODEL']?.value?.toLowerCase() === 'true'
+  return Object.values(settings.value).filter((s) => {
+    // VD_FOLLOW_CHAT_MODEL 在日程弹窗的主动对话设置中显示，此处仅用于控制隐藏
+    if (s.key === 'VD_FOLLOW_CHAT_MODEL') return false
+    if (!followChatModel) return true
+    return !hiddenKeysWhenFollowing.includes(s.key)
+  })
+})
 const saveStatus = reactive({
   message: "",
   color: "#10b981", // 成功颜色
@@ -125,12 +135,21 @@ const saveSettings = async () => {
   saveStatus.color = "#6366f1"; // 靛蓝色提示
 
   try {
-    saveStatus.message = (await saveEnvConfigSettings(formData)).message;
+    const saveResult = await saveEnvConfigSettings(formData);
+
+    try {
+      await reloadProactiveSystem();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error || "未知错误");
+      throw new Error(`配置已保存，但主动对话系统重载失败，当前运行实例尚未应用：${message}`);
+    }
+
+    saveStatus.message = `${saveResult.message} 主动对话系统已重载。`;
     saveStatus.color = "#10b981";
-    reloadProactiveSystem();
     await loadConfig();
-  } catch (error: any) {
-    saveStatus.message = `错误: ${error.message}`;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error || "未知错误");
+    saveStatus.message = `错误: ${message}`;
     saveStatus.color = "#ef4444";
   } finally {
     setTimeout(() => {
@@ -141,13 +160,13 @@ const saveSettings = async () => {
 
 const loadConfig = async () => {
   const configKeys = [
-    'ENABLE_PROACTIVE_SYSTEM',
-    'MAX_PROACTIVE_TIMES',
+    'VD_FOLLOW_CHAT_MODEL',
     'VD_API_KEY',
     'VD_BASE_URL',
     'VD_MODEL',
     'ENABLE_VISUAL_PRECEPTION',
     'SCREEN_WEIGHT',
+    'VISUAL_PERCEPTION_PRIORITY',
     'ENABLE_TOPIC_CREATER',
     'TOPIC_WEIGHT',
     'ENABLE_TODO_PRECEPTION',

--- a/src/components/views/PetMode.vue
+++ b/src/components/views/PetMode.vue
@@ -60,6 +60,7 @@ import { eventQueue } from '@/core/events/event-queue'
 import ChatInput from '../pet/ChatInput.vue'
 import DialogueBox from '../pet/DialogueBox.vue'
 import GameRolesStage from '../pet/GameRolesStage.vue'
+import { setExternalDeliveryBlocked } from '@/composables/useCanDeliver'
 
 const BASE_AVATAR_SIZE = 240
 const CHAT_BASE_H = 45
@@ -246,9 +247,13 @@ const handleAvatarClick = () => {
 }
 
 const handleOpenSettings = async () => {
+  setExternalDeliveryBlocked(true)
   try {
     const existing = await WebviewWindow.getByLabel('settings')
     if (existing) {
+      void existing.once('tauri://destroyed', () => {
+        setExternalDeliveryBlocked(false)
+      })
       await existing.setFocus()
       return
     }
@@ -270,9 +275,14 @@ const handleOpenSettings = async () => {
     })
 
     webview.once('tauri://error', (e) => {
+      setExternalDeliveryBlocked(false)
       console.error('创建桌宠轻量设置窗口失败:', e)
     })
+    webview.once('tauri://destroyed', () => {
+      setExternalDeliveryBlocked(false)
+    })
   } catch (error) {
+    setExternalDeliveryBlocked(false)
     console.error('打开设置窗口时出错:', error)
   }
 }
@@ -349,7 +359,9 @@ const handleExitPetMode = async () => {
     if (settingsWindow) {
       await settingsWindow.close()
     }
+    setExternalDeliveryBlocked(false)
   } catch {
+    setExternalDeliveryBlocked(false)
     // 窗口不存在，忽略
   }
 

--- a/src/composables/useCanDeliver.ts
+++ b/src/composables/useCanDeliver.ts
@@ -1,4 +1,4 @@
-import { ref, watch, onMounted } from 'vue'
+import { onBeforeUnmount, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { invoke } from '@tauri-apps/api/core'
 import { useUIStore } from '@/stores/modules/ui/ui'
@@ -15,6 +15,7 @@ const CHAT_ROUTES = ['LingChat', 'PetMode']
 
 // ===== 全局输入状态（由 GameDialog / ChatInput 组件上报） =====
 let _inputHasText = false
+let _externalWindowBlocked = false
 const _inputListeners = new Set<() => void>()
 
 /** 各输入组件在 watch 中调用此函数来更新输入状态 */
@@ -24,16 +25,28 @@ export function setInputHasText(val: boolean) {
   _inputListeners.forEach((fn) => fn())
 }
 
+/** 独立设置/覆盖层窗口打开时，由主窗口显式阻止主动回复。 */
+export function setExternalDeliveryBlocked(val: boolean) {
+  if (_externalWindowBlocked === val) return
+  _externalWindowBlocked = val
+  _inputListeners.forEach((fn) => fn())
+}
+
 export function useCanDeliver() {
   const router = useRouter()
   const uiStore = useUIStore()
 
   const canDeliver = ref(false)
-  let lastInvoked: boolean | null = null
+  let acknowledged: boolean | null = null
+  let syncing = false
+  let retryTimer: number | null = null
+  let retryDelayMs = 250
+  let disposed = false
 
   function recompute() {
     const onChatRoute = CHAT_ROUTES.includes(router.currentRoute.value.name as string)
-    canDeliver.value = onChatRoute && !uiStore.showSettings && !_inputHasText
+    canDeliver.value =
+      onChatRoute && !uiStore.showSettings && !_inputHasText && !_externalWindowBlocked
   }
 
   // 监听变更
@@ -49,15 +62,51 @@ export function useCanDeliver() {
 
   // 输入状态变化时重新计算
   _inputListeners.add(recompute)
-
-  // 值翻转时通知后端
-  watch(canDeliver, (val) => {
-    if (val !== lastInvoked) {
-      lastInvoked = val
-      invoke('proactive_set_can_deliver', { canDeliver: val })
-        .catch((e) => console.error('[CanDeliver] invoke failed:', e))
-    }
+  onBeforeUnmount(() => {
+    disposed = true
+    _inputListeners.delete(recompute)
+    if (retryTimer !== null) window.clearTimeout(retryTimer)
   })
+
+  // 串行同步，避免 true/false 两次 invoke 乱序完成后把后端留在过期状态。
+  async function syncCanDeliver() {
+    if (syncing || disposed) return
+    syncing = true
+
+    try {
+      while (!disposed && acknowledged !== canDeliver.value) {
+        const target = canDeliver.value
+        try {
+          await invoke('proactive_set_can_deliver', { canDeliver: target })
+          acknowledged = target
+          retryDelayMs = 250
+          if (retryTimer !== null) {
+            window.clearTimeout(retryTimer)
+            retryTimer = null
+          }
+        } catch (error) {
+          console.error('[CanDeliver] invoke failed:', error)
+          retryTimer = window.setTimeout(() => {
+            retryTimer = null
+            void syncCanDeliver()
+          }, retryDelayMs)
+          retryDelayMs = Math.min(retryDelayMs * 2, 5000)
+          break
+        }
+      }
+    } finally {
+      syncing = false
+    }
+  }
+
+  // 值翻转时通知后端；只有调用成功后才更新 acknowledged。
+  watch(
+    canDeliver,
+    () => {
+      void syncCanDeliver()
+    },
+    { immediate: true },
+  )
 
   return { canDeliver }
 }

--- a/src/core/events/processors/status-reset-processor.ts
+++ b/src/core/events/processors/status-reset-processor.ts
@@ -18,6 +18,7 @@ export default class StatusResetProcessor implements IEventProcessor {
       (event.status as 'input' | 'thinking' | 'responding' | 'presenting') || 'input'
     gameStore.currentLine = ''
     gameStore.thinkingLength = 0
+    gameStore.isProactiveThinking = false
     console.log('游戏状态已重置为:', event.status || 'input')
   }
 }

--- a/src/core/events/processors/thinking-processor.ts
+++ b/src/core/events/processors/thinking-processor.ts
@@ -14,11 +14,13 @@ export default class ThinkingProcessor implements IEventProcessor {
       // AI 开始思考，锁定输入
       gameStore.currentStatus = 'thinking'
       gameStore.thinkingLength = 0
+      gameStore.isProactiveThinking = Boolean(event.isProactive)
     } else {
       // AI 停止思考（通常是错误恢复），重置到可输入状态
       gameStore.currentStatus = 'input'
       gameStore.currentLine = ''
       gameStore.thinkingLength = 0
+      gameStore.isProactiveThinking = false
     }
   }
 }

--- a/src/stores/modules/game/state.ts
+++ b/src/stores/modules/game/state.ts
@@ -66,6 +66,8 @@ export interface GameState {
   currentStatus: 'input' | 'thinking' | 'responding' | 'presenting'
   /** 当前思考链累计字数（用于实时显示“已深度思考 N 字”） */
   thinkingLength: number
+  /** 当前是否处于主动回复的思考阶段 */
+  isProactiveThinking: boolean
   dialogHistory: GameMessage[]
   currentScene: SceneInfo | null // 当前加载的场景
   command: string | null
@@ -90,6 +92,7 @@ export const state: GameState = {
   currentLine: '',
   currentStatus: 'input',
   thinkingLength: 0,
+  isProactiveThinking: false,
   dialogHistory: [],
   currentScene: null,
   command: null,

--- a/src/stores/modules/ui/ui.ts
+++ b/src/stores/modules/ui/ui.ts
@@ -31,6 +31,7 @@ interface UIState {
   showCharacterThinkLine: string
   showSettings: boolean
   currentSettingsTab: string
+  advanceInitialTab: 'menu' | 'llm' | 'other'
 
   currentBackgroundTransition: number
   currentPresentPic: string
@@ -92,6 +93,7 @@ export const useUIStore = defineStore('ui', {
     showCharacterThinkLine: 'Ling Ling Thinking...',
     showSettings: false,
     currentSettingsTab: 'text',
+    advanceInitialTab: 'menu',
     currentBackgroundTransition: 300,
     currentPresentPic: '',
     currentPresentPicScale: 1,
@@ -197,6 +199,9 @@ export const useUIStore = defineStore('ui', {
     },
     setSettingsTab(tab: string) {
       this.currentSettingsTab = tab
+    },
+    setAdvanceInitialTab(tab: 'menu' | 'llm' | 'other') {
+      this.advanceInitialTab = tab
     },
 
     // ========== Notification Actions ==========

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -44,6 +44,8 @@ export interface ScriptDialogueEvent extends ScriptEvent {
 export interface ScriptThinkingEvent extends ScriptEvent {
   type: 'thinking'
   isThinking: boolean
+  /** 是否为主动回复触发的前置思考 */
+  isProactive?: boolean
 }
 
 export interface ScriptFreeDialogueEvent extends ScriptEvent {


### PR DESCRIPTION
## 改动内容

### 主动回复调度与稳定性

- 重构主动回复循环，耗时的视觉分析和生成阶段不再长期占用全局锁。
- 使用交互 epoch 丢弃用户发言后才返回的过期结果，修复主动回复竞态。
- 统一前端投递、用户状态、脚本状态和生成状态门控，并为失败投递增加退避。
- 仅在消息成功投递后消耗兴趣值，修复兴趣度衰减下限导致无法再次触发的问题。
- 日程提醒按天去重，主动消息增加历史相似度去重和 `[PASS]` 过滤。
- 增加手动测试主动消息入口，并向标准模式和桌宠模式透传主动思考状态。

### 视觉理解增强

- 为主动回复提供角色名、用户名和最近对话摘要等屏幕上下文。
- 优先分析前台窗口所在显示器，并按尺寸与质量上限压缩截图，减少视觉请求耗时。
- 支持视觉理解优先模式；视觉判断不适合搭话时可回退到普通话题。
- 支持视觉模型跟随聊天模型或配置独立轻量视觉模型，并对配置数值做边界保护。
- Kimi for Coding 改用 Anthropic Messages API，兼容 thinking/text 多 block 与工具定义。
- 修复 Kimi 流结束时重复输出 thinking，以及仅有 thinking 时正文回退失效的问题。
- 规范视觉接口地址拼接、超时、图片大小与 max_tokens，增加关键耗时日志。

### 设置与界面

- 整理主动回复基础、感知/话题、视觉模型三组设置，减少重复配置。
- 在输入框中显示“主动回复中”和累计思考字数。
- 主动回复成功前不提前修改前端/后端状态，避免 UI 与实际投递不一致。

## 影响

主动回复在视觉模型较慢、用户突然发送消息、脚本或界面状态变化时更不容易误触发、重复触发或卡死；视觉模型兼容性和响应速度也得到改善。已有配置键继续兼容，新配置均提供默认值和边界限制。

## 验证

- `cargo test --lib`：18 项测试通过
- `cargo check --lib`：通过
- `cargo clippy --lib --tests`：通过（保留上游已有告警）
- `pnpm build`：Vue/TypeScript 生产构建通过
- `pnpm tauri build --debug --no-bundle`：Windows 桌面程序构建通过
- `git diff --check`：通过
