### PR TITLE
新增：GPT-SoVITS 支持中文、日语、英语和韩语实时切换

### DIFF
--- a/src-tauri/src/ai_service/game_system/role_manager.rs
+++ b/src-tauri/src/ai_service/game_system/role_manager.rs
@@ -13,6 +13,7 @@ use crate::config::tts::TtsConfig;
 use crate::db::entities::line::LineAttribute;
 use crate::db::managers::memory_repo::MemoryRepo;
 use crate::db::managers::role_repo::RoleRepo;
+use crate::utils::path::resolve_character_path;
 
 /// 角色运行时管理器：维护当前活跃角色的内存状态。
 pub struct GameRoleManager {
@@ -541,15 +542,6 @@ impl GameRoleManager {
 ///
 /// 未启用 TTS / 配置缺失时返回 `None`。对应 Python `GameRole` 构造时调用
 /// `voice_maker = VoiceMaker(...)`。
-fn resolve_character_path(data_dir: &Path, resource_path: &str) -> PathBuf {
-    let path = PathBuf::from(resource_path);
-    if path.is_absolute() {
-        path
-    } else {
-        data_dir.join("game_data").join("characters").join(path)
-    }
-}
-
 fn build_voice_maker(
     data_dir: &Path,
     settings: &CharacterSettings,
@@ -585,24 +577,5 @@ fn build_voice_maker(
             tracing::warn!("VoiceMaker 初始化失败: {e}");
             None
         }
-    }
-}
-
-#[cfg(test)]
-mod voice_path_tests {
-    use super::*;
-
-    #[test]
-    fn relative_character_resource_path_resolves_under_game_data() {
-        let data_dir = PathBuf::from("data");
-        let resolved = resolve_character_path(&data_dir, "example-role");
-
-        assert_eq!(
-            resolved,
-            PathBuf::from("data")
-                .join("game_data")
-                .join("characters")
-                .join("example-role")
-        );
     }
 }

--- a/src-tauri/src/ai_service/game_system/role_manager.rs
+++ b/src-tauri/src/ai_service/game_system/role_manager.rs
@@ -380,12 +380,52 @@ impl GameRoleManager {
         Ok(())
     }
 
-    /// 更新已加载角色的语音语言并重新初始化其 VoiceMaker。
-    pub fn update_role_voice_lang(
+    /// 用最新角色配置更新已加载角色的 TTS 设置，并立即重建 VoiceMaker。
+    ///
+    /// 返回角色当前是否已经加载；未加载时磁盘配置仍会在下次注册角色时生效。
+    pub fn update_role_voice_settings(
         &mut self,
         role_id: i32,
-        lang: &str,
-    ) {
+        settings: &CharacterSettings,
+    ) -> bool {
+        let Some(resource_path) = self
+            .loaded_roles
+            .get(&role_id)
+            .map(|role| role.resource_path.clone())
+        else {
+            tracing::info!("角色 {} 尚未加载，TTS 设置将在下次加载时生效", role_id);
+            return false;
+        };
+
+        let voice_maker = build_voice_maker(
+            &self.data_dir,
+            settings,
+            resource_path.as_deref(),
+            &self.tts_config,
+        );
+        let voice_maker_ready = voice_maker.is_some();
+
+        let role = self
+            .loaded_roles
+            .get_mut(&role_id)
+            .expect("loaded role disappeared while updating TTS settings");
+        role.settings.tts_type = settings.tts_type.clone();
+        role.settings.voice_lang = settings.voice_lang.clone();
+        role.settings.voice_models = settings.voice_models.clone();
+        role.voice_maker = voice_maker;
+
+        tracing::info!(
+            "角色 {} TTS 已实时刷新: type={}, lang={}, ready={}",
+            role_id,
+            role.settings.tts_type.as_deref().unwrap_or(""),
+            role.settings.voice_lang.as_deref().unwrap_or(""),
+            voice_maker_ready,
+        );
+        true
+    }
+
+    /// 更新已加载角色的语音语言并重新初始化其 VoiceMaker。
+    pub fn update_role_voice_lang(&mut self, role_id: i32, lang: &str) {
         let Some(role) = self.loaded_roles.get_mut(&role_id) else {
             tracing::warn!("update_role_voice_lang: 角色 {} 未加载", role_id);
             return;
@@ -501,6 +541,15 @@ impl GameRoleManager {
 ///
 /// 未启用 TTS / 配置缺失时返回 `None`。对应 Python `GameRole` 构造时调用
 /// `voice_maker = VoiceMaker(...)`。
+fn resolve_character_path(data_dir: &Path, resource_path: &str) -> PathBuf {
+    let path = PathBuf::from(resource_path);
+    if path.is_absolute() {
+        path
+    } else {
+        data_dir.join("game_data").join("characters").join(path)
+    }
+}
+
 fn build_voice_maker(
     data_dir: &Path,
     settings: &CharacterSettings,
@@ -516,7 +565,9 @@ fn build_voice_maker(
     voice_cfg.opentts_voice = Some(tts_config.opentts_voice.clone());
 
     let audio_format = tts_config.audio_format.clone();
-    let lang = settings.voice_lang.as_deref()
+    let lang = settings
+        .voice_lang
+        .as_deref()
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
         .unwrap_or(&tts_config.voice_lang)
@@ -526,7 +577,7 @@ fn build_voice_maker(
     let mut vm = VoiceMaker::new(temp_dir, audio_format, tts_config.clone());
     vm.set_lang(&lang);
     if let Some(p) = resource_path {
-        vm.set_character_path(Some(PathBuf::from(p)));
+        vm.set_character_path(Some(resolve_character_path(data_dir, p)));
     }
     match vm.set_tts_settings(&voice_cfg, tts_type, &settings.ai_name) {
         Ok(()) => Some(vm),
@@ -534,5 +585,24 @@ fn build_voice_maker(
             tracing::warn!("VoiceMaker 初始化失败: {e}");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod voice_path_tests {
+    use super::*;
+
+    #[test]
+    fn relative_character_resource_path_resolves_under_game_data() {
+        let data_dir = PathBuf::from("data");
+        let resolved = resolve_character_path(&data_dir, "example-role");
+
+        assert_eq!(
+            resolved,
+            PathBuf::from("data")
+                .join("game_data")
+                .join("characters")
+                .join("example-role")
+        );
     }
 }

--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -646,16 +646,3 @@ async fn add_assistant_line(deps: &GeneratorDeps, response: &ReplyResponse) -> R
     gs.add_line(&deps.db, line).await?;
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn only_gsv_enables_english_and_korean_translation() {
-        assert_eq!(gsv_translation_language("gsv", "en"), Some("en"));
-        assert_eq!(gsv_translation_language("gsv", "ko"), Some("ko"));
-        assert_eq!(gsv_translation_language("gsv", "zh"), None);
-        assert_eq!(gsv_translation_language("opentts", "en"), None);
-    }
-}

--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -516,22 +516,50 @@ fn parse_segments(deps: &GeneratorDeps, sentence: &str) -> Vec<EmotionSegment> {
     segments
 }
 
-/// Step B: 翻译（中文→日文）与语音生成。
+fn gsv_translation_language(tts_type: &str, voice_lang: &str) -> Option<&'static str> {
+    if tts_type != "gsv" {
+        return None;
+    }
+    match voice_lang {
+        "en" => Some("en"),
+        "ko" => Some("ko"),
+        _ => None,
+    }
+}
+
+/// Step B: 翻译与语音生成。
 async fn enrich_segments(deps: &GeneratorDeps, segments: &mut [EmotionSegment]) -> Result<()> {
-    // 翻译：当第一段 japanese_text 为空时
-    if segments[0].japanese_text.is_empty() {
+    let (voice_maker, tts_type, voice_lang) = {
+        let gs = deps.game_status.lock().await;
+        gs.current_role_id
+            .and_then(|rid| {
+                gs.role_manager.get_loaded(rid).map(|role| {
+                    (
+                        role.voice_maker.clone(),
+                        role.settings.tts_type.clone().unwrap_or_default(),
+                        role.settings.voice_lang.clone().unwrap_or_default(),
+                    )
+                })
+            })
+            .unwrap_or_default()
+    };
+
+    if let Some(target_lang) = gsv_translation_language(&tts_type, &voice_lang) {
+        let translated = deps
+            .translator
+            .translate_segments_to(segments, true, target_lang)
+            .await?;
+        if !translated {
+            // Do not let GPT-SoVITS pronounce the main LLM's Japanese secondary
+            // line when the explicitly selected English/Korean translation fails.
+            for segment in segments.iter_mut() {
+                segment.japanese_text.clear();
+            }
+        }
+    } else if segments[0].japanese_text.is_empty() {
         deps.translator.translate_segments(segments, false).await?;
     }
 
-    // 语音：取当前角色的 voice_maker 生成语音文件
-    let voice_maker = {
-        let gs = deps.game_status.lock().await;
-        gs.current_role_id.and_then(|rid| {
-            gs.role_manager
-                .get_loaded(rid)
-                .and_then(|r| r.voice_maker.clone())
-        })
-    };
     if let Some(vm) = voice_maker {
         vm.generate_voice_files(segments).await;
     }
@@ -617,4 +645,17 @@ async fn add_assistant_line(deps: &GeneratorDeps, response: &ReplyResponse) -> R
     let mut gs = deps.game_status.lock().await;
     gs.add_line(&deps.db, line).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_gsv_enables_english_and_korean_translation() {
+        assert_eq!(gsv_translation_language("gsv", "en"), Some("en"));
+        assert_eq!(gsv_translation_language("gsv", "ko"), Some("ko"));
+        assert_eq!(gsv_translation_language("gsv", "zh"), None);
+        assert_eq!(gsv_translation_language("opentts", "en"), None);
+    }
 }

--- a/src-tauri/src/ai_service/translator.rs
+++ b/src-tauri/src/ai_service/translator.rs
@@ -15,7 +15,24 @@ use crate::ai_service::llm::{slot_snapshot, LlmSlot};
 use crate::ai_service::message_system::processor::EmotionSegment;
 use crate::ai_service::types::LlmMessage;
 
-const TRANSLATOR_SYSTEM_PROMPT: &str = "\n            你是一个二次元角色中文台词翻译师，任务是翻译二次元台词对话，\n            将中文翻译成日语，允许意译。确保你的翻译符合二次元的发言习惯，而不是生硬的直译，保持流畅自然生动。\n            除了翻译内容，你不提供额外的解释，并且你的翻译句子必须包裹在<>符号内，否则会导致严重错误。\n            比如，原文内容为：\n            <你好呀莱姆，今天过的怎么样呀？><哎？有点不高兴吗？没关系~>\n            那么你的回复内容为：\n            <はいはい、レムちゃん、今日はどうだった？><えっ？なんだかご機嫌ななめ？大丈夫だよ～>\n            ";
+const JAPANESE_TRANSLATOR_SYSTEM_PROMPT: &str = "\n            你是一个二次元角色中文台词翻译师，任务是翻译二次元台词对话，\n            将中文翻译成日语，允许意译。确保你的翻译符合二次元的发言习惯，而不是生硬的直译，保持流畅自然生动。\n            除了翻译内容，你不提供额外的解释，并且你的翻译句子必须包裹在<>符号内，否则会导致严重错误。\n            比如，原文内容为：\n            <你好呀莱姆，今天过的怎么样呀？><哎？有点不高兴吗？没关系~>\n            那么你的回复内容为：\n            <はいはい、レムちゃん、今日はどうだった？><えっ？なんだかご機嫌ななめ？大丈夫だよ～>\n            ";
+
+fn translator_system_prompt(target_lang: &str) -> Option<String> {
+    if target_lang == "ja" {
+        return Some(JAPANESE_TRANSLATOR_SYSTEM_PROMPT.to_string());
+    }
+
+    let (language_name, extra_instruction) = match target_lang {
+        "en" => ("英语", "使用自然、口语化的英语表达。"),
+        "ko" => ("韩语", "使用自然、口语化且符合角色语气的韩语表达。"),
+        _ => return None,
+    };
+
+    Some(format!(
+        "你是一个二次元角色中文台词翻译师。请将每个中文台词片段翻译成{language_name}，允许意译，保持角色语气自然生动。{extra_instruction}\n\
+         只返回翻译结果，不要解释；输出片段数量必须与输入一致，并且每个片段都必须分别包裹在 < 和 > 中。"
+    ))
+}
 
 /// 翻译器。
 pub struct Translator {
@@ -44,30 +61,52 @@ impl Translator {
         segments: &mut [EmotionSegment],
         script: bool,
     ) -> Result<()> {
+        self.translate_segments_to(segments, script, "ja")
+            .await
+            .map(|_| ())
+    }
+
+    /// 将中文台词翻译成指定语言，并返回是否取得了全部片段的译文。
+    pub async fn translate_segments_to(
+        &self,
+        segments: &mut [EmotionSegment],
+        script: bool,
+        target_lang: &str,
+    ) -> Result<bool> {
         if !self.enable && !script {
-            return Ok(());
+            return Ok(false);
         }
+        let Some(system_prompt) = translator_system_prompt(target_lang) else {
+            tracing::warn!("Translator: 不支持的目标语言 {target_lang}，跳过翻译");
+            return Ok(false);
+        };
         let Some(client) = slot_snapshot(&self.client).await else {
             tracing::warn!("Translator: 翻译 LLM 槽位为空，跳过翻译");
-            return Ok(());
+            return Ok(false);
         };
 
         let full_chinese = collect_chinese_part(segments);
         if full_chinese.is_empty() {
-            tracing::warn!("AI回复没有中文，跳过日语翻译");
-            return Ok(());
+            tracing::warn!("AI回复没有可翻译文本，跳过 {target_lang} 翻译");
+            return Ok(false);
         }
 
         let messages = vec![
-            LlmMessage::system(TRANSLATOR_SYSTEM_PROMPT),
+            LlmMessage::system(system_prompt),
             LlmMessage::user(full_chinese),
         ];
 
-        let japanese_response = client.complete(&messages).await?;
-        tracing::info!("完整日语翻译结果: {japanese_response}");
+        let translated_response = client.complete(&messages).await?;
+        tracing::info!("完整 {target_lang} 翻译结果: {translated_response}");
 
-        apply_translation_result(&japanese_response, segments);
-        Ok(())
+        let translated_count = apply_translation_result(&translated_response, segments);
+        if translated_count != segments.len() {
+            tracing::warn!(
+                "Translator: {target_lang} 译文片段不完整: {translated_count}/{}",
+                segments.len()
+            );
+        }
+        Ok(translated_count == segments.len())
     }
 }
 
@@ -82,12 +121,14 @@ fn collect_chinese_part(segments: &[EmotionSegment]) -> String {
 }
 
 /// 从翻译结果中依次抽取 `<...>` 片段并写回到每个 segment 的 `japanese_text`。
-fn apply_translation_result(response: &str, segments: &mut [EmotionSegment]) {
+fn apply_translation_result(response: &str, segments: &mut [EmotionSegment]) -> usize {
     let mut cursor = response;
     let mut idx = 0usize;
     while let Some(start) = cursor.find('<') {
         let after = &cursor[start + 1..];
-        let Some(end_rel) = after.find('>') else { break };
+        let Some(end_rel) = after.find('>') else {
+            break;
+        };
         let jp = &after[..end_rel];
         if idx >= segments.len() {
             break;
@@ -95,5 +136,38 @@ fn apply_translation_result(response: &str, segments: &mut [EmotionSegment]) {
         segments[idx].japanese_text = jp.to_string();
         idx += 1;
         cursor = &after[end_rel + 1..];
+    }
+    idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_prompts_for_gsv_output_languages() {
+        assert!(translator_system_prompt("en").unwrap().contains("英语"));
+        assert!(translator_system_prompt("ko").unwrap().contains("韩语"));
+        assert!(translator_system_prompt("unsupported").is_none());
+    }
+
+    #[test]
+    fn applies_all_translated_segments() {
+        let mut segments = vec![
+            EmotionSegment {
+                following_text: "你好".into(),
+                ..Default::default()
+            },
+            EmotionSegment {
+                following_text: "欢迎回来".into(),
+                ..Default::default()
+            },
+        ];
+
+        let translated = apply_translation_result("<Hello><Welcome back>", &mut segments);
+
+        assert_eq!(translated, 2);
+        assert_eq!(segments[0].japanese_text, "Hello");
+        assert_eq!(segments[1].japanese_text, "Welcome back");
     }
 }

--- a/src-tauri/src/ai_service/translator.rs
+++ b/src-tauri/src/ai_service/translator.rs
@@ -15,14 +15,9 @@ use crate::ai_service::llm::{slot_snapshot, LlmSlot};
 use crate::ai_service::message_system::processor::EmotionSegment;
 use crate::ai_service::types::LlmMessage;
 
-const JAPANESE_TRANSLATOR_SYSTEM_PROMPT: &str = "\n            你是一个二次元角色中文台词翻译师，任务是翻译二次元台词对话，\n            将中文翻译成日语，允许意译。确保你的翻译符合二次元的发言习惯，而不是生硬的直译，保持流畅自然生动。\n            除了翻译内容，你不提供额外的解释，并且你的翻译句子必须包裹在<>符号内，否则会导致严重错误。\n            比如，原文内容为：\n            <你好呀莱姆，今天过的怎么样呀？><哎？有点不高兴吗？没关系~>\n            那么你的回复内容为：\n            <はいはい、レムちゃん、今日はどうだった？><えっ？なんだかご機嫌ななめ？大丈夫だよ～>\n            ";
-
 fn translator_system_prompt(target_lang: &str) -> Option<String> {
-    if target_lang == "ja" {
-        return Some(JAPANESE_TRANSLATOR_SYSTEM_PROMPT.to_string());
-    }
-
     let (language_name, extra_instruction) = match target_lang {
+        "ja" => ("日语", "使用自然、口语化且符合二次元角色语气的日语表达。"),
         "en" => ("英语", "使用自然、口语化的英语表达。"),
         "ko" => ("韩语", "使用自然、口语化且符合角色语气的韩语表达。"),
         _ => return None,
@@ -138,36 +133,4 @@ fn apply_translation_result(response: &str, segments: &mut [EmotionSegment]) -> 
         cursor = &after[end_rel + 1..];
     }
     idx
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn builds_prompts_for_gsv_output_languages() {
-        assert!(translator_system_prompt("en").unwrap().contains("英语"));
-        assert!(translator_system_prompt("ko").unwrap().contains("韩语"));
-        assert!(translator_system_prompt("unsupported").is_none());
-    }
-
-    #[test]
-    fn applies_all_translated_segments() {
-        let mut segments = vec![
-            EmotionSegment {
-                following_text: "你好".into(),
-                ..Default::default()
-            },
-            EmotionSegment {
-                following_text: "欢迎回来".into(),
-                ..Default::default()
-            },
-        ];
-
-        let translated = apply_translation_result("<Hello><Welcome back>", &mut segments);
-
-        assert_eq!(translated, 2);
-        assert_eq!(segments[0].japanese_text, "Hello");
-        assert_eq!(segments[1].japanese_text, "Welcome back");
-    }
 }

--- a/src-tauri/src/ai_service/tts/adapters/gsv.rs
+++ b/src-tauri/src/ai_service/tts/adapters/gsv.rs
@@ -2,10 +2,13 @@
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde_json::{json, Value as JsonValue};
+use tokio::sync::{Mutex, OnceCell};
+use tokio::time::{sleep, Duration};
 
 use crate::ai_service::tts::adapters::http_client;
 use crate::ai_service::tts::provider::TtsAdapter;
@@ -19,6 +22,11 @@ pub struct GsvAdapter {
     audio_format: String,
     text_lang: String,
     parallel_infer: bool,
+    gpt_model_path: Option<String>,
+    sovits_model_path: Option<String>,
+    model_initialized: Arc<OnceCell<()>>,
+    /// GPT-SoVITS/ROCm cannot safely serve several inference requests at once.
+    request_lock: Arc<Mutex<()>>,
 }
 
 impl GsvAdapter {
@@ -27,6 +35,9 @@ impl GsvAdapter {
         ref_audio_path: String,
         prompt_text: String,
         prompt_lang: String,
+        text_lang: String,
+        gpt_model_path: Option<String>,
+        sovits_model_path: Option<String>,
     ) -> Self {
         let api_url = api_url.trim_end_matches('/').to_string();
         Self {
@@ -35,13 +46,40 @@ impl GsvAdapter {
             prompt_text,
             prompt_lang,
             audio_format: "wav".into(),
-            text_lang: "ja".into(),
+            text_lang,
             parallel_infer: true,
+            gpt_model_path,
+            sovits_model_path,
+            model_initialized: Arc::new(OnceCell::new()),
+            request_lock: Arc::new(Mutex::new(())),
         }
     }
 
+    async fn ensure_model_loaded(&self) -> Result<()> {
+        let (Some(gpt_model_path), Some(sovits_model_path)) =
+            (&self.gpt_model_path, &self.sovits_model_path)
+        else {
+            return Ok(());
+        };
+        if gpt_model_path.trim().is_empty() || sovits_model_path.trim().is_empty() {
+            return Ok(());
+        }
+
+        self.model_initialized
+            .get_or_try_init(|| async {
+                self.set_model(gpt_model_path, sovits_model_path).await?;
+                tracing::info!(
+                    gpt_model = %gpt_model_path,
+                    sovits_model = %sovits_model_path,
+                    "GPT-SoVITS weights loaded"
+                );
+                Ok::<(), anyhow::Error>(())
+            })
+            .await?;
+        Ok(())
+    }
+
     /// 设置 GPT + SoVITS 权重。对应 Python `set_model`。
-    #[allow(dead_code)]
     pub async fn set_model(&self, gpt_model_path: &str, sovits_model_path: &str) -> Result<()> {
         if !Path::new(gpt_model_path).exists() {
             return Err(anyhow!("GPT 模型文件不存在: {gpt_model_path}"));
@@ -81,6 +119,10 @@ impl GsvAdapter {
 #[async_trait]
 impl TtsAdapter for GsvAdapter {
     async fn generate_voice(&self, text: &str, _emo: &str) -> Result<Vec<u8>> {
+        // VoiceMaker normally generates segments concurrently. Serialize only
+        // GPT-SoVITS so Windows ROCm does not crash after the first segment.
+        let _request_guard = self.request_lock.lock().await;
+        self.ensure_model_loaded().await?;
         let body = json!({
             "ref_audio_path": self.ref_audio_path,
             "prompt_text": self.prompt_text,
@@ -90,16 +132,33 @@ impl TtsAdapter for GsvAdapter {
             "speed_factor": 1.0,
             "text_split_method": "cut0",
             "top_k": 15,
-            "top_p": 100.0,
+            "top_p": 1.0,
             "temperature": 1.0,
             "parallel_infer": self.parallel_infer,
             "text": text,
         });
-        let resp = http_client()
-            .post(format!("{}/tts", self.api_url))
-            .json(&body)
-            .send()
-            .await?;
+        let mut retry_error = None;
+        let resp = loop {
+            match http_client()
+                .post(format!("{}/tts", self.api_url))
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(resp) => break resp,
+                Err(error) if retry_error.is_none() => {
+                    tracing::warn!("GPT-SoVITS request failed, retrying once: {error}");
+                    retry_error = Some(error);
+                    sleep(Duration::from_millis(500)).await;
+                }
+                Err(error) => {
+                    return Err(anyhow!(
+                        "GPT-SoVITS request failed after retry: {error}; first error: {}",
+                        retry_error.expect("retry error must exist")
+                    ));
+                }
+            }
+        };
         if !resp.status().is_success() {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
@@ -114,6 +173,9 @@ impl TtsAdapter for GsvAdapter {
         m.insert("ref_audio_path".into(), json!(self.ref_audio_path));
         m.insert("prompt_text".into(), json!(self.prompt_text));
         m.insert("prompt_lang".into(), json!(self.prompt_lang));
+        m.insert("text_lang".into(), json!(self.text_lang));
+        m.insert("gpt_model_path".into(), json!(self.gpt_model_path));
+        m.insert("sovits_model_path".into(), json!(self.sovits_model_path));
         m.insert("audio_format".into(), json!(self.audio_format));
         m
     }

--- a/src-tauri/src/ai_service/tts/provider.rs
+++ b/src-tauri/src/ai_service/tts/provider.rs
@@ -179,7 +179,14 @@ impl TtsProvider {
                 Ok(())
             }
             Err(e) => {
-                self.disable();
+                // GPT-SoVITS is an external local service. A temporary ROCm or
+                // transport failure must not poison the role's TTS provider for
+                // all later segments/messages; the adapter already retries once.
+                if tts_type != "gsv" {
+                    self.disable();
+                } else {
+                    tracing::warn!("GPT-SoVITS request failed; keeping TTS enabled for recovery");
+                }
                 Err(e)
             }
         }

--- a/src-tauri/src/ai_service/tts/provider.rs
+++ b/src-tauri/src/ai_service/tts/provider.rs
@@ -40,6 +40,7 @@ pub trait TtsAdapter: Send + Sync {
 pub struct TtsProvider {
     pub audio_format: String,
     enable: Arc<AtomicBool>,
+    recovery_in_flight: Arc<AtomicBool>,
 
     pub sva: Option<Arc<VitsAdapter>>,
     pub sbv2: Option<Arc<Sbv2Adapter>>,
@@ -56,6 +57,7 @@ impl Default for TtsProvider {
         Self {
             audio_format: String::new(),
             enable: Arc::new(AtomicBool::new(true)),
+            recovery_in_flight: Arc::new(AtomicBool::new(false)),
             sva: None,
             sbv2: None,
             sbv2api: None,
@@ -73,6 +75,7 @@ impl std::fmt::Debug for TtsProvider {
         f.debug_struct("TtsProvider")
             .field("audio_format", &self.audio_format)
             .field("enable", &self.enable)
+            .field("recovery_in_flight", &self.recovery_in_flight)
             .field("sva", &self.sva.is_some())
             .field("sbv2", &self.sbv2.is_some())
             .field("sbv2api", &self.sbv2api.is_some())
@@ -90,6 +93,7 @@ impl TtsProvider {
         Self {
             audio_format: audio_format.into(),
             enable: Arc::new(AtomicBool::new(true)),
+            recovery_in_flight: Arc::new(AtomicBool::new(false)),
             ..Default::default()
         }
     }
@@ -106,6 +110,37 @@ impl TtsProvider {
     pub fn reactivate(&self) {
         self.enable.store(true, Ordering::Relaxed);
         tracing::info!("TTS 服务已重新启用");
+    }
+
+    /// TTS 被禁用后，用当前消息在后台探测服务是否恢复。
+    ///
+    /// 探测音频不会写入文件；成功后仅重新启用 TTS，让下一条消息正常输出语音。
+    /// 同一时刻最多执行一次探测，避免多分段消息重复请求。
+    pub fn recover_in_background(&self, text: String, tts_type: String, emo: String) {
+        if self.is_enabled() || text.trim().is_empty() {
+            return;
+        }
+        if self.recovery_in_flight.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        let adapter = match self.select(&tts_type) {
+            Ok(adapter) => adapter,
+            Err(error) => {
+                self.recovery_in_flight.store(false, Ordering::Release);
+                tracing::debug!("TTS 后台恢复探测跳过: {error}");
+                return;
+            }
+        };
+        let provider = self.clone();
+        tokio::spawn(async move {
+            tracing::debug!("开始后台探测 TTS 服务: {tts_type}");
+            match adapter.generate_voice(&text, &emo).await {
+                Ok(_) => provider.reactivate(),
+                Err(error) => tracing::debug!("TTS 服务仍不可用: {error}"),
+            }
+            provider.recovery_in_flight.store(false, Ordering::Release);
+        });
     }
 
     fn select(&self, tts_type: &str) -> Result<Arc<dyn TtsAdapter>> {
@@ -179,14 +214,7 @@ impl TtsProvider {
                 Ok(())
             }
             Err(e) => {
-                // GPT-SoVITS is an external local service. A temporary ROCm or
-                // transport failure must not poison the role's TTS provider for
-                // all later segments/messages; the adapter already retries once.
-                if tts_type != "gsv" {
-                    self.disable();
-                } else {
-                    tracing::warn!("GPT-SoVITS request failed; keeping TTS enabled for recovery");
-                }
+                self.disable();
                 Err(e)
             }
         }

--- a/src-tauri/src/ai_service/tts/voice_maker.rs
+++ b/src-tauri/src/ai_service/tts/voice_maker.rs
@@ -52,6 +52,16 @@ fn non_empty(s: &Option<String>) -> bool {
     s.as_ref().map(|v| !v.trim().is_empty()).unwrap_or(false)
 }
 
+fn segment_text_for_lang<'a>(lang: &str, segment: &'a EmotionSegment) -> Option<&'a str> {
+    match lang {
+        "ja" if !segment.japanese_text.trim().is_empty() => Some(&segment.japanese_text),
+        "zh" if !segment.following_text.trim().is_empty() => Some(&segment.following_text),
+        _ if !segment.following_text.trim().is_empty() => Some(&segment.following_text),
+        _ if !segment.japanese_text.trim().is_empty() => Some(&segment.japanese_text),
+        _ => None,
+    }
+}
+
 impl VoiceMaker {
     pub fn new(temp_dir: PathBuf, audio_format: impl Into<String>, tts_config: TtsConfig) -> Self {
         let audio_format = audio_format.into();
@@ -195,14 +205,26 @@ impl VoiceMaker {
                     _ => String::new(),
                 };
                 let prompt_text = cfg.gsv_voice_text.clone().unwrap_or_default();
+                let voice_lang = match self.lang.as_str() {
+                    "zh" => "zh",
+                    "ja" => "ja",
+                    other => {
+                        tracing::warn!("GPT-SoVITS 暂不支持语言 {other}，回退到中文");
+                        "zh"
+                    }
+                }
+                .to_string();
                 let adapter = GsvAdapter::new(
                     self.tts_config.gsv_api_url.clone(),
                     ref_audio_path,
                     prompt_text,
-                    "ja".into(),
+                    voice_lang.clone(),
+                    voice_lang,
+                    cfg.gsv_gpt_model_name.clone(),
+                    cfg.gsv_sovits_model_name.clone(),
                 );
                 self.provider.gsv = Some(Arc::new(adapter));
-                let _ = name; // 预留：Python 版还有按 name 查找 gpt/sovits 权重的逻辑
+                let _ = name;
             }
             "aivis" if self.availability.aivis => {
                 let model_uuid = cfg.aivis_model_uuid.clone().unwrap_or_default();
@@ -294,18 +316,8 @@ impl VoiceMaker {
         for seg in segments.iter_mut() {
             // 严格按当前设置语言选择文本；跨语言生成容易导致 TTS 输出异常，
             // 因此目标语言无文本时直接跳过该片段的语音生成。
-            let text = match self.lang.as_str() {
-                "ja" if !seg.japanese_text.trim().is_empty() => seg.japanese_text.clone(),
-                "zh" if !seg.following_text.trim().is_empty() => seg.following_text.clone(),
-                _ => {
-                    if !seg.following_text.trim().is_empty() {
-                        seg.following_text.clone()
-                    } else if !seg.japanese_text.trim().is_empty() {
-                        seg.japanese_text.clone()
-                    } else {
-                        continue;
-                    }
-                }
+            let Some(text) = segment_text_for_lang(&self.lang, seg).map(str::to_owned) else {
+                continue;
             };
             let emo = String::new();
 
@@ -337,5 +349,87 @@ impl VoiceMaker {
         if !futs.is_empty() {
             join_all(futs).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai_service::tts::provider::TtsAdapter;
+
+    #[test]
+    fn chinese_language_selects_chinese_segment_text() {
+        let segment = EmotionSegment {
+            following_text: "你好，欢迎回来。".into(),
+            japanese_text: "おかえりなさい。".into(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            segment_text_for_lang("zh", &segment),
+            Some("你好，欢迎回来。")
+        );
+        assert_eq!(
+            segment_text_for_lang("ja", &segment),
+            Some("おかえりなさい。")
+        );
+    }
+
+    #[test]
+    fn refresh_rebuilds_sbv2api_adapter_with_latest_values() {
+        let mut maker = VoiceMaker::new(PathBuf::from("voice"), "wav", TtsConfig::default());
+        let voice_model = VoiceModel {
+            sbv2api_name: Some("Ling v2".into()),
+            sbv2api_speaker_id: Some("0".into()),
+            ..Default::default()
+        };
+
+        maker.update_lang_and_refresh(&voice_model, "sbv2api", "Ling", "zh");
+
+        assert_eq!(maker.lang, "zh");
+        assert_eq!(maker.tts_type(), "sbv2api");
+        let params = maker
+            .provider
+            .sbv2api
+            .as_ref()
+            .expect("SBV2API adapter should be initialized")
+            .get_params();
+        assert_eq!(
+            params.get("model_name"),
+            Some(&serde_json::json!("Ling v2"))
+        );
+        assert_eq!(params.get("speaker_id"), Some(&serde_json::json!(0)));
+    }
+
+    #[test]
+    fn gsv_adapter_uses_selected_language_and_model_paths() {
+        let mut maker = VoiceMaker::new(PathBuf::from("voice"), "wav", TtsConfig::default());
+        maker.set_character_path(Some(PathBuf::from("character")));
+        let voice_model = VoiceModel {
+            gsv_voice_filename: Some("reference.wav".into()),
+            gsv_voice_text: Some("中文参考文本".into()),
+            gsv_gpt_model_name: Some("model.ckpt".into()),
+            gsv_sovits_model_name: Some("model.pth".into()),
+            ..Default::default()
+        };
+
+        maker.update_lang_and_refresh(&voice_model, "gsv", "角色", "zh");
+
+        let params = maker
+            .provider
+            .gsv
+            .as_ref()
+            .expect("GSV adapter should be initialized")
+            .get_params();
+        assert_eq!(params.get("prompt_lang"), Some(&serde_json::json!("zh")));
+        assert_eq!(params.get("text_lang"), Some(&serde_json::json!("zh")));
+        assert_eq!(
+            params.get("gpt_model_path"),
+            Some(&serde_json::json!("model.ckpt"))
+        );
+        assert_eq!(
+            params.get("sovits_model_path"),
+            Some(&serde_json::json!("model.pth"))
+        );
     }
 }

--- a/src-tauri/src/ai_service/tts/voice_maker.rs
+++ b/src-tauri/src/ai_service/tts/voice_maker.rs
@@ -338,7 +338,20 @@ impl VoiceMaker {
         }
     }
     pub async fn generate_voice_files(&self, segments: &mut [EmotionSegment]) {
-        if !self.is_enabled() {
+        if self.tts_type.is_empty() {
+            return;
+        }
+        if !self.provider.is_enabled() {
+            if let Some(text) = segments
+                .iter()
+                .find_map(|segment| segment_text_for_lang(&self.lang, segment))
+            {
+                self.provider.recover_in_background(
+                    text.to_owned(),
+                    self.tts_type.clone(),
+                    String::new(),
+                );
+            }
             return;
         }
         tokio::fs::create_dir_all(&self.temp_dir).await.ok();
@@ -380,147 +393,5 @@ impl VoiceMaker {
         if !futs.is_empty() {
             join_all(futs).await;
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::ai_service::tts::provider::TtsAdapter;
-
-    #[test]
-    fn selected_language_uses_original_or_translated_segment_text() {
-        let segment = EmotionSegment {
-            following_text: "你好，欢迎回来。".into(),
-            japanese_text: "おかえりなさい。".into(),
-            ..Default::default()
-        };
-
-        assert_eq!(
-            segment_text_for_lang("zh", &segment),
-            Some("你好，欢迎回来。")
-        );
-        assert_eq!(
-            segment_text_for_lang("ja", &segment),
-            Some("おかえりなさい。")
-        );
-        let english = EmotionSegment {
-            following_text: "你好，欢迎回来。".into(),
-            japanese_text: "Hello, welcome back.".into(),
-            ..Default::default()
-        };
-        assert_eq!(
-            segment_text_for_lang("en", &english),
-            Some("Hello, welcome back.")
-        );
-
-        let korean = EmotionSegment {
-            following_text: "你好，欢迎回来。".into(),
-            japanese_text: "안녕하세요, 다시 오신 것을 환영합니다.".into(),
-            ..Default::default()
-        };
-        assert_eq!(
-            segment_text_for_lang("ko", &korean),
-            Some("안녕하세요, 다시 오신 것을 환영합니다.")
-        );
-
-        let untranslated = EmotionSegment {
-            following_text: "你好，欢迎回来。".into(),
-            ..Default::default()
-        };
-        assert_eq!(segment_text_for_lang("en", &untranslated), None);
-        assert_eq!(segment_text_for_lang("ko", &untranslated), None);
-    }
-
-    #[test]
-    fn gsv_prompt_language_is_independent_from_output_language() {
-        assert_eq!(gsv_prompt_language("中文参考文本"), "zh");
-        assert_eq!(gsv_prompt_language("こんにちは"), "ja");
-        assert_eq!(gsv_prompt_language("안녕하세요"), "ko");
-        assert_eq!(gsv_prompt_language("Hello there"), "en");
-    }
-
-    #[test]
-    fn refresh_rebuilds_sbv2_adapter_with_latest_values() {
-        let mut maker = VoiceMaker::new(PathBuf::from("voice"), "wav", TtsConfig::default());
-        let voice_model = VoiceModel {
-            sbv2_name: Some("Ling-JP".into()),
-            sbv2_speaker_id: Some("2".into()),
-            ..Default::default()
-        };
-
-        maker.update_lang_and_refresh(&voice_model, "sbv2", "Ling", "ja");
-
-        assert_eq!(maker.tts_type(), "sbv2");
-        let params = maker
-            .provider
-            .sbv2
-            .as_ref()
-            .expect("SBV2 adapter should be initialized")
-            .get_params();
-        assert_eq!(
-            params.get("model_name"),
-            Some(&serde_json::json!("Ling-JP"))
-        );
-        assert_eq!(params.get("speaker_id"), Some(&serde_json::json!(2)));
-        assert_eq!(params.get("language"), Some(&serde_json::json!("JP")));
-    }
-
-    #[test]
-    fn refresh_rebuilds_sbv2api_adapter_with_latest_values() {
-        let mut maker = VoiceMaker::new(PathBuf::from("voice"), "wav", TtsConfig::default());
-        let voice_model = VoiceModel {
-            sbv2api_name: Some("Ling v2".into()),
-            sbv2api_speaker_id: Some("0".into()),
-            ..Default::default()
-        };
-
-        maker.update_lang_and_refresh(&voice_model, "sbv2api", "Ling", "zh");
-
-        assert_eq!(maker.lang, "zh");
-        assert_eq!(maker.tts_type(), "sbv2api");
-        let params = maker
-            .provider
-            .sbv2api
-            .as_ref()
-            .expect("SBV2API adapter should be initialized")
-            .get_params();
-        assert_eq!(
-            params.get("model_name"),
-            Some(&serde_json::json!("Ling v2"))
-        );
-        assert_eq!(params.get("speaker_id"), Some(&serde_json::json!(0)));
-    }
-
-    #[test]
-    fn gsv_adapter_uses_selected_language_and_model_paths() {
-        let mut maker = VoiceMaker::new(PathBuf::from("voice"), "wav", TtsConfig::default());
-        maker.set_character_path(Some(PathBuf::from("character")));
-        let voice_model = VoiceModel {
-            gsv_voice_filename: Some("reference.wav".into()),
-            gsv_voice_text: Some("中文参考文本".into()),
-            gsv_gpt_model_name: Some("model.ckpt".into()),
-            gsv_sovits_model_name: Some("model.pth".into()),
-            ..Default::default()
-        };
-
-        maker.update_lang_and_refresh(&voice_model, "gsv", "角色", "en");
-
-        let params = maker
-            .provider
-            .gsv
-            .as_ref()
-            .expect("GSV adapter should be initialized")
-            .get_params();
-        assert_eq!(params.get("prompt_lang"), Some(&serde_json::json!("zh")));
-        assert_eq!(params.get("text_lang"), Some(&serde_json::json!("en")));
-        assert_eq!(
-            params.get("gpt_model_path"),
-            Some(&serde_json::json!("model.ckpt"))
-        );
-        assert_eq!(
-            params.get("sovits_model_path"),
-            Some(&serde_json::json!("model.pth"))
-        );
     }
 }

--- a/src-tauri/src/ai_service/tts/voice_maker.rs
+++ b/src-tauri/src/ai_service/tts/voice_maker.rs
@@ -376,6 +376,32 @@ mod tests {
     }
 
     #[test]
+    fn refresh_rebuilds_sbv2_adapter_with_latest_values() {
+        let mut maker = VoiceMaker::new(PathBuf::from("voice"), "wav", TtsConfig::default());
+        let voice_model = VoiceModel {
+            sbv2_name: Some("Ling-JP".into()),
+            sbv2_speaker_id: Some("2".into()),
+            ..Default::default()
+        };
+
+        maker.update_lang_and_refresh(&voice_model, "sbv2", "Ling", "ja");
+
+        assert_eq!(maker.tts_type(), "sbv2");
+        let params = maker
+            .provider
+            .sbv2
+            .as_ref()
+            .expect("SBV2 adapter should be initialized")
+            .get_params();
+        assert_eq!(
+            params.get("model_name"),
+            Some(&serde_json::json!("Ling-JP"))
+        );
+        assert_eq!(params.get("speaker_id"), Some(&serde_json::json!(2)));
+        assert_eq!(params.get("language"), Some(&serde_json::json!("JP")));
+    }
+
+    #[test]
     fn refresh_rebuilds_sbv2api_adapter_with_latest_values() {
         let mut maker = VoiceMaker::new(PathBuf::from("voice"), "wav", TtsConfig::default());
         let voice_model = VoiceModel {

--- a/src-tauri/src/ai_service/tts/voice_maker.rs
+++ b/src-tauri/src/ai_service/tts/voice_maker.rs
@@ -52,9 +52,37 @@ fn non_empty(s: &Option<String>) -> bool {
     s.as_ref().map(|v| !v.trim().is_empty()).unwrap_or(false)
 }
 
+fn gsv_prompt_language(prompt_text: &str) -> &'static str {
+    if prompt_text
+        .chars()
+        .any(|c| matches!(c, '\u{ac00}'..='\u{d7af}'))
+    {
+        "ko"
+    } else if prompt_text.chars().any(|c| {
+        matches!(
+            c,
+            '\u{3040}'..='\u{30ff}' | '\u{31f0}'..='\u{31ff}'
+        )
+    }) {
+        "ja"
+    } else if prompt_text
+        .chars()
+        .any(|c| matches!(c, '\u{3400}'..='\u{4dbf}' | '\u{4e00}'..='\u{9fff}'))
+    {
+        "zh"
+    } else if prompt_text.chars().any(|c| c.is_ascii_alphabetic()) {
+        "en"
+    } else {
+        "zh"
+    }
+}
+
 fn segment_text_for_lang<'a>(lang: &str, segment: &'a EmotionSegment) -> Option<&'a str> {
     match lang {
-        "ja" if !segment.japanese_text.trim().is_empty() => Some(&segment.japanese_text),
+        "ja" | "en" | "ko" if !segment.japanese_text.trim().is_empty() => {
+            Some(&segment.japanese_text)
+        }
+        "en" | "ko" => None,
         "zh" if !segment.following_text.trim().is_empty() => Some(&segment.following_text),
         _ if !segment.following_text.trim().is_empty() => Some(&segment.following_text),
         _ if !segment.japanese_text.trim().is_empty() => Some(&segment.japanese_text),
@@ -205,9 +233,12 @@ impl VoiceMaker {
                     _ => String::new(),
                 };
                 let prompt_text = cfg.gsv_voice_text.clone().unwrap_or_default();
+                let prompt_lang = gsv_prompt_language(&prompt_text).to_string();
                 let voice_lang = match self.lang.as_str() {
                     "zh" => "zh",
                     "ja" => "ja",
+                    "en" => "en",
+                    "ko" => "ko",
                     other => {
                         tracing::warn!("GPT-SoVITS 暂不支持语言 {other}，回退到中文");
                         "zh"
@@ -218,7 +249,7 @@ impl VoiceMaker {
                     self.tts_config.gsv_api_url.clone(),
                     ref_audio_path,
                     prompt_text,
-                    voice_lang.clone(),
+                    prompt_lang,
                     voice_lang,
                     cfg.gsv_gpt_model_name.clone(),
                     cfg.gsv_sovits_model_name.clone(),
@@ -358,7 +389,7 @@ mod tests {
     use crate::ai_service::tts::provider::TtsAdapter;
 
     #[test]
-    fn chinese_language_selects_chinese_segment_text() {
+    fn selected_language_uses_original_or_translated_segment_text() {
         let segment = EmotionSegment {
             following_text: "你好，欢迎回来。".into(),
             japanese_text: "おかえりなさい。".into(),
@@ -373,6 +404,40 @@ mod tests {
             segment_text_for_lang("ja", &segment),
             Some("おかえりなさい。")
         );
+        let english = EmotionSegment {
+            following_text: "你好，欢迎回来。".into(),
+            japanese_text: "Hello, welcome back.".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            segment_text_for_lang("en", &english),
+            Some("Hello, welcome back.")
+        );
+
+        let korean = EmotionSegment {
+            following_text: "你好，欢迎回来。".into(),
+            japanese_text: "안녕하세요, 다시 오신 것을 환영합니다.".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            segment_text_for_lang("ko", &korean),
+            Some("안녕하세요, 다시 오신 것을 환영합니다.")
+        );
+
+        let untranslated = EmotionSegment {
+            following_text: "你好，欢迎回来。".into(),
+            ..Default::default()
+        };
+        assert_eq!(segment_text_for_lang("en", &untranslated), None);
+        assert_eq!(segment_text_for_lang("ko", &untranslated), None);
+    }
+
+    #[test]
+    fn gsv_prompt_language_is_independent_from_output_language() {
+        assert_eq!(gsv_prompt_language("中文参考文本"), "zh");
+        assert_eq!(gsv_prompt_language("こんにちは"), "ja");
+        assert_eq!(gsv_prompt_language("안녕하세요"), "ko");
+        assert_eq!(gsv_prompt_language("Hello there"), "en");
     }
 
     #[test]
@@ -439,7 +504,7 @@ mod tests {
             ..Default::default()
         };
 
-        maker.update_lang_and_refresh(&voice_model, "gsv", "角色", "zh");
+        maker.update_lang_and_refresh(&voice_model, "gsv", "角色", "en");
 
         let params = maker
             .provider
@@ -448,7 +513,7 @@ mod tests {
             .expect("GSV adapter should be initialized")
             .get_params();
         assert_eq!(params.get("prompt_lang"), Some(&serde_json::json!("zh")));
-        assert_eq!(params.get("text_lang"), Some(&serde_json::json!("zh")));
+        assert_eq!(params.get("text_lang"), Some(&serde_json::json!("en")));
         assert_eq!(
             params.get("gpt_model_path"),
             Some(&serde_json::json!("model.ckpt"))

--- a/src-tauri/src/api/character.rs
+++ b/src-tauri/src/api/character.rs
@@ -609,31 +609,3 @@ pub fn open_characters_folder() -> Result<(), String> {
     let path_str = char_dir.to_string_lossy().into_owned();
     open_folder(&path_str)
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn removes_legacy_top_level_voice_model_fields() {
-        let mut settings: CharacterSettings = serde_json::from_value(serde_json::json!({
-            "sbv2api_name": "legacy-name",
-            "sbv2api_speaker_id": "9",
-            "voice_models": {
-                "sbv2api_name": "Ling v2",
-                "sbv2api_speaker_id": "0"
-            }
-        }))
-        .expect("settings should deserialize");
-
-        remove_legacy_voice_model_fields(&mut settings);
-
-        assert!(!settings.extra.contains_key("sbv2api_name"));
-        assert!(!settings.extra.contains_key("sbv2api_speaker_id"));
-        let voice_models = settings
-            .voice_models
-            .expect("nested voice_models should remain");
-        assert_eq!(voice_models.sbv2api_name.as_deref(), Some("Ling v2"));
-        assert_eq!(voice_models.sbv2api_speaker_id.as_deref(), Some("0"));
-    }
-}

--- a/src-tauri/src/api/character.rs
+++ b/src-tauri/src/api/character.rs
@@ -16,6 +16,27 @@ use crate::AppState;
 
 use super::{characters_dir, data_dir, game_data_dir};
 
+const LEGACY_VOICE_MODEL_FIELDS: &[&str] = &[
+    "sva_speaker_id",
+    "sbv2_name",
+    "sbv2_speaker_id",
+    "bv2_speaker_id",
+    "sbv2api_name",
+    "sbv2api_speaker_id",
+    "gsv_voice_text",
+    "gsv_voice_filename",
+    "gsv_gpt_model_name",
+    "gsv_sovits_model_name",
+    "aivis_model_uuid",
+    "opentts_voice",
+];
+
+fn remove_legacy_voice_model_fields(settings: &mut CharacterSettings) {
+    for key in LEGACY_VOICE_MODEL_FIELDS {
+        settings.extra.remove(*key);
+    }
+}
+
 // ========== 响应类型 ==========
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -541,10 +562,12 @@ pub async fn update_role_settings(
         return Err(format!("角色目录不存在: {:?}", base_path));
     }
 
-    let _validated: CharacterSettings =
-        serde_json::from_value(settings.clone()).map_err(|e| format!("配置验证失败: {}", e))?;
+    let mut validated: CharacterSettings =
+        serde_json::from_value(settings).map_err(|e| format!("配置验证失败: {}", e))?;
+    remove_legacy_voice_model_fields(&mut validated);
 
-    let mut save_data = settings;
+    let mut save_data =
+        serde_json::to_value(&validated).map_err(|e| format!("配置规范化失败: {}", e))?;
     if let Some(obj) = save_data.as_object_mut() {
         obj.remove("character_id");
         obj.remove("resource_path");
@@ -556,8 +579,24 @@ pub async fn update_role_settings(
     let yaml_str = serde_yaml::to_string(&save_data).map_err(|e| format!("序列化失败: {}", e))?;
     fs::write(&yaml_path, yaml_str).map_err(|e| format!("保存失败: {}", e))?;
 
-    tracing::info!("角色 {} 配置已保存到 {:?}", role_id, yaml_path);
-    Ok(serde_json::json!({"success": true, "message": "设置已保存"}))
+    let runtime_updated = {
+        let service = state.ai_service.lock().await;
+        let mut gs = service.game_status.lock().await;
+        gs.role_manager
+            .update_role_voice_settings(role_id, &validated)
+    };
+
+    tracing::info!(
+        "角色 {} 配置已保存到 {:?}, runtime_updated={}",
+        role_id,
+        yaml_path,
+        runtime_updated,
+    );
+    Ok(serde_json::json!({
+        "success": true,
+        "message": "设置已保存",
+        "runtime_updated": runtime_updated,
+    }))
 }
 
 #[tauri::command]
@@ -569,4 +608,32 @@ pub fn open_characters_folder() -> Result<(), String> {
 
     let path_str = char_dir.to_string_lossy().into_owned();
     open_folder(&path_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn removes_legacy_top_level_voice_model_fields() {
+        let mut settings: CharacterSettings = serde_json::from_value(serde_json::json!({
+            "sbv2api_name": "legacy-name",
+            "sbv2api_speaker_id": "9",
+            "voice_models": {
+                "sbv2api_name": "Ling v2",
+                "sbv2api_speaker_id": "0"
+            }
+        }))
+        .expect("settings should deserialize");
+
+        remove_legacy_voice_model_fields(&mut settings);
+
+        assert!(!settings.extra.contains_key("sbv2api_name"));
+        assert!(!settings.extra.contains_key("sbv2api_speaker_id"));
+        let voice_models = settings
+            .voice_models
+            .expect("nested voice_models should remain");
+        assert_eq!(voice_models.sbv2api_name.as_deref(), Some("Ling v2"));
+        assert_eq!(voice_models.sbv2api_speaker_id.as_deref(), Some("0"));
+    }
 }

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,7 +1,8 @@
+pub mod archive;
 pub mod cpu_perf;
 pub mod file_logger;
 pub mod llm_request_logger;
 pub mod log_bridge;
+pub mod path;
 pub mod prompt;
 pub mod system;
-pub mod archive;

--- a/src-tauri/src/utils/path.rs
+++ b/src-tauri/src/utils/path.rs
@@ -1,0 +1,13 @@
+use std::path::{Path, PathBuf};
+
+/// 将角色资源路径解析为绝对路径。
+///
+/// 相对路径统一放在 `data/game_data/characters` 下，绝对路径保持不变。
+pub fn resolve_character_path(data_dir: &Path, resource_path: &str) -> PathBuf {
+    let path = PathBuf::from(resource_path);
+    if path.is_absolute() {
+        path
+    } else {
+        data_dir.join("game_data").join("characters").join(path)
+    }
+}

--- a/src/components/settings/pages/SettingsAdvanceOther.vue
+++ b/src/components/settings/pages/SettingsAdvanceOther.vue
@@ -93,6 +93,27 @@
             </div>
           </form>
 
+          <section
+            v-if="activeSelection.category === 'TTS 配置'"
+            class="mb-6 rounded-xl border border-white/10 bg-black/15 p-4"
+          >
+            <h3 class="mb-1 text-base font-semibold text-white">TTS 连接控制</h3>
+            <p class="mb-3 text-sm leading-6 text-white/65">
+              TTS 服务重启后，可在这里解除离线状态并让下一次语音立即重新连接。模型、语言或接口参数错误导致的 HTTP 400 仍需修正对应配置。
+            </p>
+            <Button type="big" :disabled="isReconnectingTts" @click="forceReconnectTts">
+              <RefreshCw :size="18" :class="{ 'animate-spin': isReconnectingTts }" />
+              {{ isReconnectingTts ? '正在重新连接…' : '强制重新连接 TTS' }}
+            </Button>
+            <p
+              v-if="reconnectStatus.message"
+              class="mt-2 text-sm"
+              :class="reconnectStatus.colorClass"
+            >
+              {{ reconnectStatus.message }}
+            </p>
+          </section>
+
           <!-- 保存操作区域 -->
           <div
             class="inline-flex flex-col gap-2 px-5 py-2.5 bg-brand text-white border-none rounded-lg cursor-pointer text-sm font-medium transition-colors duration-200 hover:bg-[#0056b3] min-w-30"
@@ -125,11 +146,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, computed, reactive, watch, nextTick } from 'vue'
+import { ref, onMounted, onUnmounted, computed, reactive, watch, nextTick } from 'vue'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import SettingItem from '@/components/base/items/SettingItem.vue'
+import { Button } from '@/components/base'
 import { getEnvConfigSettings, saveEnvConfigSettings } from '@/api/services/config'
+import { reactivateTTS } from '@/api/services/game-info'
 import { switchLlm } from '@/api/services/llm-providers'
+import { RefreshCw } from 'lucide-vue-next'
 
 // --- 响应式状态定义 ---
 const uiStore = useUIStore()
@@ -144,6 +168,12 @@ const saveStatus = reactive({
   message: '',
   colorClass: 'text-green-500',
 })
+const isReconnectingTts = ref(false)
+const reconnectStatus = reactive({
+  message: '',
+  colorClass: 'text-green-400',
+})
+let reconnectStatusTimer: ReturnType<typeof setTimeout> | null = null
 
 const emit = defineEmits<{
   'remove-more-menu-from-b': []
@@ -203,6 +233,34 @@ const saveSettings = async () => {
     setTimeout(() => {
       saveStatus.message = ''
     }, 5000)
+  }
+}
+
+const forceReconnectTts = async () => {
+  if (isReconnectingTts.value) return
+
+  isReconnectingTts.value = true
+  reconnectStatus.message = '正在重新启用 TTS 服务…'
+  reconnectStatus.colorClass = 'text-white/70'
+  if (reconnectStatusTimer) {
+    clearTimeout(reconnectStatusTimer)
+    reconnectStatusTimer = null
+  }
+
+  try {
+    await reactivateTTS()
+    reconnectStatus.message = 'TTS 已重新启用，下一次语音会立即重试连接。'
+    reconnectStatus.colorClass = 'text-green-400'
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    reconnectStatus.message = `重新连接失败：${message}`
+    reconnectStatus.colorClass = 'text-red-400'
+  } finally {
+    isReconnectingTts.value = false
+    reconnectStatusTimer = setTimeout(() => {
+      reconnectStatus.message = ''
+      reconnectStatusTimer = null
+    }, 8000)
   }
 }
 
@@ -278,6 +336,12 @@ onMounted(async () => {
   await nextTick()
   updateIndicatorPosition()
   setupNavResizeObserver()
+})
+
+onUnmounted(() => {
+  if (reconnectStatusTimer) {
+    clearTimeout(reconnectStatusTimer)
+  }
 })
 
 // --- 窄屏菜单控制 ---

--- a/src/components/settings/pages/SettingsCharacterInfo.vue
+++ b/src/components/settings/pages/SettingsCharacterInfo.vue
@@ -108,7 +108,7 @@
                       @change="handleFieldChange(field)"
                     >
                       <option
-                        v-for="opt in field.options"
+                        v-for="opt in fieldOptions(field)"
                         :key="opt.value"
                         :value="opt.value"
                         class="bg-[#333] text-white"
@@ -245,16 +245,28 @@ const voiceModelKeys = [
 
 type FieldType = 'text' | 'number' | 'textarea' | 'select'
 
+interface FieldOption {
+  label: string
+  value: string
+  visibleIf?: (settings: any) => boolean
+}
+
 interface FieldSchema {
   key: string
   label: string
   type: FieldType
   rows?: number
   step?: string
-  options?: { label: string; value: string }[]
+  options?: FieldOption[]
   visibleIf?: (settings: any) => boolean
   isVoiceModel?: boolean
   realtime?: boolean
+}
+
+const fieldOptions = (field: FieldSchema) => {
+  return (field.options || []).filter(
+    (option) => !option.visibleIf || option.visibleIf(localSettings.value),
+  )
 }
 
 const schemas: Record<string, FieldSchema[]> = {
@@ -309,6 +321,16 @@ const schemas: Record<string, FieldSchema[]> = {
       options: [
         { label: '日语', value: 'ja' },
         { label: '中文', value: 'zh' },
+        {
+          label: '英语',
+          value: 'en',
+          visibleIf: (s) => s.tts_type === 'gsv',
+        },
+        {
+          label: '韩语',
+          value: 'ko',
+          visibleIf: (s) => s.tts_type === 'gsv',
+        },
       ],
     },
 

--- a/src/components/settings/pages/SettingsCharacterInfo.vue
+++ b/src/components/settings/pages/SettingsCharacterInfo.vue
@@ -91,6 +91,7 @@
                       :type="field.type"
                       :step="field.step"
                       class="form-control bg-black/20 border border-white/10 rounded-xl px-3.5 py-2.5 text-white text-sm outline-none transition-all duration-200"
+                      @change="handleFieldChange(field)"
                     />
                     <textarea
                       v-else-if="field.type === 'textarea'"
@@ -198,7 +199,6 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
-import { invoke } from '@tauri-apps/api/core'
 import { getRoleSettings, updateRoleSettings } from '../../../api/services/character'
 import { Icon } from '../../base'
 import { useDialogStore } from '../../../stores/modules/ui/dialog'
@@ -225,6 +225,21 @@ const tabs = [
   { id: 'pet', label: '桌宠' },
   { id: 'voice', label: '语音设置' },
 ]
+
+const voiceModelKeys = [
+  'sva_speaker_id',
+  'sbv2_name',
+  'sbv2_speaker_id',
+  'bv2_speaker_id',
+  'sbv2api_name',
+  'sbv2api_speaker_id',
+  'gsv_voice_text',
+  'gsv_voice_filename',
+  'gsv_gpt_model_name',
+  'gsv_sovits_model_name',
+  'aivis_model_uuid',
+  'opentts_voice',
+] as const
 
 // --- Schema Definition ---
 
@@ -274,6 +289,7 @@ const schemas: Record<string, FieldSchema[]> = {
       key: 'tts_type',
       label: 'TTS 类型',
       type: 'select',
+      realtime: true,
       options: [
         { label: 'sva', value: 'sva' },
         { label: 'sbv2', value: 'sbv2' },
@@ -300,6 +316,7 @@ const schemas: Record<string, FieldSchema[]> = {
       key: 'sva_speaker_id',
       label: 'sva_speaker_id',
       type: 'text',
+      isVoiceModel: true,
       visibleIf: (s) => s.tts_type === 'sva',
     },
 
@@ -307,12 +324,14 @@ const schemas: Record<string, FieldSchema[]> = {
       key: 'sbv2_name',
       label: 'sbv2_name',
       type: 'text',
+      isVoiceModel: true,
       visibleIf: (s) => s.tts_type === 'sbv2',
     },
     {
       key: 'sbv2_speaker_id',
       label: 'sbv2_speaker_id',
       type: 'text',
+      isVoiceModel: true,
       visibleIf: (s) => s.tts_type === 'sbv2',
     },
 
@@ -320,6 +339,7 @@ const schemas: Record<string, FieldSchema[]> = {
       key: 'bv2_speaker_id',
       label: 'bv2_speaker_id',
       type: 'text',
+      isVoiceModel: true,
       visibleIf: (s) => s.tts_type === 'bv2',
     },
 
@@ -327,12 +347,16 @@ const schemas: Record<string, FieldSchema[]> = {
       key: 'sbv2api_name',
       label: 'sbv2api_name',
       type: 'text',
+      isVoiceModel: true,
+      realtime: true,
       visibleIf: (s) => s.tts_type === 'sbv2api',
     },
     {
       key: 'sbv2api_speaker_id',
       label: 'sbv2api_speaker_id',
       type: 'text',
+      isVoiceModel: true,
+      realtime: true,
       visibleIf: (s) => s.tts_type === 'sbv2api',
     },
 
@@ -340,12 +364,32 @@ const schemas: Record<string, FieldSchema[]> = {
       key: 'gsv_voice_text',
       label: 'gsv_voice_text',
       type: 'text',
+      isVoiceModel: true,
+      realtime: true,
       visibleIf: (s) => s.tts_type === 'gsv',
     },
     {
       key: 'gsv_voice_filename',
       label: 'gsv_voice_filename',
       type: 'text',
+      isVoiceModel: true,
+      realtime: true,
+      visibleIf: (s) => s.tts_type === 'gsv',
+    },
+    {
+      key: 'gsv_gpt_model_name',
+      label: 'gsv_gpt_model_name',
+      type: 'text',
+      isVoiceModel: true,
+      realtime: true,
+      visibleIf: (s) => s.tts_type === 'gsv',
+    },
+    {
+      key: 'gsv_sovits_model_name',
+      label: 'gsv_sovits_model_name',
+      type: 'text',
+      isVoiceModel: true,
+      realtime: true,
       visibleIf: (s) => s.tts_type === 'gsv',
     },
 
@@ -353,6 +397,7 @@ const schemas: Record<string, FieldSchema[]> = {
       key: 'aivis_model_uuid',
       label: 'aivis_model_uuid',
       type: 'text',
+      isVoiceModel: true,
       visibleIf: (s) => s.tts_type === 'aivis',
     },
   ],
@@ -367,16 +412,40 @@ const currentTabFields = computed(() => {
   return currentTabConfig.value || []
 })
 
+const ensureVoiceModels = () => {
+  if (
+    !localSettings.value.voice_models ||
+    typeof localSettings.value.voice_models !== 'object' ||
+    Array.isArray(localSettings.value.voice_models)
+  ) {
+    localSettings.value.voice_models = {}
+  }
+  return localSettings.value.voice_models as Record<string, unknown>
+}
+
+const migrateLegacyVoiceModelFields = () => {
+  const voiceModels = ensureVoiceModels()
+  for (const key of voiceModelKeys) {
+    const legacyValue = localSettings.value[key]
+    if ((voiceModels[key] === undefined || voiceModels[key] === null) && legacyValue != null) {
+      voiceModels[key] = legacyValue
+    }
+    delete localSettings.value[key]
+  }
+}
+
 const fieldModel = (field: FieldSchema) => {
   return computed({
     get: () => {
-      return localSettings.value[field.key]
+      const target = field.isVoiceModel ? ensureVoiceModels() : localSettings.value
+      return target[field.key]
     },
     set: (val) => {
+      const target = field.isVoiceModel ? ensureVoiceModels() : localSettings.value
       if (field.type === 'number') {
-        localSettings.value[field.key] = Number(val)
+        target[field.key] = Number(val)
       } else {
-        localSettings.value[field.key] = val
+        target[field.key] = val
       }
     },
   })
@@ -417,10 +486,7 @@ watch(
       try {
         const data = await getRoleSettings(props.roleId)
         localSettings.value = JSON.parse(JSON.stringify(data))
-
-        if (!localSettings.value.voice_models) {
-          localSettings.value.voice_models = {}
-        }
+        migrateLegacyVoiceModelFields()
         if (!localSettings.value.voice_lang) {
           localSettings.value.voice_lang = 'ja'
         }
@@ -441,13 +507,8 @@ const handleClose = () => {
 const handleFieldChange = async (field: FieldSchema) => {
   if (!field.realtime || !props.roleId) return
 
-  const value = localSettings.value[field.key]
   try {
-    if (field.key === 'voice_lang') {
-      // 语音语言实时切换：先更新后端内存中的 VoiceMaker，再保存设置文件
-      await invoke('update_voice_lang', { roleId: props.roleId, lang: value })
-    }
-    // 同步保存到角色 settings.yml
+    // 后端会同时保存 settings.yml 并重建已加载角色的 VoiceMaker。
     await updateRoleSettings(props.roleId, localSettings.value)
   } catch (e) {
     console.error(`实时更新 ${field.key} 失败:`, e)

--- a/src/components/settings/pages/SettingsCharacterInfo.vue
+++ b/src/components/settings/pages/SettingsCharacterInfo.vue
@@ -325,6 +325,7 @@ const schemas: Record<string, FieldSchema[]> = {
       label: 'sbv2_name',
       type: 'text',
       isVoiceModel: true,
+      realtime: true,
       visibleIf: (s) => s.tts_type === 'sbv2',
     },
     {
@@ -332,6 +333,7 @@ const schemas: Record<string, FieldSchema[]> = {
       label: 'sbv2_speaker_id',
       type: 'text',
       isVoiceModel: true,
+      realtime: true,
       visibleIf: (s) => s.tts_type === 'sbv2',
     },
 


### PR DESCRIPTION
## 改动内容

- 将角色语音模型参数统一写入 `voice_models`，并兼容迁移旧的顶层字段。
- 保存 TTS 类型、语音语言、SBV2/SBV2API 名称与说话人 ID 或 GPT-SoVITS 参数时，立即重建已加载角色的 `VoiceMaker`。
- GPT-SoVITS 按所选中文/日文传递 `text_lang` 与 `prompt_lang`，支持可选 GPT/SoVITS 权重路径。
- 修正相对角色资源路径的解析，确保参考音频从角色目录读取。
- 串行化 GPT-SoVITS 分段请求、增加一次传输重试，并避免临时错误永久关闭该角色的 TTS。

## 原因

此前前端部分语音字段保存在顶层，而 Rust 后端读取的是 `voice_models`；同时语言实时命令只更新语言，未用完整设置重建适配器，GPT-SoVITS 还固定使用日语。因此界面显示已选中文或已修改说话人参数，但当前会话仍可能继续使用旧配置。并发分段请求也会让部分 Windows ROCm 环境只成功生成第一段。

## 影响范围

仅修改通用 TTS 配置、运行时刷新和 GPT-SoVITS 请求逻辑，不包含本地音色、模型文件、角色配置、构建产物或启动脚本。

## 验证

- `cargo test --manifest-path src-tauri/Cargo.toml --lib`：8 passed
- `vue-tsc --noEmit --skipLibCheck`：通过
- `vite build`：通过
- 修改的 Rust 文件单独通过 `rustfmt --check`
