### PR TITLE
fix:修复32位CPU（编译器）无rbx寄存器导致的编译失败

### DIFF
--- a/src-tauri/src/utils/cpu_perf.rs
+++ b/src-tauri/src/utils/cpu_perf.rs
@@ -52,7 +52,8 @@ impl CpuDetectionCache {
 mod x86_impl {
     use super::*;
 
-    /// 执行 CPUID 指令
+    /// 执行 CPUID 指令 (x86_64，使用 rbx)
+    #[cfg(target_arch = "x86_64")]
     #[inline]
     fn cpuid(leaf: u32, subleaf: u32) -> (u32, u32, u32, u32) {
         let eax: u32;
@@ -68,6 +69,27 @@ mod x86_impl {
                 tmp = out(reg) _,
                 ebx = out(reg) ebx,
                 inout("eax") leaf => eax,
+                inout("ecx") subleaf => ecx,
+                out("edx") edx,
+                options(nostack, preserves_flags)
+            );
+        }
+        (eax, ebx, ecx, edx)
+    }
+
+    /// 执行 CPUID 指令 (x86，直接使用 out("ebx") 让编译器处理保存/恢复)
+    #[cfg(target_arch = "x86")]
+    #[inline]
+    fn cpuid(leaf: u32, subleaf: u32) -> (u32, u32, u32, u32) {
+        let eax: u32;
+        let ebx: u32;
+        let ecx: u32;
+        let edx: u32;
+        unsafe {
+            core::arch::asm!(
+                "cpuid",
+                inout("eax") leaf => eax,
+                out("ebx") ebx,
                 inout("ecx") subleaf => ecx,
                 out("edx") edx,
                 options(nostack, preserves_flags)


### PR DESCRIPTION
无意中发现的这个问题，由于32位下无法使用`rbx`寄存器，故把`CPUID`逻辑拆分为两个`#[cfg]` 条件编译版本。x86使用`edx` ，x86_64使用`rbx`。顺带解决32位下寄存器冲突导致的乱码