### PR TITLE
feat: 为 Kimi Code 添加自动模型发现

### DIFF
--- a/src-tauri/src/ai_service/llm/mod.rs
+++ b/src-tauri/src/ai_service/llm/mod.rs
@@ -9,7 +9,7 @@ pub mod provider_config;
 mod providers;
 
 pub use factory::create_llm_client;
-pub use provider::LlmProvider;
+pub use provider::{LlmModelInfo, LlmProvider};
 
 use std::pin::Pin;
 use std::time::Duration;
@@ -73,6 +73,10 @@ impl LlmClient {
 
     pub fn config(&self) -> &LlmConfig {
         &self.cfg
+    }
+
+    pub async fn list_models(&self) -> Result<Vec<LlmModelInfo>> {
+        self.provider.list_models(&self.http).await
     }
 
     /// 非流式：一次性取完整回复。

--- a/src-tauri/src/ai_service/llm/provider.rs
+++ b/src-tauri/src/ai_service/llm/provider.rs
@@ -1,11 +1,21 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use reqwest::Client;
+use serde::Serialize;
 
 use crate::ai_service::llm::ChunkStream;
 use crate::ai_service::types::{LlmMessage, ToolCall, ToolDefinition};
 
 /// `complete_with_tools` 的返回值。
+#[derive(Debug, Clone, Serialize)]
+pub struct LlmModelInfo {
+    pub id: String,
+    pub display_name: Option<String>,
+    pub context_length: Option<u64>,
+    pub supports_reasoning: bool,
+    pub supports_thinking_type: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct LlmResponseWithTools {
     /// 文本回复（可能为空，如果 LLM 只返回 tool call）。
@@ -20,6 +30,10 @@ pub struct LlmResponseWithTools {
 /// 参照 `TtsAdapter` trait 使用 `async_trait` + `Send + Sync` 的模式。
 #[async_trait]
 pub trait LlmProvider: Send + Sync {
+    async fn list_models(&self, _http: &Client) -> Result<Vec<LlmModelInfo>> {
+        Ok(Vec::new())
+    }
+
     /// 非流式：发送消息列表，返回完整回复文本。
     async fn complete(&self, http: &Client, messages: &[LlmMessage]) -> Result<String>;
 

--- a/src-tauri/src/ai_service/llm/providers/kimi_code.rs
+++ b/src-tauri/src/ai_service/llm/providers/kimi_code.rs
@@ -7,13 +7,45 @@
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use futures_util::StreamExt;
-use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
-use crate::ai_service::llm::provider::{LlmProvider, LlmResponseWithTools};
+use crate::ai_service::llm::provider::{LlmModelInfo, LlmProvider, LlmResponseWithTools};
 use crate::ai_service::llm::{ChunkStream, LlmChunk, LlmConfig};
 use crate::ai_service::types::{LlmMessage, ToolCall, ToolDefinition};
+
+#[derive(Debug, Deserialize)]
+struct KimiCodeModelsResponse {
+    data: Vec<KimiCodeModelRecord>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KimiCodeModelRecord {
+    id: String,
+    #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    context_length: Option<u64>,
+    #[serde(default)]
+    supports_reasoning: bool,
+    #[serde(default)]
+    supports_thinking_type: Option<String>,
+}
+
+fn kimi_code_models_endpoint(base_url: &str) -> String {
+    let base = if base_url.trim().is_empty() {
+        "https://api.kimi.com/coding"
+    } else {
+        base_url.trim().trim_end_matches('/')
+    };
+    if base.ends_with("/v1") {
+        format!("{base}/models")
+    } else {
+        format!("{base}/v1/models")
+    }
+}
 
 pub struct KimiCodeProvider {
     model: String,
@@ -137,6 +169,52 @@ impl KimiCodeProvider {
 
 #[async_trait]
 impl LlmProvider for KimiCodeProvider {
+    async fn list_models(&self, http: &Client) -> Result<Vec<LlmModelInfo>> {
+        if self.api_key.trim().is_empty() {
+            return Err(anyhow!("请先填写 Kimi Code API 密钥"));
+        }
+
+        let endpoint = kimi_code_models_endpoint(&self.base_url);
+        let response = http
+            .get(&endpoint)
+            .timeout(Duration::from_secs(30))
+            .bearer_auth(self.api_key.trim())
+            .header(USER_AGENT, "claude-code/0.1.0")
+            .header(ACCEPT, "application/json")
+            .send()
+            .await
+            .context("请求 Kimi Code 模型列表失败")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let detail = response.text().await.unwrap_or_default();
+            let detail = detail.chars().take(500).collect::<String>();
+            return Err(anyhow!("获取 Kimi Code 模型列表失败 ({status}): {detail}"));
+        }
+
+        let payload: KimiCodeModelsResponse = response
+            .json()
+            .await
+            .context("解析 Kimi Code 模型列表失败")?;
+        let models = payload
+            .data
+            .into_iter()
+            .filter(|model| !model.id.trim().is_empty())
+            .map(|model| LlmModelInfo {
+                id: model.id,
+                display_name: model.display_name,
+                context_length: model.context_length,
+                supports_reasoning: model.supports_reasoning,
+                supports_thinking_type: model.supports_thinking_type,
+            })
+            .collect::<Vec<_>>();
+
+        if models.is_empty() {
+            return Err(anyhow!("Kimi Code 没有返回可用模型"));
+        }
+        Ok(models)
+    }
+
     async fn complete(&self, http: &Client, messages: &[LlmMessage]) -> Result<String> {
         let body = self.build_request(messages, false, None, None);
         let resp = http

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -16,6 +16,7 @@ use crate::ai_service::llm::provider_config::{
     build_llm_client_from_provider, load_providers, load_role_assignment, save_providers,
     save_role_assignment, LlmProviderConfig, LlmProvidersResponse,
 };
+use crate::ai_service::llm::LlmModelInfo;
 use crate::config::tts::TtsConfig;
 
 // ========== 字段键（对标 Python .env） ==========
@@ -930,4 +931,18 @@ pub async fn test_llm_provider(
     .map_err(|_| "请求超时（30秒），请检查网络或 API 地址".to_string())?;
 
     timeout.map_err(|e| format!("测试请求失败: {e}"))
+}
+
+#[tauri::command]
+pub async fn list_llm_models(
+    provider: LlmProviderConfig,
+) -> Result<Vec<LlmModelInfo>, String> {
+    let Some(client) = build_llm_client_from_provider(&provider) else {
+        return Err("无法创建 LLM 客户端，请检查 API Key 和模型名称".to_string());
+    };
+
+    client
+        .list_models()
+        .await
+        .map_err(|error| error.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -306,6 +306,7 @@ pub fn run() {
             config::delete_llm_provider,
             config::set_llm_role,
             config::test_llm_provider,
+            config::list_llm_models,
             api::character::get_character_list,
             api::character::get_role_info,
             api::character::get_role_settings,

--- a/src/api/services/llm-providers.ts
+++ b/src/api/services/llm-providers.ts
@@ -19,13 +19,19 @@ export interface LlmProvidersResponse {
   god_agent_provider_id: string | null
 }
 
+export interface LlmModelInfo {
+  id: string
+  display_name: string | null
+  context_length: number | null
+  supports_reasoning: boolean
+  supports_thinking_type: string | null
+}
+
 export async function listLlmProviders(): Promise<LlmProvidersResponse> {
   return invoke('list_llm_providers')
 }
 
-export async function saveLlmProvider(
-  provider: LlmProviderConfig,
-): Promise<void> {
+export async function saveLlmProvider(provider: LlmProviderConfig): Promise<void> {
   return invoke('save_llm_provider', { provider })
 }
 
@@ -38,4 +44,10 @@ export async function setLlmRole(
   providerId: string | null,
 ): Promise<void> {
   return invoke('set_llm_role', { role, providerId })
+}
+
+export async function listLlmModels(
+  provider: LlmProviderConfig,
+): Promise<LlmModelInfo[]> {
+  return invoke('list_llm_models', { provider })
 }

--- a/src/components/settings/pages/SettingsLlmProviders.vue
+++ b/src/components/settings/pages/SettingsLlmProviders.vue
@@ -286,9 +286,7 @@
                   <option value="openai" class="bg-gray-800 text-white">
                     OpenAI 兼容 (DeepSeek / 通义千问 / Ollama)
                   </option>
-                  <option value="lmstudio" class="bg-gray-800 text-white">
-                    LM Studio（本地）
-                  </option>
+                  <option value="lmstudio" class="bg-gray-800 text-white">LM Studio（本地）</option>
                   <option value="gemini" class="bg-gray-800 text-white">Gemini</option>
                   <option value="kimicode" class="bg-gray-800 text-white">
                     Kimi Code (kimi-for-coding)
@@ -320,13 +318,75 @@
               <input
                 v-model="editing.model"
                 type="text"
-                :placeholder="editing.provider === 'lmstudio' ? '如: llama-3.2-3b-instruct' : '如: deepseek-chat'"
+                :placeholder="
+                  editing.provider === 'lmstudio'
+                    ? '如: llama-3.2-3b-instruct'
+                    : '如: deepseek-chat'
+                "
                 class="px-3 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm outline-none focus:border-brand transition-colors placeholder:text-white/20"
               />
             </div>
 
-            <!-- Hidden model for kimicode -->
-            <input v-if="editing.provider === 'kimicode'" v-model="editing.model" type="hidden" />
+            <!-- Kimi Code model discovery -->
+            <div v-else class="flex flex-col gap-1">
+              <label class="text-xs font-medium text-white/60">模型名称</label>
+              <div class="flex gap-2">
+                <div v-if="availableModels.length > 0" class="relative flex-1 min-w-0">
+                  <select
+                    v-model="editing.model"
+                    class="w-full appearance-none pl-3 pr-8 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm outline-none focus:border-brand transition-colors cursor-pointer"
+                  >
+                    <option
+                      v-for="model in availableModels"
+                      :key="model.id"
+                      :value="model.id"
+                      class="bg-gray-800 text-white"
+                    >
+                      {{ model.display_name ? `${model.display_name} (${model.id})` : model.id }}
+                    </option>
+                  </select>
+                  <div
+                    class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2.5"
+                  >
+                    <svg
+                      class="w-4 h-4 text-white/40"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M19 9l-7 7-7-7"
+                      />
+                    </svg>
+                  </div>
+                </div>
+                <input
+                  v-else
+                  v-model="editing.model"
+                  type="text"
+                  placeholder="kimi-for-coding"
+                  class="flex-1 min-w-0 px-3 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm outline-none focus:border-brand transition-colors placeholder:text-white/20"
+                />
+                <button
+                  type="button"
+                  class="shrink-0 px-3 py-2 rounded-lg bg-brand/80 text-white text-sm hover:bg-brand transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  :disabled="loadingModels || !editing.api_key.trim()"
+                  @click="fetchProviderModels"
+                >
+                  {{ loadingModels ? '获取中...' : '自动获取' }}
+                </button>
+              </div>
+              <p
+                v-if="modelsMessage"
+                class="text-xs"
+                :class="modelsError ? 'text-red-400' : 'text-green-400'"
+              >
+                {{ modelsMessage }}
+              </p>
+            </div>
 
             <!-- API Key -->
             <div class="flex flex-col gap-1">
@@ -351,7 +411,11 @@
             </div>
 
             <!-- Hidden base_url for kimicode -->
-            <input v-if="editing.provider === 'kimicode'" v-model="editing.base_url" type="hidden" />
+            <input
+              v-if="editing.provider === 'kimicode'"
+              v-model="editing.base_url"
+              type="hidden"
+            />
 
             <!-- Temperature -->
             <div class="flex flex-col gap-1">
@@ -472,7 +536,11 @@ import { ref, onMounted, reactive } from 'vue'
 import { useLlmProvidersStore } from '@/stores/modules/llm-providers'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import { invoke } from '@tauri-apps/api/core'
-import type { LlmProviderConfig } from '@/api/services/llm-providers'
+import {
+  listLlmModels,
+  type LlmModelInfo,
+  type LlmProviderConfig,
+} from '@/api/services/llm-providers'
 
 const store = useLlmProvidersStore()
 const uiStore = useUIStore()
@@ -483,6 +551,10 @@ const saveMessage = ref('')
 const saveError = ref(false)
 const lmstudioAutoFilled = ref(false)
 const kimicodeAutoFilled = ref(false)
+const availableModels = ref<LlmModelInfo[]>([])
+const loadingModels = ref(false)
+const modelsMessage = ref('')
+const modelsError = ref(false)
 
 // Test state
 const testProvider = ref<LlmProviderConfig | null>(null)
@@ -510,8 +582,15 @@ function closePanel() {
   saveMessage.value = ''
 }
 
+function resetModelList() {
+  availableModels.value = []
+  modelsMessage.value = ''
+  modelsError.value = false
+}
+
 // LM Studio 兼容：本质是 OpenAI 协议，这里只帮用户预填默认地址和假 key
 function onProviderChange() {
+  resetModelList()
   if (editing.provider === 'lmstudio') {
     editing.base_url = 'http://localhost:1234/v1'
     editing.api_key = 'sk-lingchat70'
@@ -545,12 +624,14 @@ function onProviderChange() {
 
 function startAdd() {
   Object.assign(editing, emptyProvider())
+  resetModelList()
   sidePanel.value = 'edit'
   saveMessage.value = ''
 }
 
 function startEdit(p: LlmProviderConfig) {
   Object.assign(editing, { ...p })
+  resetModelList()
   sidePanel.value = 'edit'
   saveMessage.value = ''
 }
@@ -587,6 +668,35 @@ async function saveCurrent() {
   } catch (e: any) {
     saveMessage.value = `保存失败: ${e}`
     saveError.value = true
+  }
+}
+
+async function fetchProviderModels() {
+  if (loadingModels.value) return
+  if (!editing.api_key.trim()) {
+    modelsMessage.value = '请先填写 Kimi Code API 密钥'
+    modelsError.value = true
+    return
+  }
+
+  loadingModels.value = true
+  modelsMessage.value = ''
+  modelsError.value = false
+  try {
+    const models = await listLlmModels({ ...editing })
+    availableModels.value = models
+    if (!models.some((model) => model.id === editing.model)) {
+      editing.model = models[0]?.id ?? editing.model
+    }
+    modelsMessage.value = `已获取 ${models.length} 个可用模型`
+  } catch (error: any) {
+    availableModels.value = []
+    modelsMessage.value = `获取失败: ${
+      typeof error === 'string' ? error : error?.message || JSON.stringify(error)
+    }`
+    modelsError.value = true
+  } finally {
+    loadingModels.value = false
   }
 }
 


### PR DESCRIPTION
## 变更内容

- 参考 `kimi-code-analysis` 的实现，为 Kimi Code 增加 `GET /coding/v1/models` 模型发现能力。
- 使用 `Authorization: Bearer` 在 Rust 后端请求模型列表，避免前端直接处理 API 密钥。
- 在 Kimi Code 提供商编辑界面增加“自动获取”按钮，获取成功后展示可用模型下拉列表。
- 保留手动填写模型名称的回退方式，并补充加载、成功和错误状态提示。
- 修复旧数据库中 `seaql_migrations.version` 与 Rust 迁移名称不一致导致的启动失败。

## 背景与原因

Kimi Code 原先默认使用 `kimi-for-coding`，可用模型发生变化时只能手动修改配置，容易出现模型名称填写错误或无法及时使用新增模型的问题。

此外，旧版数据库记录的迁移名称为 `m20240101_000001_create_tables`，而当前 Rust 迁移返回了包含源码路径的名称，导致升级后的迁移检查认为历史迁移文件缺失并终止启动。本次修改使迁移名称与已有数据库记录保持一致。

## 用户影响

- 用户可以通过当前 Kimi Code API 密钥直接获取账号可用模型并完成选择。
- 获取失败时仍可手动输入模型名称，不影响原有配置流程。
- 已使用旧版本数据库的用户可以正常启动升级后的 Rust 版本。

## 验证结果

- [x] `pnpm build`
- [x] `cargo check`
- [x] 实际请求 `https://api.kimi.com/coding/v1/models`，成功获取 `kimi-for-coding` 与 `kimi-for-coding-highspeed`
- [x] 完整 Tauri/NSIS release 构建成功
- [x] 完整 EXE 替换后启动验证通过
