### PR TITLE
fix：主动对话设置页隐藏新建按钮并完善视觉感知配置说明

### DIFF
--- a/src-tauri/src/config/keys.rs
+++ b/src-tauri/src/config/keys.rs
@@ -65,6 +65,8 @@ pub const VOICE_LANG: &str = "tts.voice_lang";
 // ========== 主动对话系统 ==========
 pub const ENABLE_PROACTIVE_SYSTEM: &str = "ENABLE_PROACTIVE_SYSTEM";
 pub const MAX_PROACTIVE_TIMES: &str = "MAX_PROACTIVE_TIMES";
+// 旧的视觉模型独立配置键已废弃，视觉模型统一到大模型管理中配置；
+// 这些常量仅保留给迁移逻辑读取旧配置使用。
 pub const VD_API_KEY: &str = "VD_API_KEY";
 pub const VD_BASE_URL: &str = "VD_BASE_URL";
 pub const VD_MODEL: &str = "VD_MODEL";

--- a/src-tauri/src/config/tree.rs
+++ b/src-tauri/src/config/tree.rs
@@ -438,11 +438,12 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
             },
         );
 
-        // 视觉与模型配置
+        // 视觉感知配置（视觉模型本身在「高级设置 → 大模型管理」中以角色形式配置）
         proactive_subs.insert(
-            "视觉与模型配置".to_string(),
+            "视觉感知设置".to_string(),
             Subcategory {
-                description: "主动对话时调用的 Vision LLM 视觉分析模型以及截图分析设置".to_string(),
+                description: "主动对话时的桌面视觉感知开关与触发权重，视觉模型在大模型管理中配置"
+                    .to_string(),
                 settings: vec![
                     ConfigSetting {
                         key: keys::ENABLE_VISUAL_PRECEPTION.to_string(),

--- a/src/components/schedule/ScheduleContent.vue
+++ b/src/components/schedule/ScheduleContent.vue
@@ -106,6 +106,7 @@
         </div>
 
         <button
+          v-show="!uiStore.scheduleView.startsWith('proactive')"
           @click="triggerCreate"
           class="bg-cyan-500 hover:bg-cyan-600 text-white rounded-xl shadow-lg transition-all flex items-center shrink-0"
           :class="uiStore.isNarrowScreen ? 'px-3 py-2 text-sm space-x-1' : 'px-5 py-2.5 space-x-2'"


### PR DESCRIPTION
## 改动内容

- **日程 → 主动对话页**：隐藏右上角无作用的「新建」按钮（`triggerCreate` 本就不处理 proactive 视图，点击无反应）
- **配置树**：「视觉与模型配置」子分类更名为「视觉感知设置」，描述更新为指向「高级设置 → 大模型管理」
- **配置键**：为已废弃的 `VD_API_KEY` / `VD_BASE_URL` / `VD_MODEL` 常量补充废弃注释（仅保留给迁移逻辑读取旧配置）

## 验证

- `vue-tsc --noEmit` 类型检查通过（仅剩与本改动无关的既有报错）
- 完整 `tauri build` 通过，替换部署后运行正常