### PR TITLE
Fix :环境音系统添加淡入淡出效果

### DIFF
--- a/src/components/game/standard/GameBackground.vue
+++ b/src/components/game/standard/GameBackground.vue
@@ -1,6 +1,9 @@
 <template>
   <!-- 背景图 + 背景光照滤镜 -->
-  <div class="absolute inset-0" :style="bgLightingFilter">
+  <div
+    class="absolute inset-0"
+    :style="bgLightingFilter"
+  >
     <ImageAcrossFade
       ref="imageFadeRef"
       class="game-background"
@@ -49,7 +52,7 @@
   <!-- 背景光照叠加层（在背景上方、角色下方） -->
   <div
     v-if="bgOverlayStyle"
-    class="absolute inset-0 pointer-events-none"
+    class="pointer-events-none absolute inset-0"
     :style="bgOverlayStyle as any"
   ></div>
 
@@ -67,22 +70,28 @@
     @ended="handleTrackEnd"
   />
 
-  <!-- 环境音多轨渲染（每轨独立 <audio> 实例，最多8轨并行） -->
-  <audio
-    v-for="track in uiStore.ambientTracks"
-    :key="track.id"
-    :ref="(el: any) => setAmbientRef(track.id, el as HTMLAudioElement)"
-    :loop="track.loop"
-  ></audio>
+  <!-- 环境音多轨渲染（每轨独立交叉淡入淡出循环组件，最多8轨并行） -->
+  <AmbientLoopPlayer
+    v-for="d in displayTracks"
+    :key="d.id"
+    :src="srcOf(d)"
+    :volume="d.volume"
+    :loop="d.loop"
+    :fade="d.fade"
+    :paused="d.paused"
+    :stopped="d.stopped"
+    @stopped-done="onStoppedDone(d.id)"
+  />
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed, nextTick } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { convertFileSrc } from '@tauri-apps/api/core'
 import { useUIStore } from '../../../stores/modules/ui/ui'
 import { useGameStore } from '../../../stores/modules/game'
 import ImageAcrossFade from '@/components/ui/ImageAcrossFade.vue'
 import AudioAcrossFade from '@/components/ui/AudioAcrossFade.vue'
+import AmbientLoopPlayer from '@/components/ui/AmbientLoopPlayer.vue'
 import StarField from './particles/StarField.vue'
 import Rain from './particles/Rain.vue'
 import Sakura from './particles/Sakura.vue'
@@ -191,159 +200,75 @@ watch(
 // !!! 在此处：因为把背景音乐交给了 AudioCrossFade 组件，所以原先的大段背景音乐逻辑全被彻底删除。
 
 // ========== 环境音多轨管理 ==========
-// 存储各环境音轨道的 <audio> DOM 引用
-const ambientRefs = ref<Map<string, HTMLAudioElement>>(new Map())
+// 显示用轨道镜像：保留淡出期间的"离场"轨道，避免直接卸载造成点击
+const displayTracks = ref<
+  Array<{
+    id: string
+    src: string
+    volume: number // 0-1 有效音量
+    loop: boolean
+    fade: boolean
+    paused: boolean
+    stopped: boolean
+  }>
+>([])
 
-// 设置/清除环境音轨道的 DOM 引用
-const setAmbientRef = (id: string, el: HTMLAudioElement | null) => {
-  if (el) {
-    ambientRefs.value.set(id, el)
-  } else {
-    ambientRefs.value.delete(id)
-  }
-}
+const effectiveVolume = (trackVolume: number) => (trackVolume / 100) * (uiStore.ambientVolume / 100)
 
-// ========== 环境音淡入淡出 ==========
-const FADE_DURATION = 1000  // 淡入淡出时长（毫秒）
-const fadeTimers = ref<Map<string, number>>(new Map())
+const srcOf = (d: { src: string }) => (d.src.startsWith('blob:') ? d.src : convertFileSrc(d.src))
 
-/** 淡入：从 0 渐增到目标音量 */
-const fadeInAmbient = (audioEl: HTMLAudioElement, trackId: string, targetVolume: number) => {
-  // 取消该轨道已有的淡入淡出
-  const existing = fadeTimers.value.get(trackId)
-  if (existing) cancelAnimationFrame(existing)
-
-  audioEl.volume = 0
-  const startTime = performance.now()
-
-  const animate = (now: number) => {
-    const elapsed = now - startTime
-    const progress = Math.min(elapsed / FADE_DURATION, 1)
-    audioEl.volume = progress * targetVolume
-
-    if (progress < 1) {
-      fadeTimers.value.set(trackId, requestAnimationFrame(animate))
-    } else {
-      fadeTimers.value.delete(trackId)
-    }
-  }
-  fadeTimers.value.set(trackId, requestAnimationFrame(animate))
-}
-
-/** 淡出：从当前音量渐减到 0，完成后暂停 */
-const fadeOutAmbient = (audioEl: HTMLAudioElement, trackId: string) => {
-  const existing = fadeTimers.value.get(trackId)
-  if (existing) cancelAnimationFrame(existing)
-
-  const startVolume = audioEl.volume
-  const startTime = performance.now()
-
-  const animate = (now: number) => {
-    const elapsed = now - startTime
-    const progress = Math.min(elapsed / FADE_DURATION, 1)
-    audioEl.volume = startVolume * (1 - progress)
-
-    if (progress < 1) {
-      fadeTimers.value.set(trackId, requestAnimationFrame(animate))
-    } else {
-      audioEl.pause()
-      fadeTimers.value.delete(trackId)
-    }
-  }
-  fadeTimers.value.set(trackId, requestAnimationFrame(animate))
-}
-
-// 监听环境音轨道列表变化，自动播放新增轨道、清理已移除轨道
+// 同步 store 轨道到 displayTracks：新增则挂载，移除则标记离场触发淡出
 watch(
   () => uiStore.ambientTracks,
-  (newTracks, oldTracks) => {
-    // 播放新增的轨道
-    nextTick(() => {
-      for (const track of newTracks) {
-        const audioEl = ambientRefs.value.get(track.id)
-        if (audioEl && !audioEl.src) {
-          // blob URL 直接使用，文件系统路径需要转换
-          audioEl.src = track.src.startsWith('blob:') ? track.src : convertFileSrc(track.src)
-          const targetVolume = (track.volume / 100) * (uiStore.ambientVolume / 100)
-          audioEl.loop = track.loop
-          audioEl.load()
-          audioEl.play().catch((e) => console.warn('环境音播放失败:', e))
-          // 如果启用淡入，从 0 渐增到目标音量
-          if (track.fade) {
-            fadeInAmbient(audioEl, track.id, targetVolume)
-          } else {
-            audioEl.volume = targetVolume
-          }
-        }
-      }
-    })
-    // 清理已移除的轨道（淡出后释放）
-    const trackIds = new Set(newTracks.map(t => t.id))
-    for (const [id, el] of ambientRefs.value.entries()) {
-      if (!trackIds.has(id)) {
-        // 检查被移除的轨道是否启用了淡出
-        const removedTrack = oldTracks?.find(t => t.id === id)
-        if (removedTrack?.fade) {
-          fadeOutAmbient(el, id)
-          // 淡出完成后清理（由 fadeOutAmbient 内部处理 pause）
-          setTimeout(() => {
-            el.src = ''
-            ambientRefs.value.delete(id)
-          }, FADE_DURATION + 100)
-        } else {
-          el.pause()
-          el.src = ''
-          ambientRefs.value.delete(id)
-        }
+  (newTracks) => {
+    const storeIds = new Set(newTracks.map((t) => t.id))
+    // 新增或同步已有（非离场）
+    for (const t of newTracks) {
+      const d = displayTracks.value.find((x) => x.id === t.id)
+      if (!d) {
+        displayTracks.value.push({
+          id: t.id,
+          src: t.src,
+          volume: effectiveVolume(t.volume),
+          loop: t.loop,
+          fade: t.fade ?? true,
+          paused: t.paused ?? false,
+          stopped: false,
+        })
+      } else if (!d.stopped) {
+        d.src = t.src
+        d.volume = effectiveVolume(t.volume)
+        d.loop = t.loop
+        d.fade = t.fade ?? true
+        d.paused = t.paused ?? false
       }
     }
+    // store 中已移除的标记离场，由组件淡出后回调清理
+    for (const d of displayTracks.value) {
+      if (!storeIds.has(d.id) && !d.stopped) d.stopped = true
+    }
   },
-  { deep: true }
+  { deep: true },
 )
 
-// 监听全局环境音音量变化，实时更新所有轨道音量
+// 全局环境音音量变化时，刷新所有非离场轨道音量
 watch(
   () => uiStore.ambientVolume,
   (newVol) => {
-    if (newVol == null) return // 防御：持久化数据可能缺少此字段
-    for (const [id, el] of ambientRefs.value.entries()) {
-      const track = uiStore.ambientTracks.find(t => t.id === id)
-      if (track) {
-        el.volume = (track.volume / 100) * (newVol / 100)
-      }
+    if (newVol == null) return
+    for (const d of displayTracks.value) {
+      if (d.stopped) continue
+      const t = uiStore.ambientTracks.find((x) => x.id === d.id)
+      if (t) d.volume = (t.volume / 100) * (newVol / 100)
     }
-  }
+  },
 )
 
-// 监听单轨音量变化，实时更新对应 <audio> 元素音量
-watch(
-  () => uiStore.ambientTracks.map(t => `${t.id}:${t.volume}`).join(','),
-  () => {
-    for (const [id, el] of ambientRefs.value.entries()) {
-      const track = uiStore.ambientTracks.find(t => t.id === id)
-      if (track) {
-        el.volume = (track.volume / 100) * (uiStore.ambientVolume / 100)
-      }
-    }
-  }
-)
-
-// 监听单轨暂停状态变化
-watch(
-  () => uiStore.ambientTracks.map(t => `${t.id}:${t.paused}`).join(','),
-  () => {
-    for (const [id, el] of ambientRefs.value.entries()) {
-      const track = uiStore.ambientTracks.find(t => t.id === id)
-      if (track) {
-        if (track.paused) {
-          el.pause()
-        } else if (el.paused && el.src) {
-          el.play().catch((e) => console.warn('环境音恢复播放失败:', e))
-        }
-      }
-    }
-  }
-)
+// 组件淡出完成回调：从 displayTracks 移除并卸载
+const onStoppedDone = (id: string) => {
+  const idx = displayTracks.value.findIndex((x) => x.id === id)
+  if (idx >= 0) displayTracks.value.splice(idx, 1)
+}
 </script>
 
 <style scoped>

--- a/src/components/ui/AmbientLoopPlayer.vue
+++ b/src/components/ui/AmbientLoopPlayer.vue
@@ -1,0 +1,281 @@
+<template>
+  <!-- 双 <audio> 实例：关闭原生 loop，在循环尾部用等功率交叉淡入淡出重叠播放，消除循环点击 -->
+  <audio
+    ref="audioA"
+    @ended="handleEnded('A')"
+    @timeupdate="handleTimeUpdate('A')"
+  ></audio>
+  <audio
+    ref="audioB"
+    @ended="handleEnded('B')"
+    @timeupdate="handleTimeUpdate('B')"
+  ></audio>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    src: string
+    volume: number // 0-1 有效音量（单轨音量 * 全局环境音音量）
+    loop?: boolean
+    fade?: boolean // 入场/出场是否启用淡入淡出
+    paused?: boolean
+    stopped?: boolean // true 时淡出后通知父级移除
+  }>(),
+  {
+    loop: true,
+    fade: true,
+    paused: false,
+    stopped: false,
+  },
+)
+
+const emit = defineEmits<{
+  (e: 'stopped-done'): void
+}>()
+
+const audioA = ref<HTMLAudioElement | null>(null)
+const audioB = ref<HTMLAudioElement | null>(null)
+
+// 淡入淡出时长
+const ENTRY_FADE_MS = 1000
+const EXIT_FADE_MS = 1000
+const LOOP_CROSSFADE_MS = 2000 // 循环交叉淡入淡出略长于入场/出场，掩盖点击更稳
+
+let fadeRaf: number | null = null
+let crossRaf: number | null = null
+const cancelFade = () => {
+  if (fadeRaf !== null) {
+    cancelAnimationFrame(fadeRaf)
+    fadeRaf = null
+  }
+}
+const cancelCross = () => {
+  if (crossRaf !== null) {
+    cancelAnimationFrame(crossRaf)
+    crossRaf = null
+  }
+}
+
+let activeKey: 'A' | 'B' = 'A'
+let otherKey: 'A' | 'B' | null = null
+let crossfading = false
+let stopping = false
+let started = false
+let targetVolume = props.volume
+
+const getEl = (k: 'A' | 'B'): HTMLAudioElement | null => (k === 'A' ? audioA.value : audioB.value)
+
+const rampVolume = (
+  el: HTMLAudioElement,
+  from: number,
+  to: number,
+  ms: number,
+  onDone?: () => void,
+) => {
+  cancelFade()
+  const start = performance.now()
+  const step = (now: number) => {
+    const p = Math.min((now - start) / ms, 1)
+    el.volume = Math.max(0, Math.min(1, from + (to - from) * p))
+    if (p < 1) fadeRaf = requestAnimationFrame(step)
+    else {
+      fadeRaf = null
+      onDone?.()
+    }
+  }
+  fadeRaf = requestAnimationFrame(step)
+}
+
+const beginCrossfade = () => {
+  if (crossfading || stopping || !props.loop) return
+  const active = getEl(activeKey)
+  const nextKey: 'A' | 'B' = activeKey === 'A' ? 'B' : 'A'
+  const next = getEl(nextKey)
+  if (!active || !next) return
+
+  const dur = active.duration
+  // 流式/未知时长交给 ended 兜底
+  if (!isFinite(dur) || dur <= 0) return
+  const cfMs = Math.min(LOOP_CROSSFADE_MS, (dur / 3) * 1000)
+  if (cfMs <= 0) return
+
+  next.src = props.src
+  next.load()
+  next.volume = 0
+  next.play().catch(() => {})
+
+  crossfading = true
+  otherKey = nextKey
+  const start = performance.now()
+  const animate = (now: number) => {
+    if (stopping) {
+      crossfading = false
+      otherKey = null
+      crossRaf = null
+      return
+    }
+    const p = Math.min((now - start) / cfMs, 1)
+    // 等功率曲线：cos²+sin²=1，总功率恒定，对噪声类环境音比线性更自然
+    const gOut = Math.cos((p * Math.PI) / 2)
+    const gIn = Math.sin((p * Math.PI) / 2)
+    active.volume = Math.max(0, Math.min(1, targetVolume * gOut))
+    next.volume = Math.max(0, Math.min(1, targetVolume * gIn))
+    if (p < 1) {
+      crossRaf = requestAnimationFrame(animate)
+    } else {
+      active.pause()
+      active.currentTime = 0
+      active.volume = 0
+      crossRaf = null
+      crossfading = false
+      otherKey = null
+      activeKey = nextKey
+    }
+  }
+  crossRaf = requestAnimationFrame(animate)
+}
+
+const handleTimeUpdate = (k: 'A' | 'B') => {
+  if (k !== activeKey || crossfading || stopping || !props.loop) return
+  const el = getEl(k)
+  if (!el) return
+  const dur = el.duration
+  if (!isFinite(dur) || dur <= 0) return
+  const cfSec = Math.min(LOOP_CROSSFADE_MS / 1000, dur / 3)
+  if (el.currentTime >= dur - cfSec) beginCrossfade()
+}
+
+// 兜底：主路径未生效（如标签页被节流、timeupdate 暂停）时由 ended 触发
+const handleEnded = (k: 'A' | 'B') => {
+  if (k !== activeKey || crossfading || stopping) return
+  if (props.loop) beginCrossfade()
+}
+
+const stopWithFade = () => {
+  stopping = true
+  cancelCross()
+  crossfading = false
+  otherKey = null
+  const active = getEl(activeKey)
+  if (!active) {
+    emit('stopped-done')
+    return
+  }
+  if (!props.fade) {
+    active.volume = 0
+    active.pause()
+    emit('stopped-done')
+    return
+  }
+  const from = active.volume
+  rampVolume(active, from, 0, EXIT_FADE_MS, () => {
+    getEl('A')?.pause()
+    getEl('B')?.pause()
+    emit('stopped-done')
+  })
+}
+
+onMounted(() => {
+  const active = getEl(activeKey)
+  if (!active) return
+  targetVolume = props.volume
+  active.src = props.src
+  active.load()
+  if (props.fade) {
+    active.volume = 0
+  } else {
+    active.volume = props.volume
+  }
+  if (!props.paused && !props.stopped) {
+    active.play().catch((e) => console.warn('环境音播放失败:', e))
+    if (props.fade) rampVolume(active, 0, props.volume, ENTRY_FADE_MS)
+  }
+  started = true
+})
+
+watch(
+  () => props.src,
+  (newSrc) => {
+    if (!started || stopping) return
+    cancelCross()
+    crossfading = false
+    otherKey = null
+    const other = getEl(activeKey === 'A' ? 'B' : 'A')
+    if (other) {
+      other.pause()
+      other.src = ''
+    }
+    const active = getEl(activeKey)
+    if (!active) return
+    targetVolume = props.volume
+    active.src = newSrc
+    active.load()
+    if (props.fade) {
+      active.volume = 0
+      if (!props.paused && !props.stopped) {
+        active.play().catch(() => {})
+        rampVolume(active, 0, props.volume, ENTRY_FADE_MS)
+      }
+    } else {
+      active.volume = props.volume
+      if (!props.paused && !props.stopped) active.play().catch(() => {})
+    }
+  },
+)
+
+watch(
+  () => props.volume,
+  (v) => {
+    targetVolume = v
+    if (crossfading || stopping) return
+    const active = getEl(activeKey)
+    if (active) {
+      cancelFade()
+      active.volume = v
+    }
+  },
+)
+
+watch(
+  () => props.paused,
+  (isPaused) => {
+    if (stopping) return
+    const active = getEl(activeKey)
+    const other = otherKey ? getEl(otherKey) : null
+    if (isPaused) {
+      active?.pause()
+      other?.pause()
+    } else {
+      if (active && active.src) active.play().catch(() => {})
+      if (crossfading && other && other.src) other.play().catch(() => {})
+    }
+  },
+)
+
+watch(
+  () => props.stopped,
+  (s) => {
+    if (s && !stopping) stopWithFade()
+  },
+)
+
+onBeforeUnmount(() => {
+  cancelFade()
+  cancelCross()
+  const a = getEl('A')
+  const b = getEl('B')
+  if (a) {
+    a.volume = 0
+    a.pause()
+    a.src = ''
+  }
+  if (b) {
+    b.volume = 0
+    b.pause()
+    b.src = ''
+  }
+})
+</script>


### PR DESCRIPTION
## 原问题

环境音系统使用 HTML5 原生 `audio.loop` 循环，文件播放到末尾时 `currentTime` 瞬间重置为 0 继续播放——这是一次硬切。只要音频文件首尾波形未对齐（mp3/wav/m4a 几乎都不对齐），每次循环都产生 click / 爆音，即"听觉断点"。

原有的淡入淡出（`FADE_DURATION=1000ms`）只在**加轨道**和**删轨道**时各跑一次，循环期间音量恒定，完全不参与每次 loop 的衔接，因此淡入淡出效果过弱 / 缺失。

## 本PR解决方案

复用 BGM 的 `AudioAcrossFade` 双元素交叉淡入淡出思路，新增 `AmbientLoopPlayer.vue`，每条环境音轨道一个实例：

- **关闭原生 `loop`**，在循环尾部用**等功率曲线**（`cos²+sin²`，总功率恒定）让两个 `<audio>` 重叠播放约 2000ms 完成交接。任一元素的文件末尾→开头硬切都发生在它已被淡到 ≈0 的时刻，点击被另一全音量副本掩盖。
- `timeupdate` 主路径触发 + `ended` 兜底（应对标签页被节流、`timeupdate` 暂停）。
- 入场 / 出场沿用原 `fade` 标志，1000ms 线性斜坡，行为与改造前一致。
- 过短音轨按 `dur/3` 比例缩短交叉时间；流式 / 未知 `duration` 交由 `ended` 兜底。

`GameBackground.vue` 的环境音渲染下沉到新组件，移除原 `ambientRefs` / `fadeInAmbient` / `fadeOutAmbient` 及三个 watcher，改为 `displayTracks` 镜像 + `@stopped-done` 回调，职责与 BGM 使用 `AudioAcrossFade` 的解耦方式完全对称。

## 改动的文件

| 文件 | 说明 |
|------|------|
| `src/components/ui/AmbientLoopPlayer.vue` | 新增，双 `<audio>` 交叉淡入淡出循环播放器 |
| `src/components/game/standard/GameBackground.vue` | 环境音渲染改用新组件，删除原环境音管理逻辑 |

## 兼容性

- `ambientTracks` 的 store 结构、`addAmbientTrack` / `clearAmbientTracks` 等 API 未变，剧本事件、声效面板、设置页均无需改动。
- `fade` 标志语义不变，默认 `true`。

## 检查验证

- [x] 完整编译通过
- [x] 实机运行
- [x] 试听


