### PR TITLE
fix: 修复桌宠模式bug

### DIFF
--- a/src/components/pet/DialogueBox.vue
+++ b/src/components/pet/DialogueBox.vue
@@ -23,7 +23,7 @@
 
       <div
         ref="textareaRef"
-        class="text-[calc(15px*var(--pet-ui-scale,1))] leading-snug font-medium overflow-y-auto max-h-[calc(40px*var(--pet-ui-scale,1))]"
+        class="text-[calc(15px*var(--pet-ui-scale,1))] leading-snug font-medium overflow-y-auto max-h-[calc(40px*var(--pet-ui-scale,1))] whitespace-pre-line [text-shadow:0_0_3px_rgba(0,0,0,0.9),0_1px_4px_rgba(0,0,0,0.5)]"
       ></div>
     </div>
   </div>
@@ -59,11 +59,20 @@ const handleDialogueClick = () => {
   }
 }
 
-const textareaRef = ref<HTMLTextAreaElement | null>(null)
+const textareaRef = ref<HTMLElement | null>(null)
 
-const { startTyping, stopTyping, isTyping } = useTypeWriter(textareaRef, (text) => {
-  currentDisplayedText.value = text
-})
+const { startTyping, stopTyping, isTyping } = useTypeWriter(
+  textareaRef,
+  (text) => {
+    currentDisplayedText.value = text
+  },
+  // DialogueBox 正文为普通 <div>（非 textarea/input），必须提供 writeFn
+  // 否则 TypeWriter 仅对 HTMLInputElement/HTMLTextAreaElement 写入 value，
+  // 会导致桌宠模式下 AI 正文不显示
+  (el, text) => {
+    el.textContent = text
+  },
+)
 
 watch([() => uiStore.showCharacterLine, () => gameStore.currentStatus], ([newLine, newStatus]) => {
   if (newLine && newLine !== '' && newStatus === 'responding') {

--- a/src/components/ui/AchievementToast.vue
+++ b/src/components/ui/AchievementToast.vue
@@ -1,6 +1,10 @@
 <template>
   <Transition name="slide-up">
-    <div v-if="store.isVisible && store.current" class="achievement-toast" :class="typeClass">
+    <div
+      v-if="store.isVisible && store.current && !isPetMode"
+      class="achievement-toast"
+      :class="typeClass"
+    >
       <div class="glow-effect"></div>
 
       <div class="achievement-icon">
@@ -51,11 +55,16 @@
 
 <script setup lang="ts">
 import { computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { useAchievementStore } from '../../stores/modules/ui/achievement'
 import { useUIStore } from '../../stores/modules/ui/ui'
 
 const store = useAchievementStore()
 const uiStore = useUIStore()
+const route = useRoute()
+
+// 桌宠模式下不显示成就弹窗（小窗空间有限，且会遮挡桌宠交互区）
+const isPetMode = computed(() => route.path === '/pet')
 
 const typeClass = computed(() => {
   return store.current?.type === 'rare' ? 'achievement-gold' : 'achievement-green'

--- a/src/components/views/MainChat.vue
+++ b/src/components/views/MainChat.vue
@@ -60,14 +60,20 @@ import GameExtraUI from '../game/standard/GameExtraUI.vue'
 
 const LOADING_STORAGE_KEY = 'lingchat_loading_shown'
 
+// 会话级标记：同一页面 session 内只播放一次加载动画。
+// 仅靠 localStorage 会在路由卸载/重挂时回显（如桌宠切回聊天），
+// 用模块级变量兜底，确保一次启动只播放一次。
+let loadingShownThisSession = false
+
 const router = useRouter()
 const uiStore = useUIStore()
 const gameStore = useGameStore()
 
-// 首次加载过渡状态（通过 localStorage 跨路由导航保持，启动时由 main.ts 清除）
-const showLoading = ref(!localStorage.getItem(LOADING_STORAGE_KEY))
+// 首次加载过渡状态：仅当本次 session 未播放过且 localStorage 未标记时播放
+const showLoading = ref(!loadingShownThisSession && !localStorage.getItem(LOADING_STORAGE_KEY))
 
 function onLoadingComplete() {
+  loadingShownThisSession = true
   showLoading.value = false
   localStorage.setItem(LOADING_STORAGE_KEY, '1')
   // 加载动画结束，恢复事件队列消费


### PR DESCRIPTION
## 现在桌宠切回正常对话模式时不会再重复触发加载动画
MainChat 加载动画改用会话级模块变量 + localStorage 双重判定， 路由卸载/重挂（/pet -> /chat）不再回显 LoadingTransition。

## 修复桌宠模式 AI 消息正文不显示
DialogueBox 正文容器为普通 `<div>`，但TypeWriter 仅对 HTMLInputElement/HTMLTextAreaElement 写入 value，对 div 无 writeFn 则不写入任何内容。补充 writeFn (el.textContent = text)， 并加 whitespace-pre-line + text-shadow 描边增强可读性。

## 桌宠模式隐藏异常的成就完成视觉提示
AchievementToast 在 /pet 路由下小窗布局异常，目前决策加 isPetMode 判定 隐藏弹窗。音频照常播放，store 队列正常流转不丢失成就。更好的实现之后再弄吧，先把逻辑弄正常了（确信）。