### PR TITLE
fix(ui): 启动时预加载 LLM providers store

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,7 @@ import AchievementToast from './components/ui/AchievementToast.vue'
 import AdventureUnlockNotify from './components/ui/AdventureUnlockNotify.vue'
 import AppDialog from './components/ui/AppDialog.vue'
 import { initUIStore } from './stores/modules/ui/ui'
+import { useLlmProvidersStore } from './stores/modules/llm-providers'
 import { useAchievementStore } from './stores/modules/ui/achievement'
 import { useSedentaryReminder } from './composables/useSedentaryReminder'
 import { useUpdater } from './composables/useUpdater'
@@ -56,6 +57,10 @@ const handleKeyDown = async (event) => {
 onMounted(() => {
   // 初始化 UI Store（加载角色 tips）
   initUIStore()
+
+  // 预加载 LLM 提供商配置，避免主界面因 store 未加载而误判未选择模型
+  const llmStore = useLlmProvidersStore()
+  llmStore.load().catch((e) => console.error('加载 LLM 提供商失败:', e))
 
   // 供成就系统控制台测试用，在 window 对象中注册一些方法
   const achievementStore = useAchievementStore()


### PR DESCRIPTION
## 修复内容

修复应用启动后、未进入设置页前，主界面发送消息提示「还没选择对话模型」的问题。

## 原因

`useLlmProvidersStore` 只在 `SettingsLlmProviders.vue` 的 `onMounted` 中调用 `load()`。如果用户打开应用后直接进入对话界面，`chatProviderId` 仍为空，触发发送按钮的拦截提示。

## 改动

在 `App.vue` 的 `onMounted` 中预加载 LLM providers store，确保应用启动后即完成模型配置加载：

```ts
const llmStore = useLlmProvidersStore()
llmStore.load().catch((e) => console.error('加载 LLM 提供商失败:', e))
```

## 测试

- 构建通过（`pnpm tauri build`）
- 启动应用后可直接在对话界面发送消息
