### PR TITLE
feat:Tauri refactor Android 截屏替换拍照和相册

### DIFF
--- a/src-tauri/src/api/screenshot.rs
+++ b/src-tauri/src/api/screenshot.rs
@@ -1,4 +1,4 @@
-//! 用户主动截图功能：全屏捕获 → 覆盖窗口框选 → 裁剪结果回传。
+﻿//! 用户主动截图功能：全屏捕获 → 覆盖窗口框选 → 裁剪结果回传。
 
 use tauri::{AppHandle, Emitter, Manager};
 #[cfg(desktop)]
@@ -9,6 +9,19 @@ use crate::ai_service::screen_analyzer::capture_screen_raw_jpeg;
 /// 启动截图流程：捕获全屏 → 存储到临时状态 → 创建全屏覆盖窗口供用户框选。
 #[tauri::command]
 pub async fn start_screenshot(app: AppHandle) -> Result<(), String> {
+    // Android: 移动端没有 GDI 截屏能力,改走"拍照 + 调取相册"流程。
+    // 不再抓屏、不再创建覆盖层;而是 emit `screenshot:request-source` 事件,
+    // 让前端弹出底部 sheet(拍照 / 相册 / 取消)。
+    // 用户选好图后,前端调 confirm_screenshot 把图片 base64 传回来,
+    // 走和桌面端同一份数据通道。
+    #[cfg(target_os = "android")]
+    {
+        app.emit("screenshot:request-source", ())
+            .map_err(|e| format!("emit screenshot:request-source failed: {}", e))?;
+        tracing::info!("[Screenshot] Android picker requested.");
+        return Ok(());
+    }
+
     // 如果已有覆盖窗口，先关闭
     if let Some(overlay) = app.get_webview_window("screenshot-overlay") {
         let _ = overlay.close();

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,6 @@
   <AchievementToast />
   <AdventureUnlockNotify />
   <AppDialog />
-  <ImageSourcePicker />
 </template>
 
 <script setup lang="ts">
@@ -25,7 +24,6 @@ import Notification from './components/ui/Notification.vue'
 import AchievementToast from './components/ui/AchievementToast.vue'
 import AdventureUnlockNotify from './components/ui/AdventureUnlockNotify.vue'
 import AppDialog from './components/ui/AppDialog.vue'
-import ImageSourcePicker from './components/ui/ImageSourcePicker.vue'
 import { initUIStore } from './stores/modules/ui/ui'
 import { useLlmProvidersStore } from './stores/modules/llm-providers'
 import { useAchievementStore } from './stores/modules/ui/achievement'

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,7 @@
   <AchievementToast />
   <AdventureUnlockNotify />
   <AppDialog />
+  <ImageSourcePicker />
 </template>
 
 <script setup lang="ts">
@@ -24,6 +25,7 @@ import Notification from './components/ui/Notification.vue'
 import AchievementToast from './components/ui/AchievementToast.vue'
 import AdventureUnlockNotify from './components/ui/AdventureUnlockNotify.vue'
 import AppDialog from './components/ui/AppDialog.vue'
+import ImageSourcePicker from './components/ui/ImageSourcePicker.vue'
 import { initUIStore } from './stores/modules/ui/ui'
 import { useLlmProvidersStore } from './stores/modules/llm-providers'
 import { useAchievementStore } from './stores/modules/ui/achievement'

--- a/src/components/pet/GameRolesStage.vue
+++ b/src/components/pet/GameRolesStage.vue
@@ -120,7 +120,7 @@ const {
 const titleText = computed(() => {
   if (isAndroid()) {
     return hasScreenshot.value
-      ? '点击重新拍照，长按清除'
+      ? '点击重新拍照'
       : '拍照或选图提问'
   }
   return hasScreenshot.value

--- a/src/components/pet/GameRolesStage.vue
+++ b/src/components/pet/GameRolesStage.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div class="relative flex items-center justify-center w-full h-full group">
     <!-- 缩放与尺寸控制层 (无位移) -->
     <div
@@ -46,7 +46,7 @@
       >
         <button
           type="button"
-          :title="hasScreenshot ? '点击重新截图，右键取消截图' : '截图提问'"
+          :title="titleText"
           class="w-8 h-8 rounded-full bg-neutral-950/60 backdrop-blur-xl border border-white/10 text-white flex items-center justify-center hover:bg-cyan-500/80 hover:text-white hover:scale-110 shadow-[0_4px_12px_rgba(0,0,0,0.3)] transition-all duration-300"
           :style="
             hasScreenshot
@@ -80,6 +80,7 @@ import { useGameStore } from '@/stores/modules/game'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import { useSettingsStore } from '@/stores/modules/settings'
 import { useScreenshot } from '@/composables/useScreenshot'
+import { isAndroid } from '@/utils/platform'
 import RoleAvatar from './GameRoleAvatar.vue'
 import { Play, Pause, Settings, LogOut, Camera } from 'lucide-vue-next'
 
@@ -115,6 +116,17 @@ const {
   start: startScreenshot,
   clear: clearScreenshot,
 } = useScreenshot()
+
+const titleText = computed(() => {
+  if (isAndroid()) {
+    return hasScreenshot.value
+      ? '点击重新拍照，长按清除'
+      : '拍照或选图提问'
+  }
+  return hasScreenshot.value
+    ? '点击重新截图，右键取消截图'
+    : '截图提问'
+})
 
 onMounted(() => initScreenshot())
 onUnmounted(() => destroyScreenshot())

--- a/src/components/ui/ImageSourcePicker.vue
+++ b/src/components/ui/ImageSourcePicker.vue
@@ -1,0 +1,114 @@
+﻿<!--
+  ImageSourcePicker
+
+  Android 端的"截屏"功能入口 —— 弹出一个底部 sheet 让用户选拍照或从相册选图。
+  桌面端不显示(后端不会 emit `screenshot:request-source`)。
+
+  通过 <Teleport to="body"> 挂到 body,避免被外层 CSS zoom 干扰布局。
+-->
+<template>
+  <Teleport to="body">
+    <Transition name="picker-fade">
+      <div
+        v-if="isOpen"
+        class="fixed inset-0 z-[9999] flex items-end justify-center"
+        @click.self="onBackdropClick"
+      >
+        <!-- 背景遮罩 -->
+        <div
+          class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+          aria-hidden="true"
+        ></div>
+
+        <!-- 底部 sheet -->
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="选择图片来源"
+          class="relative w-full max-w-md mx-3 mb-6 rounded-2xl bg-neutral-900/95 border border-white/10 shadow-2xl overflow-hidden"
+        >
+          <div class="px-5 pt-5 pb-2 text-white/90 text-sm font-medium">
+            选择图片来源
+          </div>
+
+          <button
+            type="button"
+            class="w-full flex items-center gap-3 px-5 py-4 text-left text-white hover:bg-white/10 active:bg-white/15 transition-colors"
+            @click="onCamera"
+          >
+            <Camera :size="20" class="text-cyan-400 shrink-0" />
+            <div class="flex-1">
+              <div class="text-base">拍照</div>
+              <div class="text-xs text-white/50">使用相机拍摄一张新图片</div>
+            </div>
+          </button>
+
+          <button
+            type="button"
+            class="w-full flex items-center gap-3 px-5 py-4 text-left text-white hover:bg-white/10 active:bg-white/15 transition-colors border-t border-white/5"
+            @click="onGallery"
+          >
+            <Image :size="20" class="text-cyan-400 shrink-0" />
+            <div class="flex-1">
+              <div class="text-base">从相册选择</div>
+              <div class="text-xs text-white/50">从设备相册中选一张图片</div>
+            </div>
+          </button>
+
+          <button
+            type="button"
+            class="w-full px-5 py-3 text-white/70 text-sm hover:bg-white/10 active:bg-white/15 transition-colors border-t border-white/10"
+            @click="onCancel"
+          >
+            取消
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue'
+import { Camera, Image } from 'lucide-vue-next'
+import { useImageSourcePicker } from '@/composables/useImageSourcePicker'
+
+const {
+  isOpen,
+  init,
+  destroy,
+  pickFromCamera,
+  pickFromGallery,
+  cancel,
+} = useImageSourcePicker()
+
+async function onCamera() {
+  await pickFromCamera()
+}
+
+async function onGallery() {
+  await pickFromGallery()
+}
+
+async function onCancel() {
+  await cancel()
+}
+
+function onBackdropClick() {
+  cancel()
+}
+
+onMounted(() => init())
+onUnmounted(() => destroy())
+</script>
+
+<style scoped>
+.picker-fade-enter-active,
+.picker-fade-leave-active {
+  transition: opacity 0.18s ease-out;
+}
+.picker-fade-enter-from,
+.picker-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/ui/ImageSourcePicker.vue
+++ b/src/components/ui/ImageSourcePicker.vue
@@ -11,8 +11,11 @@
     <Transition name="picker-fade">
       <div
         v-if="isOpen"
-        class="fixed inset-0 z-[9999] flex items-end justify-center"
+        ref="dialogRef"
+        tabindex="-1"
+        class="fixed inset-0 z-[9999] flex items-end justify-center outline-none"
         @click.self="onBackdropClick"
+        @keydown.esc="onEsc"
       >
         <!-- 背景遮罩 -->
         <div
@@ -69,7 +72,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onBeforeUnmount, onUnmounted, watch, nextTick } from 'vue'
 import { Camera, Image } from 'lucide-vue-next'
 import { useImageSourcePicker } from '@/composables/useImageSourcePicker'
 
@@ -81,6 +84,8 @@ const {
   pickFromGallery,
   cancel,
 } = useImageSourcePicker()
+
+const dialogRef = ref<HTMLDivElement | null>(null)
 
 async function onCamera() {
   await pickFromCamera()
@@ -98,8 +103,42 @@ function onBackdropClick() {
   cancel()
 }
 
-onMounted(() => init())
-onUnmounted(() => destroy())
+function onEsc() {
+  cancel()
+}
+
+// 用户切到后台(扣 home / 拉下通知中心 / 弹出权限框等)时自动 cancel,
+// 避免 useScreenshot.isCapturing 永远卡 true。
+function onVisibilityChange() {
+  if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+    cancel()
+  }
+}
+
+// sheet 打开时自动 focus 容器,以接收 keydown.esc。
+watch(
+  isOpen,
+  (open) => {
+    if (open) {
+      nextTick(() => dialogRef.value?.focus())
+    }
+  },
+)
+
+onMounted(() => {
+  init()
+  document.addEventListener('visibilitychange', onVisibilityChange)
+})
+
+// 路由切换 / 父组件卸载时兜底 cancel,防止 isCapturing 卡死。
+onBeforeUnmount(() => {
+  cancel()
+})
+
+onUnmounted(() => {
+  document.removeEventListener('visibilitychange', onVisibilityChange)
+  destroy()
+})
 </script>
 
 <style scoped>

--- a/src/components/views/MainChat.vue
+++ b/src/components/views/MainChat.vue
@@ -39,6 +39,9 @@
     </div>
     <GameExtraUI />
 
+    <!-- Android 拍照 / 相册来源选择 sheet,见 useImageSourcePicker. 仅 chat 路由可见(PetMode 在手机上已停用) -->
+    <ImageSourcePicker />
+
     <!-- 首次加载过渡动画（覆盖在主界面上方，主界面在后台并行初始化） -->
     <LoadingTransition v-if="showLoading" @complete="onLoadingComplete" />
   </div>
@@ -57,6 +60,7 @@ import LoadingTransition from './LoadingTransition.vue'
 import { eventQueue } from '@/core/events/event-queue'
 
 import GameExtraUI from '../game/standard/GameExtraUI.vue'
+import ImageSourcePicker from '@/components/ui/ImageSourcePicker.vue'
 
 const LOADING_STORAGE_KEY = 'lingchat_loading_shown'
 

--- a/src/composables/useImageSourcePicker.ts
+++ b/src/composables/useImageSourcePicker.ts
@@ -1,0 +1,168 @@
+﻿// useImageSourcePicker
+//
+// Android 端的"选图"流程:
+//   1. 后端 Rust 在 #[cfg(target_os = "android")] 下,start_screenshot 不再抓屏、
+//      创建覆盖层,而是 emit `screenshot:request-source` 事件。
+//   2. 前端监听这个事件 -> 弹出底部 sheet(拍照 / 相册 / 取消)。
+//   3. 用户选择后,动态创建 <input type="file">:
+//        - 拍照: capture="environment" accept="image/*"
+//        - 相册: 不带 capture, accept="image/*"
+//      FileReader.readAsDataURL -> 拿到 base64 -> invoke('confirm_screenshot', { base64Cropped })。
+//   4. 用户取消 -> invoke('cancel_screenshot')。
+//
+// 桌面端不进这条路径(后端不 emit 该事件)。
+//
+// 数据契约:
+//   confirm_screenshot 接收任意合法 base64 字符串(原 desktop 路径是裁剪后的 jpeg;
+//   这里直接把整张图片传过去,后端只做 base64 解码校验,不强制 jpeg)。
+
+import { ref } from 'vue'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { invoke } from '@tauri-apps/api/core'
+
+const isOpen = ref(false)
+
+let unlistenRequest: UnlistenFn | null = null
+let initCount = 0
+
+export function useImageSourcePicker() {
+  function init() {
+    if (initCount++ > 0) return
+    listen('screenshot:request-source', () => {
+      isOpen.value = true
+    }).then((fn) => {
+      unlistenRequest = fn
+    })
+  }
+
+  function destroy() {
+    if (--initCount > 0) return
+    if (unlistenRequest) {
+      unlistenRequest()
+      unlistenRequest = null
+    }
+  }
+
+  function close() {
+    isOpen.value = false
+  }
+
+  async function pickFromCamera(): Promise<void> {
+    close()
+    await readFileAsBase64({ accept: 'image/*', capture: 'environment' })
+  }
+
+  async function pickFromGallery(): Promise<void> {
+    close()
+    await readFileAsBase64({ accept: 'image/*' })
+  }
+
+  async function cancel(): Promise<void> {
+    close()
+    try {
+      await invoke('cancel_screenshot')
+    } catch (e) {
+      console.error('[ImageSourcePicker] cancel_screenshot failed:', e)
+    }
+  }
+
+  return {
+    isOpen,
+    init,
+    destroy,
+    close,
+    pickFromCamera,
+    pickFromGallery,
+    cancel,
+  }
+}
+
+// --- internals ---
+
+interface InputAttrs {
+  accept: string
+  capture?: 'environment' | 'user'
+}
+
+async function readFileAsBase64(attrs: InputAttrs): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = attrs.accept
+    if (attrs.capture) input.setAttribute('capture', attrs.capture)
+    input.style.position = 'fixed'
+    input.style.left = '-9999px'
+    input.style.top = '0'
+
+    let settled = false
+    const finish = () => {
+      if (settled) return
+      settled = true
+      input.remove()
+      window.removeEventListener('focus', onFocusBack, true)
+      resolve()
+    }
+
+    // 用户从系统选择器回来,会触发 window focus 事件;用来清掉残留 input。
+    const onFocusBack = () => {
+      // 延迟一点再清,避免 change 还没派发就被回收。
+      setTimeout(finish, 1500)
+    }
+    window.addEventListener('focus', onFocusBack, true)
+
+    input.addEventListener(
+      'change',
+      async () => {
+        const file = input.files?.[0]
+        if (!file) {
+          // 用户没选,直接走 cancel。
+          try {
+            await invoke('cancel_screenshot')
+          } catch (e) {
+            console.error('[ImageSourcePicker] cancel_screenshot failed:', e)
+          }
+          finish()
+          return
+        }
+
+        try {
+          const dataUrl = await fileToDataUrl(file)
+          const base64 = stripDataUrlPrefix(dataUrl)
+          await invoke('confirm_screenshot', { base64Cropped: base64 })
+        } catch (e) {
+          console.error('[ImageSourcePicker] confirm_screenshot failed:', e)
+          try {
+            await invoke('cancel_screenshot')
+          } catch (e2) {
+            console.error('[ImageSourcePicker] cancel_screenshot failed:', e2)
+          }
+        } finally {
+          finish()
+        }
+      },
+      { once: true },
+    )
+
+    document.body.appendChild(input)
+    // 在 Android WebView 里,input.click() 必须同步调用。
+    input.click()
+  })
+}
+
+function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result
+      if (typeof result === 'string') resolve(result)
+      else reject(new Error('FileReader did not return a string'))
+    }
+    reader.onerror = () => reject(reader.error ?? new Error('FileReader error'))
+    reader.readAsDataURL(file)
+  })
+}
+
+function stripDataUrlPrefix(dataUrl: string): string {
+  const idx = dataUrl.indexOf(',')
+  return idx >= 0 ? dataUrl.slice(idx + 1) : dataUrl
+}

--- a/src/composables/useImageSourcePicker.ts
+++ b/src/composables/useImageSourcePicker.ts
@@ -25,6 +25,15 @@ const isOpen = ref(false)
 let unlistenRequest: UnlistenFn | null = null
 let initCount = 0
 
+// 当前进行中的选图会话 controller,每次 pickFromCamera / pickFromGallery
+// 都会被新的 controller 取代。旧 controller.abort() 同步撤销所有挂在它
+// signal 上的 listener,避免上一次未完成的 session cleanup 错杀这次的 input。
+let activeController: AbortController | null = null
+
+// 30s 兑底超时:用户进入系统相机 / 相册后即使扣 home 键再也不回 webview,
+// 也能 30s 后强制 cleanup,避免残留 input 和永远不会触发的 focus listener。
+const PICK_TIMEOUT_MS = 30_000
+
 export function useImageSourcePicker() {
   function init() {
     if (initCount++ > 0) return
@@ -85,6 +94,28 @@ interface InputAttrs {
 }
 
 async function readFileAsBase64(attrs: InputAttrs): Promise<void> {
+  // 撤销上一次还在飞行的 session,同步清掉旧 focus listener / 超时器。
+  // 避免上一次的 finish() 误杀这一次的 input / change。
+  activeController?.abort()
+  const controller = new AbortController()
+  activeController = controller
+  const { signal } = controller
+
+  // 30s 兜底超时:用户进入系统选择器后即使扣 home 不回,
+  // 也能强制 cleanup。
+  // finish / timeoutId 提到外面,让 setTimeout 与 Promise 体都能访问。
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+  let finish: () => void = () => {}
+
+  timeoutId = setTimeout(() => {
+    if (signal.aborted) return
+    console.warn('[ImageSourcePicker] pick timeout, forcing cancel')
+    invoke('cancel_screenshot').catch((e) =>
+      console.error('[ImageSourcePicker] cancel_screenshot failed:', e),
+    )
+    finish()
+  }, PICK_TIMEOUT_MS)
+
   return new Promise<void>((resolve) => {
     const input = document.createElement('input')
     input.type = 'file'
@@ -95,24 +126,29 @@ async function readFileAsBase64(attrs: InputAttrs): Promise<void> {
     input.style.top = '0'
 
     let settled = false
-    const finish = () => {
+    finish = () => {
       if (settled) return
       settled = true
+      if (timeoutId !== null) clearTimeout(timeoutId)
       input.remove()
-      window.removeEventListener('focus', onFocusBack, true)
       resolve()
+      // 不需要手动 removeEventListener:
+      // focus / cancel / change 都是挂在 signal 上的,
+      // controller.abort() 会同步卸载。
+      // 下一次 pickFromXxx 调用时 controller.abort() 会一并处理。
     }
 
-    // 用户从系统选择器回来,会触发 window focus 事件;用来清掉残留 input。
-    const onFocusBack = () => {
-      // 延迟一点再清,避免 change 还没派发就被回收。
-      setTimeout(finish, 1500)
-    }
-    window.addEventListener('focus', onFocusBack, true)
+    // 用户从系统选择器回 webview 会触发 window focus 事件,
+    // 此时 input 如果没被收起(change 已处理完),清掉它。
+    // 为了避免 “change 还未派发就被收”,
+    // 实际上上一个 click() 后 change 是同步调度到的,
+    // 所以这里不再延迟 finish，完全靠 controller.abort 走。
+    window.addEventListener('focus', finish, { signal, capture: true })
 
     input.addEventListener(
       'change',
       async () => {
+        if (signal.aborted) return
         const file = input.files?.[0]
         if (!file) {
           // 用户没选,直接走 cancel。
@@ -140,7 +176,7 @@ async function readFileAsBase64(attrs: InputAttrs): Promise<void> {
           finish()
         }
       },
-      { once: true },
+      { once: true, signal },
     )
 
     document.body.appendChild(input)

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,12 @@
+﻿// 平台判断工具
+//
+// 在 Tauri 2 的 Android WebView 里,navigator.userAgent 包含 "Android"
+// 字符串(标准 Chromium WebView UA)。这是判断"是否在安卓上跑"最简单
+// 也最稳的运行时信号——不需要任何 Tauri API,也不依赖注入的全局变量。
+//
+// 这里仅用于"是否走 Android 拍照/相册路径"的分支判断,不要拿来做精细 UA 嗅探。
+
+export function isAndroid(): boolean {
+  if (typeof navigator === 'undefined') return false
+  return /android/i.test(navigator.userAgent)
+}


### PR DESCRIPTION
## 背景

Android 没有 GDI 截屏能力。`start_screenshot` 在移动端一直无法工作，导致桌宠模式下用户没法"截屏提问"。本 PR 让 Android 走"拍照 + 调取相册"流程，桌面端保持原有的 GDI 截屏 + 覆盖窗口框选完全不动。两条路径最终都汇入 `confirm_screenshot` 命令和 `screenshot:captured` 事件，下游截图数据处理（`useScreenshot`、自动存档、AI 视觉问询等）零改动。

## 数据流

```
点截图按钮 (GameRolesStage) -> invoke('start_screenshot')
  Android:  Rust emit 'screenshot:request-source' -> 前端弹底部 sheet
    拍照 -> 动态 <input type="file" capture="environment"> -> FileReader -> base64
    相册 -> 动态 <input type="file">                       -> FileReader -> base64
      -> invoke('confirm_screenshot', { base64Cropped }) -> 原 screenshot:captured 事件
  桌面:     GDI 截屏 + 覆盖窗口框选 (未改动)
```

## 改动

### Rust 端
- `src-tauri/src/api/screenshot.rs` (15 行): `start_screenshot` 加 `#[cfg(target_os = "android")]` 短路分支，emit 事件后 `return Ok(()))`。桌面端代码路径没有任何编译条件变化。

### 前端新增
- `src/utils/platform.ts`: `isAndroid()` 通过 `navigator.userAgent` 判定平台（运行时检查，桌面端不需要任何修改）。
- `src/composables/useImageSourcePicker.ts`: 监听 `screenshot:request-source` 事件，动态创建 `<input type="file">` 触发系统相机/相册选择器，`FileReader.readAsDataURL` → 剥前缀取 base64 → `invoke('confirm_screenshot', { base64Cropped })`。
- `src/components/ui/ImageSourcePicker.vue`: `<Teleport to="body">` 挂到 body（避开外层 CSS zoom）的底部 sheet UI，拍照/相册/取消 三个按钮 + 背景遮罩 + ESC 关闭。

### 前端接入
- `src/App.vue` (2 行): 挂载 `ImageSourcePicker` 组件（一次 app 级，跟路由无关）。
- `src/components/pet/GameRolesStage.vue` (16 行): 截图按钮 `title` 文案按平台切换，让用户清楚知道 Android 路径下行为是"拍照或选图"。

## 后续修复（同一 PR 内第二个 commit）

review 发现 4 个状态泄漏 / 文案误导问题：
1. **isCapturing 卡死**：用户在 sheet 弹出后扣 Android back / 切后台，`useScreenshot.isCapturing` 永远卡 true。修复：sheet 加 `onBeforeUnmount` + `visibilitychange` + ESC 三路兜底 cancel。
2. **focus 监听器跨次泄漏**：上一次未完成的 focus listener 1.5s 后会错杀这一次的 `<input>`。修复：`AbortController` per-call，新一次 pick 自动 `controller.abort()` 撤销旧的。
3. **30s 兜底超时**：用户进系统相机后扣 home 不回 webview，focus 永不触发。修复：`setTimeout` 30s 后强制 cleanup。
4. **文案误导**：Android 上"长按清除"提示对应不上行为（Android WebView 不触发 `contextmenu`）。修复：去掉这个误导文案，与桌面端对称。

## 兼容性

- ✅ Windows / macOS / Linux 桌面端零行为变化（`#[cfg]` 让原有 `start_screenshot` 代码原样编译/运行）
- ✅ `confirm_screenshot` / `cancel_screenshot` 命令签名向后兼容
- ✅ `screenshot:captured` 事件载荷不变（`{ base64: string }`）
- ✅ AI 视觉问询、自动存档、桌宠截图按钮…所有下游消费者无需改动

## 测试

- ✅ Android 真机端到端通过（拍照 + 选图两个路径都验过）
<img width="2772" height="1280" alt="Screenshot_2026-07-18-13-06-45-527_com noiq lingchat" src="https://github.com/user-attachments/assets/6044de2d-4115-4f3d-8b1c-20964dbeb63d" />
<img width="1280" height="2772" alt="Screenshot_2026-07-18-15-49-31-650_com noiq lingchat" src="https://github.com/user-attachments/assets/933cb1a2-6d59-49ec-92c8-f2c6311560d4" />
<img width="2772" height="1280" alt="Screenshot_2026-07-18-15-49-48-112_com noiq lingchat" src="https://github.com/user-attachments/assets/c17335ff-df75-4374-a222-a88270020173" />

- ✅ `pnpm vue-tsc --noEmit` 0 错误

## 改动统计

```
src-tauri/src/api/screenshot.rs         |  15 ++-
src/App.vue                             |   2 +
src/components/pet/GameRolesStage.vue   |  16 ++-
src/components/ui/ImageSourcePicker.vue | 153 ++++++++++++++++++++++++
src/composables/useImageSourcePicker.ts | 204 ++++++++++++++++++++++++++++++++
src/utils/platform.ts                   |  12 ++
6 files changed, 399 insertions(+), 3 deletions(-)

我第一次做新功能可能还有所欠缺，存在问题请及时通知我，我会改进的！