### PR TITLE
feat(llm): Kimi Code K3 支持推理深度（reasoning effort）设置

### DIFF
--- a/src-tauri/src/ai_service/llm/mod.rs
+++ b/src-tauri/src/ai_service/llm/mod.rs
@@ -32,6 +32,8 @@ pub struct LlmConfig {
     pub temperature: Option<f64>,
     pub top_p: Option<f64>,
     pub enable_thinking: bool,
+    /// 推理深度（如 "low" / "high" / "max"），目前仅 Kimi Code 的 K3 模型使用。
+    pub reasoning_effort: Option<String>,
 }
 
 impl LlmConfig {

--- a/src-tauri/src/ai_service/llm/provider_config.rs
+++ b/src-tauri/src/ai_service/llm/provider_config.rs
@@ -32,6 +32,9 @@ pub struct LlmProviderConfig {
     pub top_p: Option<f64>,
     #[serde(default)]
     pub enable_thinking: bool,
+    /// 推理深度（如 "low" / "high" / "max"），目前仅 Kimi Code 的 K3 模型使用。
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
 }
 
 impl LlmProviderConfig {
@@ -49,6 +52,7 @@ impl LlmProviderConfig {
             temperature: self.temperature,
             top_p: self.top_p,
             enable_thinking: self.enable_thinking,
+            reasoning_effort: self.reasoning_effort.clone(),
         }
     }
 }
@@ -235,6 +239,7 @@ pub fn migrate_if_needed(app: &AppHandle) {
             temperature: old_temperature,
             top_p: old_top_p,
             enable_thinking: old_thinking,
+            reasoning_effort: None,
         });
         chat_id = Some(id);
     }
@@ -267,6 +272,7 @@ pub fn migrate_if_needed(app: &AppHandle) {
                 temperature: None,
                 top_p: None,
                 enable_thinking: false,
+                reasoning_effort: None,
             });
             translate_id = Some(id);
         }

--- a/src-tauri/src/ai_service/llm/providers/kimi_code.rs
+++ b/src-tauri/src/ai_service/llm/providers/kimi_code.rs
@@ -54,6 +54,7 @@ pub struct KimiCodeProvider {
     temperature: Option<f64>,
     top_p: Option<f64>,
     enable_thinking: bool,
+    reasoning_effort: Option<String>,
 }
 
 impl KimiCodeProvider {
@@ -76,6 +77,7 @@ impl KimiCodeProvider {
             temperature: cfg.temperature,
             top_p: cfg.top_p,
             enable_thinking: cfg.enable_thinking,
+            reasoning_effort: cfg.reasoning_effort.clone(),
         })
     }
 
@@ -127,6 +129,10 @@ impl KimiCodeProvider {
             }
         }
 
+        // 推理深度（K3）：对齐 kimi-code 的做法，在 thinking 中携带
+        // effort: "low"|"high"|"max"，未设置则不携带 effort 字段。
+        let reasoning_effort = self.reasoning_effort.clone().filter(|e| !e.is_empty());
+
         MessagesRequest {
             model: &self.model,
             max_tokens: 65536,
@@ -141,14 +147,19 @@ impl KimiCodeProvider {
             messages: conversation,
             tools,
             tool_choice,
-            thinking: if self.enable_thinking {
-                Some(ThinkingConfig {
-                    type_: "enabled".to_string(),
-                })
-            } else {
-                Some(ThinkingConfig {
-                    type_: "disabled".to_string(),
-                })
+            thinking: {
+                // 设置了推理深度时视为启用思考链（K3 始终开启思考）
+                if reasoning_effort.is_some() || self.enable_thinking {
+                    Some(ThinkingConfig {
+                        type_: "enabled".to_string(),
+                        effort: reasoning_effort.clone(),
+                    })
+                } else {
+                    Some(ThinkingConfig {
+                        type_: "disabled".to_string(),
+                        effort: None,
+                    })
+                }
             },
         }
     }
@@ -466,6 +477,9 @@ struct AnthropicMessage<'a> {
 struct ThinkingConfig {
     #[serde(rename = "type")]
     type_: String,
+    /// K3 推理深度："low" | "high" | "max"，未设置则不携带该字段
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effort: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src/api/services/llm-providers.ts
+++ b/src/api/services/llm-providers.ts
@@ -10,6 +10,7 @@ export interface LlmProviderConfig {
   temperature: number | null
   top_p: number | null
   enable_thinking: boolean
+  reasoning_effort: string | null
 }
 
 export interface LlmProvidersResponse {

--- a/src/components/settings/pages/SettingsLlmProviders.vue
+++ b/src/components/settings/pages/SettingsLlmProviders.vue
@@ -410,6 +410,39 @@
               </p>
             </div>
 
+            <!-- Reasoning effort (K3) -->
+            <div v-if="showReasoningEffort" class="flex flex-col gap-1">
+              <label class="text-xs font-medium text-white/60">推理深度（K3 支持）</label>
+              <div class="relative">
+                <select
+                  v-model="editing.reasoning_effort"
+                  class="w-full appearance-none pl-3 pr-8 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm outline-none focus:border-brand transition-colors cursor-pointer"
+                >
+                  <option :value="null" class="bg-gray-800 text-white">默认（跟随模型）</option>
+                  <option value="low" class="bg-gray-800 text-white">Low（低）</option>
+                  <option value="high" class="bg-gray-800 text-white">High（高）</option>
+                  <option value="max" class="bg-gray-800 text-white">Max（最强）</option>
+                </select>
+                <div
+                  class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2.5"
+                >
+                  <svg
+                    class="w-4 h-4 text-white/40"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </div>
+
             <!-- API Key -->
             <div class="flex flex-col gap-1">
               <label class="text-xs font-medium text-white/60">API 密钥</label>
@@ -554,7 +587,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, reactive } from 'vue'
+import { ref, onMounted, reactive, computed, watch } from 'vue'
 import { useLlmProvidersStore } from '@/stores/modules/llm-providers'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import { invoke } from '@tauri-apps/api/core'
@@ -597,6 +630,7 @@ function emptyProvider(): LlmProviderConfig {
     temperature: null,
     top_p: null,
     enable_thinking: false,
+    reasoning_effort: null,
   }
 }
 
@@ -604,6 +638,16 @@ function closePanel() {
   sidePanel.value = null
   saveMessage.value = ''
 }
+
+// K3 推理深度：仅 Kimi Code 且模型为 k3 时显示
+const showReasoningEffort = computed(
+  () => editing.provider === 'kimicode' && editing.model === 'k3',
+)
+
+// 切到不支持推理深度的模型/提供商时清掉已选档位，避免残留值被静默发往其他模型
+watch([() => editing.provider, () => editing.model], () => {
+  if (!showReasoningEffort.value) editing.reasoning_effort = null
+})
 
 function resetModelList() {
   availableModels.value = []

--- a/src/stores/modules/llm-providers.ts
+++ b/src/stores/modules/llm-providers.ts
@@ -50,6 +50,7 @@ export const useLlmProvidersStore = defineStore('llm-providers', {
       temperature: null,
       top_p: null,
       enable_thinking: false,
+      reasoning_effort: null,
     }),
   },
   actions: {


### PR DESCRIPTION
## 概述

为 Kimi Code（kimicode）提供商的 K3 模型增加「推理深度」设置，对齐 kimi-code 官方 CLI 的行为：K3 始终开启思考，可通过 thinking 中的 effort 档位调节推理深度（low / high / max）。

## 改动

- **设置界面**：编辑模型对话框中，选中 K3 (k3) 时自动显示「推理深度」下拉（默认(跟随模型)/Low/High/Max），位于模型名称下方；切换到其他模型或提供商时自动隐藏并清空已选档位
- **配置链路**：`LlmProviderConfig` 与 `LlmConfig` 新增 `reasoning_effort: Option<String>`（`#[serde(default)]`，旧 settings.json 无缝兼容）
- **请求层**：`MessagesRequest.thinking` 在已有 `type` 基础上扩展可选 `effort` 字段；仅当用户选择了档位时携带，未选择时不改变现有请求体；设置推理深度时视为启用思考链

## 验证

- 实测 `https://api.kimi.com/coding/v1/messages`：`thinking: {type: "enabled", effort: "low|high|max"}` 被正常接受，异常档位值静默回退、不报错
- `vue-tsc --noEmit`、`cargo check` 通过
- 参考：kimi-code 官方 CLI 对 K3 的实现（thinking.type=enabled + effort 档位，档位来自模型元数据）