### PR TITLE
新增：外置 IndexTTS2 支持情绪标签与中英文切换

### DIFF
--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -520,6 +520,8 @@ fn parse_segments(deps: &GeneratorDeps, sentence: &str) -> Vec<EmotionSegment> {
 fn tts_translation_language(tts_type: &str, voice_lang: &str) -> Option<&'static str> {
     match (tts_type, voice_lang) {
         ("gsv" | "opentts" | "sbv2", "en") => Some("en"),
+        // IndexTTS2 官方支持中/英文：voice_lang=en 时先翻译成英文再合成
+        ("indextts2", "en") => Some("en"),
         ("gsv" | "opentts", "ko") => Some("ko"),
         _ => None,
     }
@@ -554,8 +556,10 @@ mod language_text_tests {
     #[test]
     fn exposes_only_supported_translation_languages() {
         assert_eq!(tts_translation_language("sbv2", "en"), Some("en"));
+        assert_eq!(tts_translation_language("indextts2", "en"), Some("en"));
         assert_eq!(tts_translation_language("opentts", "ko"), Some("ko"));
         assert_eq!(tts_translation_language("sbv2", "ko"), None);
+        assert_eq!(tts_translation_language("indextts2", "ja"), None);
     }
 
     #[test]

--- a/src-tauri/src/ai_service/tts/adapters/indextts.rs
+++ b/src-tauri/src/ai_service/tts/adapters/indextts.rs
@@ -34,13 +34,25 @@ impl Default for IndexTtsAdapter {
     }
 }
 
+/// 情绪分类器标签 → IndexTTS 服务端情绪表可识别标签的归一化。
+///
+/// 服务端（server_indextts.py 的 `EMO_LABEL_TO_VEC`）未覆盖的标签在此归一到
+/// 语义最近的已覆盖标签；其余标签原样透传。未识别的标签服务端会安全回退为
+/// 「跟随音色参考」，不会报错。
+fn normalize_emo_label(emo: &str) -> &str {
+    match emo.trim() {
+        "心动" => "情动",
+        other => other,
+    }
+}
+
 #[async_trait]
 impl TtsAdapter for IndexTtsAdapter {
     async fn generate_voice(&self, text: &str, emo: &str) -> Result<Vec<u8>> {
         let query: Vec<(&str, String)> = vec![
             ("id", self.speaker_id.to_string()),
             ("emo_control_method", "1".into()),
-            ("emo_id", emo.to_string()),
+            ("emo_id", normalize_emo_label(emo).to_string()),
             ("vec1", "0.0".into()),
             ("vec2", "0.0".into()),
             ("vec3", "0.0".into()),

--- a/src-tauri/src/ai_service/tts/voice_maker.rs
+++ b/src-tauri/src/ai_service/tts/voice_maker.rs
@@ -369,7 +369,9 @@ impl VoiceMaker {
             let Some(text) = segment_text_for_lang(&self.lang, seg).map(str::to_owned) else {
                 continue;
             };
-            let emo = String::new();
+            // 将情绪分类器的预测标签传给 TTS 适配器（目前仅 IndexTTS2 消费 emo，
+            // 其余适配器忽略该参数，行为不变）
+            let emo = seg.predicted.clone();
 
             let file_name = if seg.voice_file.is_empty() {
                 format!(

--- a/src-tauri/src/ai_service/tts/voice_maker.rs
+++ b/src-tauri/src/ai_service/tts/voice_maker.rs
@@ -314,6 +314,12 @@ impl VoiceMaker {
                 }
             }
             "indextts2" => {
+                // IndexTTS2 仅支持中/英文：角色若残留日语配置（旧版本可选），
+                // 兜底为中文，避免日语文本被直接送去合成。
+                if self.lang == "ja" {
+                    tracing::warn!("IndexTTS2 不支持日语，voice_lang 已从 ja 兜底为 zh");
+                    self.lang = "zh".to_string();
+                }
                 self.provider.indextts = Some(Arc::new(IndexTtsAdapter::new(
                     self.tts_config.indextts_api_url.clone(),
                 )));

--- a/src/components/settings/pages/SettingsCharacterCreate.vue
+++ b/src/components/settings/pages/SettingsCharacterCreate.vue
@@ -273,6 +273,7 @@
                     <option value="sbv2api">sbv2api</option>
                     <option value="gsv">gsv</option>
                     <option value="aivis">aivis</option>
+                    <option value="indextts2">indextts2</option>
                   </select>
                 </div>
 

--- a/src/components/settings/pages/SettingsCharacterInfo.vue
+++ b/src/components/settings/pages/SettingsCharacterInfo.vue
@@ -312,6 +312,7 @@ const schemas: Record<string, FieldSchema[]> = {
         { label: 'gsv', value: 'gsv' },
         { label: 'aivis', value: 'aivis' },
         { label: 'opentts', value: 'opentts' },
+        { label: 'indextts2', value: 'indextts2' },
       ],
     },
 
@@ -321,13 +322,13 @@ const schemas: Record<string, FieldSchema[]> = {
       type: 'select',
       realtime: true,
       options: [
-        { label: '日语', value: 'ja' },
+        { label: '日语', value: 'ja', visibleIf: (s) => s.tts_type !== 'indextts2' },
         { label: '中文', value: 'zh' },
         {
           label: '英语',
           value: 'en',
           visibleIf: (s) =>
-            s.tts_type === 'gsv' || s.tts_type === 'opentts' || s.tts_type === 'sbv2',
+            ['gsv', 'opentts', 'sbv2', 'indextts2'].includes(s.tts_type),
         },
         {
           label: '韩语',

--- a/src/components/settings/pages/SettingsCharacterInfo.vue
+++ b/src/components/settings/pages/SettingsCharacterInfo.vue
@@ -545,6 +545,16 @@ const handleClose = () => {
 const handleFieldChange = async (field: FieldSchema) => {
   if (!field.realtime || !props.roleId) return
 
+  // IndexTTS2 仅支持中/英文：切换到该类型时，把残留的日语重置为中文，
+  // 避免日语选项被隐藏后旧值仍然生效。
+  if (
+    field.key === 'tts_type' &&
+    localSettings.value.tts_type === 'indextts2' &&
+    localSettings.value.voice_lang === 'ja'
+  ) {
+    localSettings.value.voice_lang = 'zh'
+  }
+
   try {
     // 后端会同时保存 settings.yml 并重建已加载角色的 VoiceMaker。
     await updateRoleSettings(props.roleId, localSettings.value)


### PR DESCRIPTION
## 概述

完善现有的外置 `indextts2` HTTP TTS 方案：在角色设置中开放该类型，把 LingChat 的情绪分类标签传给外置服务，并支持中文/英文实时切换。

原先混入本 PR 的进程内嵌引擎已全部移出，独立为 #541。本 PR 不包含 PyO3、嵌入式 Python、模型资源、音色管理或内置引擎生命周期代码。

## 主要改动

- 角色创建与角色设置页增加 `indextts2` 外置 TTS 类型。
- IndexTTS2 下隐藏不受支持的日语，开放中文/英文选择。
- 选择英语时，语音生成前将文本翻译为英语；翻译失败时不回退朗读其他语言文本。
- 将逐段情绪分类结果传入 TTS 适配器，供现有 IndexTTS2 HTTP 服务消费。
- 保留本分支原有的 SBV2 英语输出及日语切换保护修复。

## 与内置方案的关系

- 本 PR：`indextts2`，通过 HTTP 连接用户自行启动的外置服务。
- #541：`indextts2_builtin`，通过 PyO3 在 LingChat 主进程内加载 IndexTTS-AMD，无端口。

两者是可独立审查、独立合并的替代部署方式，互不依赖。

## 验证

- [x] `pnpm build`：Vue 类型检查与 Vite 生产构建通过
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`：通过
- [x] `git diff --check origin/tauri-refactor...HEAD`：通过

目前保持为 Draft，便于继续审查与 #537 共享的 SBV2 / 翻译路由改动。
