### PR TITLE
修复：将情绪标签移至角色副标题旁

### DIFF
--- a/src/components/game/standard/GameDialog.vue
+++ b/src/components/game/standard/GameDialog.vue
@@ -26,16 +26,17 @@
             <div id="character-sub">{{ uiStore.showCharacterSubtitle }}</div>
           </div>
 
-          <!-- 右侧区域：情绪标签 + 操作按钮组（窄屏时占据剩余全部宽度，优先显示） -->
+          <div
+            class="text-xl font-bold text-[#ff77dd] font-[inherit] text-shadow-[inherit] shrink-0"
+            :class="uiStore.isNarrowScreen ? 'ml-auto' : 'ml-3'"
+          >
+            <div id="character-emotion">{{ uiStore.showCharacterEmotion }}</div>
+          </div>
+
           <div
             class="flex items-baseline ml-auto min-w-0"
             :class="{ 'flex-1 shrink-0': uiStore.isNarrowScreen }"
           >
-            <div
-              class="text-xl font-bold text-[#ff77dd] font-[inherit] text-shadow-[inherit] shrink-0"
-            >
-              <div id="character-emotion">{{ uiStore.showCharacterEmotion }}</div>
-            </div>
 
             <!-- 桌面端：直接显示所有操作按钮 -->
             <template v-if="!isMobile">


### PR DESCRIPTION
## 改动内容
将对话框中的情绪标签移动到角色副标题旁，并把桌面端间距调整为约 12px。

## 修改原因
情绪标签原本位于右侧操作按钮组内，与角色信息在视觉上分离，不利于阅读。

## 影响范围
角色名称、副标题和情绪会形成紧凑的左侧信息组；右侧操作按钮保持原有位置，窄屏布局仍会自适应。

## 验证情况
本地已完成对应界面改动的 Tauri release 构建。独立 PR 分支基于官方 `tauri-refactor` 目标分支提交。