### PR TITLE
Fix: 修复回放/首句语音未跟随角色音量，并支持回放中实时调节

### DIFF
--- a/src/components/game/standard/GameRolesStage.vue
+++ b/src/components/game/standard/GameRolesStage.vue
@@ -59,6 +59,7 @@ watch(
         const dataUrl = await getVoiceAudio(newAudio)
         mainAudio.value.src = dataUrl
         mainAudio.value.load()
+        mainAudio.value.volume = uiStore.characterVolume / 100
         mainAudio.value.play().catch((e) => console.error('播放失败', e))
         emit('audio-started')
       } catch (e) {

--- a/src/components/pet/GameRolesStage.vue
+++ b/src/components/pet/GameRolesStage.vue
@@ -147,6 +147,7 @@ watch(
       const dataUrl = await getVoiceAudio(newAudio)
       mainAudio.value.src = dataUrl
       mainAudio.value.load()
+      mainAudio.value.volume = uiStore.characterVolume / 100
       mainAudio.value.play().catch((e) => console.error('播放失败', e))
       emit('audio-started')
     } catch (e) {

--- a/src/components/settings/pages/SettingsHistory.vue
+++ b/src/components/settings/pages/SettingsHistory.vue
@@ -273,8 +273,16 @@ async function handleBacktrack(messageSeq: number) {
 const playAudio = async (audioFile: string) => {
   if (!audioFile || !audioRef.value) return
   audioRef.value.src = await getVoiceAudio(audioFile)
+  audioRef.value.volume = uiStore.characterVolume / 100
   audioRef.value.play()
 }
+
+watch(
+  () => uiStore.characterVolume,
+  (v) => {
+    if (audioRef.value) audioRef.value.volume = v / 100
+  },
+)
 
 // 滚动到内容底部（最新记录）
 async function scrollToBottom() {

--- a/src/components/settings_pet/components/tabs/HistoryTab.vue
+++ b/src/components/settings_pet/components/tabs/HistoryTab.vue
@@ -160,6 +160,7 @@ import { useGameStore } from '../../../../stores/modules/game'
 import type { GameMessage } from '../../../../stores/modules/game/state'
 import { convertInitLines } from '../../../../stores/modules/game/actions'
 import { useDialogStore } from '../../../../stores/modules/ui/dialog'
+import { useUIStore } from '../../../../stores/modules/ui/ui'
 import { getVoiceAudio } from '@/api/services/game-info'
 import { invoke } from '@tauri-apps/api/core'
 import type { GameLineInit } from '@/api/services/game-info'
@@ -191,6 +192,7 @@ interface HistoryBlock {
 // --- Store & Refs ---
 const gameStore = useGameStore()
 const dialogStore = useDialogStore()
+const uiStore = useUIStore()
 const audioRef = ref<HTMLAudioElement>()
 const contentRef = ref<HTMLDivElement>()
 
@@ -331,8 +333,16 @@ async function handleBacktrack(messageSeq: number) {
 const playAudio = async (audioFile: string) => {
   if (!audioFile || !audioRef.value) return
   audioRef.value.src = await getVoiceAudio(audioFile)
+  audioRef.value.volume = uiStore.characterVolume / 100
   audioRef.value.play()
 }
+
+watch(
+  () => uiStore.characterVolume,
+  (v) => {
+    if (audioRef.value) audioRef.value.volume = v / 100
+  },
+)
 
 // --- 滚动到内容底部 ---
 async function scrollToBottom() {


### PR DESCRIPTION
### 修复内容

修复回放模式和首句播放时语音音量未跟随角色音量设置的问题，同时支持回放过程中实时调节音量。

### 改动文件

| 文件 | 改动 |
|------|:----:|
| `src/components/game/standard/GameRolesStage.vue` | 首句播放时应用角色音量 |
| `src/components/pet/GameRolesStage.vue` | 桌宠模式首句播放时应用角色音量 |
| `src/components/settings/pages/SettingsHistory.vue` | 回放语音跟随音量 + 增加音量监听实时更新 |
| `src/components/settings_pet/components/tabs/HistoryTab.vue` | 桌宠回放语音跟随音量 + 增加音量监听实时更新 |

### 改动说明

- 在 `playAudio` 和首句播放时设置 `audio.volume = uiStore.characterVolume / 100`
- 新增 `watch(characterVolume)` 监听，回放中调节音量即时生效
- 共 **4 个文件，+20 行**，无侵入改动

### 检验
- [x] 完整编译
- [x] 人工测试