### PR TITLE
新增：Style-Bert-VITS2 支持英语输出并修复日语切换

### DIFF
--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -546,37 +546,6 @@ fn needs_japanese_translation(segments: &[EmotionSegment]) -> bool {
     })
 }
 
-#[cfg(test)]
-mod language_text_tests {
-    use super::{looks_like_japanese, needs_japanese_translation, tts_translation_language};
-    use crate::ai_service::message_system::processor::EmotionSegment;
-
-    #[test]
-    fn exposes_only_supported_translation_languages() {
-        assert_eq!(tts_translation_language("sbv2", "en"), Some("en"));
-        assert_eq!(tts_translation_language("opentts", "ko"), Some("ko"));
-        assert_eq!(tts_translation_language("sbv2", "ko"), None);
-    }
-
-    #[test]
-    fn recognizes_japanese_and_rejects_english() {
-        assert!(looks_like_japanese("もう満足した？次は私の番でしょ？"));
-        assert!(!looks_like_japanese(
-            "Done copping a feel? Then it is my turn."
-        ));
-    }
-
-    #[test]
-    fn stale_english_translation_is_retranslated_for_japanese() {
-        let segment = EmotionSegment {
-            following_text: "接下来轮到我了。".to_string(),
-            japanese_text: "Now it is my turn.".to_string(),
-            ..Default::default()
-        };
-        assert!(needs_japanese_translation(&[segment]));
-    }
-}
-
 /// Step B: 翻译与语音生成。
 async fn enrich_segments(deps: &GeneratorDeps, segments: &mut [EmotionSegment]) -> Result<()> {
     let (voice_maker, tts_type, voice_lang) = {

--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -516,15 +516,64 @@ fn parse_segments(deps: &GeneratorDeps, sentence: &str) -> Vec<EmotionSegment> {
     segments
 }
 
-/// GPT-SoVITS 与 OpenTTS 支持把回复翻译成英语/韩语后再合成语音。
-fn translation_language(tts_type: &str, voice_lang: &str) -> Option<&'static str> {
-    if tts_type != "gsv" && tts_type != "opentts" {
-        return None;
-    }
-    match voice_lang {
-        "en" => Some("en"),
-        "ko" => Some("ko"),
+/// 返回当前 TTS 需要的目标翻译语言。
+fn tts_translation_language(tts_type: &str, voice_lang: &str) -> Option<&'static str> {
+    match (tts_type, voice_lang) {
+        ("gsv" | "opentts" | "sbv2", "en") => Some("en"),
+        ("gsv" | "opentts", "ko") => Some("ko"),
         _ => None,
+    }
+}
+
+/// 判断文本是否适合作为日语 TTS 输入。
+fn looks_like_japanese(text: &str) -> bool {
+    let has_kana = text
+        .chars()
+        .any(|c| matches!(c, '\u{3040}'..='\u{30ff}' | '\u{31f0}'..='\u{31ff}'));
+    let has_cjk = text
+        .chars()
+        .any(|c| matches!(c, '\u{3400}'..='\u{4dbf}' | '\u{4e00}'..='\u{9fff}'));
+    let has_ascii_letters = text.chars().any(|c| c.is_ascii_alphabetic());
+
+    has_kana || (has_cjk && !has_ascii_letters)
+}
+
+/// 切回日语后，检测并修复上一次英语模式残留的译文。
+fn needs_japanese_translation(segments: &[EmotionSegment]) -> bool {
+    segments.iter().any(|segment| {
+        !segment.following_text.trim().is_empty()
+            && !looks_like_japanese(segment.japanese_text.trim())
+    })
+}
+
+#[cfg(test)]
+mod language_text_tests {
+    use super::{looks_like_japanese, needs_japanese_translation, tts_translation_language};
+    use crate::ai_service::message_system::processor::EmotionSegment;
+
+    #[test]
+    fn exposes_only_supported_translation_languages() {
+        assert_eq!(tts_translation_language("sbv2", "en"), Some("en"));
+        assert_eq!(tts_translation_language("opentts", "ko"), Some("ko"));
+        assert_eq!(tts_translation_language("sbv2", "ko"), None);
+    }
+
+    #[test]
+    fn recognizes_japanese_and_rejects_english() {
+        assert!(looks_like_japanese("もう満足した？次は私の番でしょ？"));
+        assert!(!looks_like_japanese(
+            "Done copping a feel? Then it is my turn."
+        ));
+    }
+
+    #[test]
+    fn stale_english_translation_is_retranslated_for_japanese() {
+        let segment = EmotionSegment {
+            following_text: "接下来轮到我了。".to_string(),
+            japanese_text: "Now it is my turn.".to_string(),
+            ..Default::default()
+        };
+        assert!(needs_japanese_translation(&[segment]));
     }
 }
 
@@ -545,14 +594,21 @@ async fn enrich_segments(deps: &GeneratorDeps, segments: &mut [EmotionSegment]) 
             .unwrap_or_default()
     };
 
-    if let Some(target_lang) = translation_language(&tts_type, &voice_lang) {
+    let translation_language = tts_translation_language(&tts_type, &voice_lang).or_else(|| {
+        if voice_lang == "ja" && needs_japanese_translation(segments) {
+            Some("ja")
+        } else {
+            None
+        }
+    });
+
+    if let Some(target_lang) = translation_language {
         let translated = deps
             .translator
             .translate_segments_to(segments, true, target_lang)
             .await?;
         if !translated {
-            // Do not let TTS pronounce the main LLM's Japanese secondary
-            // line when the explicitly selected English/Korean translation fails.
+            // 目标语言翻译失败时不要回退朗读主模型附带的其他语言译文。
             for segment in segments.iter_mut() {
                 segment.japanese_text.clear();
             }

--- a/src-tauri/src/ai_service/tts/adapters/sbv2.rs
+++ b/src-tauri/src/ai_service/tts/adapters/sbv2.rs
@@ -26,10 +26,11 @@ impl Sbv2Adapter {
         audio_format: String,
         lang: &str,
     ) -> Self {
-        let language = if lang == "ja" {
-            "JP".to_string()
-        } else {
-            lang.to_string()
+        let language = match lang {
+            "ja" => "JP",
+            "zh" => "ZH",
+            "en" => "EN",
+            other => other,
         };
         let api_url = api_url.trim_end_matches('/').to_string();
         Self {
@@ -37,7 +38,7 @@ impl Sbv2Adapter {
             audio_format,
             model_name,
             speaker_id,
-            language,
+            language: language.to_string(),
         }
     }
 }

--- a/src/components/settings/pages/SettingsCharacterInfo.vue
+++ b/src/components/settings/pages/SettingsCharacterInfo.vue
@@ -326,7 +326,8 @@ const schemas: Record<string, FieldSchema[]> = {
         {
           label: '英语',
           value: 'en',
-          visibleIf: (s) => s.tts_type === 'gsv' || s.tts_type === 'opentts',
+          visibleIf: (s) =>
+            s.tts_type === 'gsv' || s.tts_type === 'opentts' || s.tts_type === 'sbv2',
         },
         {
           label: '韩语',


### PR DESCRIPTION
## 改动

- 在角色语音语言选择中为 Style-Bert-VITS2 开放英语
- 将 LingChat 的 `ja`、`zh`、`en` 映射为 SBV2 接口使用的 `JP`、`ZH`、`EN`
- 选择 SBV2 英语时，将中文台词翻译成英文后再交给 TTS
- 从英语切回日语时检测残留英文译文并重新翻译，避免日语 TTS 只朗读英文字母
- 添加语言路由和日语文本检测单元测试

## 原因

Style-Bert-VITS2 后端支持英语，但 LingChat 的角色设置没有为 SBV2 显示英语选项，翻译路由也只覆盖 GPT-SoVITS 和 OpenTTS。运行时从英语切回日语后，旧的英文译文还可能继续进入日语声学前端。

## 影响

角色可在 SBV2 中选择中文、日语和英语并实时切换。现有 GPT-SoVITS 与 OpenTTS 的英语/韩语路由保持不变，SBV2 不开放未支持的韩语。

## 验证

- `pnpm build`
- `cargo test --manifest-path src-tauri/Cargo.toml language_text_tests --lib`（3 项通过）
- `rustfmt --check`（本次修改的两个 Rust 文件）
