### PR TITLE
feat: 推理深度选项按模型能力自动显示喵～（对齐 kimi-code 官方机制）

### DIFF
--- a/src-tauri/src/ai_service/llm/mod.rs
+++ b/src-tauri/src/ai_service/llm/mod.rs
@@ -56,7 +56,7 @@ pub struct LlmConfig {
     pub temperature: Option<f64>,
     pub top_p: Option<f64>,
     pub enable_thinking: bool,
-    /// 推理深度（如 "low" / "high" / "max"），目前仅 Kimi Code 的 K3 模型使用。
+    /// 推理深度（如 "low" / "high" / "max"），由支持 reasoning 的模型使用（如 Kimi Code K3 系列）。
     pub reasoning_effort: Option<String>,
 }
 

--- a/src-tauri/src/ai_service/llm/provider.rs
+++ b/src-tauri/src/ai_service/llm/provider.rs
@@ -6,6 +6,13 @@ use serde::Serialize;
 use crate::ai_service::llm::ChunkStream;
 use crate::ai_service::types::{LlmMessage, ToolCall, ToolDefinition};
 
+/// 模型声明的推理深度档位（think_efforts）。
+#[derive(Debug, Clone, Serialize)]
+pub struct ThinkEffortsInfo {
+    pub valid_efforts: Vec<String>,
+    pub default_effort: Option<String>,
+}
+
 /// `complete_with_tools` 的返回值。
 #[derive(Debug, Clone, Serialize)]
 pub struct LlmModelInfo {
@@ -14,6 +21,8 @@ pub struct LlmModelInfo {
     pub context_length: Option<u64>,
     pub supports_reasoning: bool,
     pub supports_thinking_type: Option<String>,
+    /// 推理深度档位；None 表示该模型不可调档（思考常开或不支持思考）
+    pub think_efforts: Option<ThinkEffortsInfo>,
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/ai_service/llm/provider_config.rs
+++ b/src-tauri/src/ai_service/llm/provider_config.rs
@@ -33,7 +33,7 @@ pub struct LlmProviderConfig {
     pub top_p: Option<f64>,
     #[serde(default)]
     pub enable_thinking: bool,
-    /// 推理深度（如 "low" / "high" / "max"），目前仅 Kimi Code 的 K3 模型使用。
+    /// 推理深度（如 "low" / "high" / "max"），由支持 reasoning 的模型使用（如 Kimi Code K3 系列）。
     #[serde(default)]
     pub reasoning_effort: Option<String>,
 }

--- a/src-tauri/src/ai_service/llm/providers/kimi_code.rs
+++ b/src-tauri/src/ai_service/llm/providers/kimi_code.rs
@@ -11,7 +11,9 @@ use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
-use crate::ai_service::llm::provider::{LlmModelInfo, LlmProvider, LlmResponseWithTools};
+use crate::ai_service::llm::provider::{
+    LlmModelInfo, LlmProvider, LlmResponseWithTools, ThinkEffortsInfo,
+};
 use crate::ai_service::llm::{ChunkStream, LlmChunk, LlmConfig};
 use crate::ai_service::types::{LlmMessage, ToolCall, ToolDefinition};
 
@@ -31,6 +33,18 @@ struct KimiCodeModelRecord {
     supports_reasoning: bool,
     #[serde(default)]
     supports_thinking_type: Option<String>,
+    #[serde(default)]
+    think_efforts: Option<KimiCodeThinkEfforts>,
+}
+
+#[derive(Debug, Deserialize)]
+struct KimiCodeThinkEfforts {
+    #[serde(default)]
+    support: bool,
+    #[serde(default)]
+    valid_efforts: Vec<String>,
+    #[serde(default)]
+    default_effort: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -272,6 +286,18 @@ impl LlmProvider for KimiCodeProvider {
                 context_length: model.context_length,
                 supports_reasoning: model.supports_reasoning,
                 supports_thinking_type: model.supports_thinking_type,
+                // 仅当模型显式声明支持调档且给出档位列表时才透传，
+                // 否则视为不可调档（如 K2.7 思考常开、无 valid_efforts）
+                think_efforts: model.think_efforts.and_then(|e| {
+                    if e.support && !e.valid_efforts.is_empty() {
+                        Some(ThinkEffortsInfo {
+                            valid_efforts: e.valid_efforts,
+                            default_effort: e.default_effort,
+                        })
+                    } else {
+                        None
+                    }
+                }),
             })
             .collect::<Vec<_>>();
 

--- a/src/api/services/llm-providers.ts
+++ b/src/api/services/llm-providers.ts
@@ -27,6 +27,10 @@ export interface LlmModelInfo {
   context_length: number | null
   supports_reasoning: boolean
   supports_thinking_type: string | null
+  think_efforts: {
+    valid_efforts: string[]
+    default_effort: string | null
+  } | null
 }
 
 export async function listLlmProviders(): Promise<LlmProvidersResponse> {

--- a/src/components/settings/pages/SettingsLlmProviders.vue
+++ b/src/components/settings/pages/SettingsLlmProviders.vue
@@ -473,18 +473,23 @@
               </p>
             </div>
 
-            <!-- Reasoning effort (K3) -->
+            <!-- Reasoning effort（按模型能力显示） -->
             <div v-if="showReasoningEffort" class="flex flex-col gap-1">
-              <label class="text-xs font-medium text-white/60">推理深度（K3 支持）</label>
+              <label class="text-xs font-medium text-white/60">推理深度（部分模型支持）</label>
               <div class="relative">
                 <select
                   v-model="editing.reasoning_effort"
                   class="w-full appearance-none pl-3 pr-8 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm outline-none focus:border-brand transition-colors cursor-pointer"
                 >
                   <option :value="null" class="bg-gray-800 text-white">默认（跟随模型）</option>
-                  <option value="low" class="bg-gray-800 text-white">Low（低）</option>
-                  <option value="high" class="bg-gray-800 text-white">High（高）</option>
-                  <option value="max" class="bg-gray-800 text-white">Max（最强）</option>
+                  <option
+                    v-for="effort in reasoningEffortOptions"
+                    :key="effort"
+                    :value="effort"
+                    class="bg-gray-800 text-white"
+                  >
+                    {{ effortLabel(effort) }}
+                  </option>
                 </select>
                 <div
                   class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2.5"
@@ -775,14 +780,38 @@ function closePanel() {
   saveMessage.value = ''
 }
 
-// K3 推理深度：仅 Kimi Code 且模型为 k3 时显示
-const showReasoningEffort = computed(
-  () => editing.provider === 'kimicode' && editing.model === 'k3',
-)
+// 推理深度档位完全由模型声明的 think_efforts.valid_efforts 驱动（与 kimi-code 官方一致）：
+// 列表非空 → 显示选择器并按其渲染档位；为空（如 K2.7 思考常开、不可调档）→ 不显示。
+// 列表尚未加载时无法判断能力，先不显示（startEdit 会自动拉取列表）
+const reasoningEffortOptions = computed<string[]>(() => {
+  if (editing.provider !== 'kimicode') return []
+  const info = availableModels.value.find((m) => m.id === editing.model)
+  return info?.think_efforts?.valid_efforts ?? []
+})
+const showReasoningEffort = computed(() => reasoningEffortOptions.value.length > 0)
 
-// 切到不支持推理深度的模型/提供商时清掉已选档位，避免残留值被静默发往其他模型
+const EFFORT_LABELS: Record<string, string> = {
+  low: 'Low（低）',
+  medium: 'Medium（中）',
+  high: 'High（高）',
+  max: 'Max（最强）',
+}
+function effortLabel(effort: string): string {
+  return EFFORT_LABELS[effort] ?? effort
+}
+
+// 切到不可调档的模型/提供商时清掉已选档位，避免残留值被静默发往其他模型；
+// 已选档位不在新模型的档位列表中时同样清空（跟随新模型默认）。
+// 但 Kimi Code 模型列表尚未加载时无法判断能力，先保留已配置值，待列表返回后再决定
 watch([() => editing.provider, () => editing.model], () => {
-  if (!showReasoningEffort.value) editing.reasoning_effort = null
+  if (editing.provider === 'kimicode' && availableModels.value.length === 0) return
+  const options = reasoningEffortOptions.value
+  if (
+    options.length === 0 ||
+    (editing.reasoning_effort && !options.includes(editing.reasoning_effort))
+  ) {
+    editing.reasoning_effort = null
+  }
 })
 
 function resetModelList() {
@@ -840,6 +869,11 @@ function startEdit(p: LlmProviderConfig) {
   resetModelList()
   sidePanel.value = 'edit'
   saveMessage.value = ''
+  // Kimi Code 已有 API 密钥时自动拉取模型列表，
+  // 以便按各模型的 supports_reasoning 能力显示推理深度选项
+  if (editing.provider === 'kimicode' && editing.api_key.trim()) {
+    fetchProviderModels()
+  }
 }
 
 function confirmDelete(p: LlmProviderConfig) {


### PR DESCRIPTION
主人好呀喵～🐾 这是松子代提交的一个小 PRnya～

## 问题喵～

大模型管理的「推理深度」选项之前是硬编码 `model === 'k3'` 才显示的：K3-256k 看不到选项，而 K2.7 Coding 却又能看到不该看的选项，模型一多就维护不动了喵。

## 调查过程nya～

松子对照了 kimi-code 官方实现（MoonshotAI/kimi-code），并实际调用了线上 `/v1/models` 接口拿到各模型的真实能力字段：

| 模型 | supports_reasoning | supports_thinking_type | think_efforts |
|---|---|---|---|
| K2.7 Coding / Highspeed | true | `"only"` | **无（思考常开、不可调档）** |
| K3 / K3-256k | true | `"only"` | `{valid:[low,high,max], default:high}` |

关键结论喵：官方的档位选择器**完全由 `think_efforts` 字段驱动**，`supports_reasoning` 四个模型全是 true 根本区分不了，全仓库也没有任何模型名硬编码nya～

## 改法（对齐官方）喵～

- 后端 `LlmModelInfo` 新增 `think_efforts`（`valid_efforts` / `default_effort`），Kimi Code 模型列表解析时透传（仅 `support=true` 且档位非空）
- 前端选择器完全由当前模型的 `think_efforts.valid_efforts` 驱动：
  - 档位为空（如 K2.7）→ **不显示**推理深度
  - 档位非空（如 K3 系）→ 显示，且**选项就是模型自己声明的列表**，不再写死 low/high/max
- 打开编辑面板时自动拉取模型列表（已有 API 密钥时）；列表未加载前不清空已保存的档位
- 切换模型后，已选档位不在新模型列表里的自动清成「默认（跟随模型）」

## 效果喵～

以后 Kimi 上新模型，只要 API 声明了 `think_efforts`，推理深度的显示与档位名**全自动适配，零代码改动**nya～♪

## 验证喵～

- 实际调用线上 `/v1/models` 确认四个模型的能力字段（见上表）
- `pnpm tauri build` 完整构建通过
- 实测：K2.7 两个模型隐藏选项；K3、K3-256k 显示 low/high/max 三档

请主人查收喵～🐾💕