### PR TITLE
feat: OpenTTS 支持角色级音色标识覆盖与英语/韩语语音

### DIFF
--- a/src-tauri/src/ai_service/game_system/role_manager.rs
+++ b/src-tauri/src/ai_service/game_system/role_manager.rs
@@ -478,8 +478,8 @@ impl GameRoleManager {
             return;
         }
 
-        let mut voice_cfg = role.settings.voice_models.clone().unwrap_or_default();
-        voice_cfg.opentts_voice = Some(self.tts_config.opentts_voice.clone());
+        // OpenTTS 音色标识：角色级优先，留空由 VoiceMaker 回退到全局配置
+        let voice_cfg = role.settings.voice_models.clone().unwrap_or_default();
         let name = role.settings.ai_name.clone();
 
         vm.update_lang_and_refresh(&voice_cfg, &tts_type, &name, lang);
@@ -584,9 +584,9 @@ fn build_voice_maker(
     if tts_type.is_empty() {
         return None;
     }
-    let mut voice_cfg = settings.voice_models.clone().unwrap_or_default();
-    // OpenTTS 音色标识统一使用全局 TTS 配置，不再读取角色级字段
-    voice_cfg.opentts_voice = Some(tts_config.opentts_voice.clone());
+    // OpenTTS 音色标识：角色级 voice_models.opentts_voice 优先，
+    // 留空时由 VoiceMaker 回退到全局 TTS 配置（tts.opentts_voice）
+    let voice_cfg = settings.voice_models.clone().unwrap_or_default();
 
     let audio_format = tts_config.audio_format.clone();
     let lang = settings

--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -516,8 +516,9 @@ fn parse_segments(deps: &GeneratorDeps, sentence: &str) -> Vec<EmotionSegment> {
     segments
 }
 
-fn gsv_translation_language(tts_type: &str, voice_lang: &str) -> Option<&'static str> {
-    if tts_type != "gsv" {
+/// GPT-SoVITS 与 OpenTTS 支持把回复翻译成英语/韩语后再合成语音。
+fn translation_language(tts_type: &str, voice_lang: &str) -> Option<&'static str> {
+    if tts_type != "gsv" && tts_type != "opentts" {
         return None;
     }
     match voice_lang {
@@ -544,13 +545,13 @@ async fn enrich_segments(deps: &GeneratorDeps, segments: &mut [EmotionSegment]) 
             .unwrap_or_default()
     };
 
-    if let Some(target_lang) = gsv_translation_language(&tts_type, &voice_lang) {
+    if let Some(target_lang) = translation_language(&tts_type, &voice_lang) {
         let translated = deps
             .translator
             .translate_segments_to(segments, true, target_lang)
             .await?;
         if !translated {
-            // Do not let GPT-SoVITS pronounce the main LLM's Japanese secondary
+            // Do not let TTS pronounce the main LLM's Japanese secondary
             // line when the explicitly selected English/Korean translation fails.
             for segment in segments.iter_mut() {
                 segment.japanese_text.clear();

--- a/src-tauri/src/ai_service/tts/voice_maker.rs
+++ b/src-tauri/src/ai_service/tts/voice_maker.rs
@@ -147,8 +147,9 @@ impl VoiceMaker {
         let gsv = (non_empty(&cfg.gsv_voice_filename) && non_empty(&cfg.gsv_voice_text))
             || (non_empty(&cfg.gsv_gpt_model_name) && non_empty(&cfg.gsv_sovits_model_name));
         let aivis = non_empty(&cfg.aivis_model_uuid);
-        // OpenTTS 可用性由全局配置决定，只要有全局 voice 就视为可用
-        let opentts = !self.tts_config.opentts_voice.trim().is_empty();
+        // OpenTTS 可用性：角色级 voice 优先，全局 TTS 配置兜底，任一非空即可用
+        let opentts =
+            non_empty(&cfg.opentts_voice) || !self.tts_config.opentts_voice.trim().is_empty();
 
         self.availability = TtsAvailability {
             sva,
@@ -275,7 +276,12 @@ impl VoiceMaker {
                 }
             }
             "opentts" if self.availability.opentts => {
-                let voice = cfg.opentts_voice.clone().unwrap_or_default();
+                // 角色级 voice 优先；为空时回退到全局 TTS 配置的音色标识
+                let voice = if non_empty(&cfg.opentts_voice) {
+                    cfg.opentts_voice.clone().unwrap_or_default()
+                } else {
+                    self.tts_config.opentts_voice.clone()
+                };
                 let model = if self.tts_config.opentts_model.trim().is_empty() {
                     "FunAudioLLM/CosyVoice2-0.5B".to_string()
                 } else {

--- a/src/components/settings/pages/SettingsCharacterInfo.vue
+++ b/src/components/settings/pages/SettingsCharacterInfo.vue
@@ -90,6 +90,7 @@
                       v-model="fieldModel(field).value"
                       :type="field.type"
                       :step="field.step"
+                      :placeholder="field.placeholder"
                       class="form-control bg-black/20 border border-white/10 rounded-xl px-3.5 py-2.5 text-white text-sm outline-none transition-all duration-200"
                       @change="handleFieldChange(field)"
                     />
@@ -257,6 +258,7 @@ interface FieldSchema {
   type: FieldType
   rows?: number
   step?: string
+  placeholder?: string
   options?: FieldOption[]
   visibleIf?: (settings: any) => boolean
   isVoiceModel?: boolean
@@ -324,12 +326,12 @@ const schemas: Record<string, FieldSchema[]> = {
         {
           label: '英语',
           value: 'en',
-          visibleIf: (s) => s.tts_type === 'gsv',
+          visibleIf: (s) => s.tts_type === 'gsv' || s.tts_type === 'opentts',
         },
         {
           label: '韩语',
           value: 'ko',
-          visibleIf: (s) => s.tts_type === 'gsv',
+          visibleIf: (s) => s.tts_type === 'gsv' || s.tts_type === 'opentts',
         },
       ],
     },
@@ -423,6 +425,16 @@ const schemas: Record<string, FieldSchema[]> = {
       type: 'text',
       isVoiceModel: true,
       visibleIf: (s) => s.tts_type === 'aivis',
+    },
+
+    {
+      key: 'opentts_voice',
+      label: 'OpenTTS 音色标识',
+      type: 'text',
+      isVoiceModel: true,
+      realtime: true,
+      placeholder: '留空则使用高级设置中的全局音色标识',
+      visibleIf: (s) => s.tts_type === 'opentts',
     },
   ],
 }


### PR DESCRIPTION
## 改动说明

### 1. 角色级 OpenTTS 音色标识（可覆盖全局）
- 角色配置编辑「语音设置」页新增 **OpenTTS 音色标识** 输入框（仅 `tts_type = opentts` 时显示，失焦实时保存）
- 角色填写 `voice_models.opentts_voice` 时使用角色自己的音色；**留空则回退**到高级设置中的全局 `tts.opentts_voice`
- 移除 `role_manager` 构建/刷新 VoiceMaker 时强制以全局音色覆盖角色配置的逻辑，优先级兜底统一收敛在 `voice_maker` 内

### 2. OpenTTS 语音语言开放英语/韩语
- 角色卡「语音语言」在 `tts_type = opentts` 时开放 **英语 / 韩语** 选项（与 gsv 一致）
- 翻译门控 `gsv_translation_language` 泛化为 `translation_language`，gsv / opentts 通用：选英/韩语时回复先经翻译器翻译再合成

### 兼容性
- 不写角色级音色的既有角色行为完全不变（仍走全局配置）
- `VoiceModel.opentts_voice` 字段与旧版平铺字段的迁移逻辑此前已存在，无需额外迁移

### 验证
- `cargo check` 通过；`vue-tsc --noEmit` 通过；`pnpm tauri build` 完整构建通过并实测角色页可正常编辑保存