### PR TITLE
feat: 历史对话支持查看 AI 思考链（可展开/收缩）

### DIFF
--- a/src-tauri/src/ai_service/game_system/script_engine/events/dialog_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/dialog_event.rs
@@ -99,6 +99,7 @@ impl ScriptEvent for DialogueEvent {
             display_name: Some(display_name.clone()),
             display_subtitle: Some(display_subtitle),
             user_message_seq: None,
+            thinking: None,
         };
         let _ = emit(ctx.app, "ai:reply", &payload);
 

--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -390,6 +390,10 @@ impl MessageGenerator {
         let (publish_tx, mut publish_rx) =
             mpsc::channel::<(usize, Option<ReplyResponse>)>(self.deps.concurrency.max(1) * 2);
 
+        // producer 与 consumer 共享的思考链缓冲：累积本轮生成的完整思考文本，
+        // 由最终句（is_final）的 consumer 快照并挂载到台词行与前端响应。
+        let thinking_buf = Arc::new(Mutex::new(String::new()));
+
         // publisher：按索引顺序 emit 到前端
         let app = self.deps.app.clone();
         let publisher = tokio::spawn(async move {
@@ -421,6 +425,7 @@ impl MessageGenerator {
             let sentence_rx = sentence_rx.clone();
             let publish_tx = publish_tx.clone();
             let user_message = user_message.clone();
+            let thinking_buf = thinking_buf.clone();
             consumer_tasks.push(tokio::spawn(async move {
                 loop {
                     let item = {
@@ -437,6 +442,7 @@ impl MessageGenerator {
                         &user_message,
                         is_final,
                         user_message_seq,
+                        &thinking_buf,
                     )
                     .await
                     {
@@ -457,7 +463,7 @@ impl MessageGenerator {
 
         // producer：LLM 流 -> 句子
         let llm_stream = self.deps.llm.complete_stream(&context).await?;
-        let producer = StreamProducer::new(llm_stream, sentence_tx, self.deps.app.clone());
+        let producer = StreamProducer::new(llm_stream, sentence_tx, self.deps.app.clone(), thinking_buf);
         let acc = producer.run().await.context("StreamProducer 失败")?;
 
         for t in consumer_tasks {
@@ -481,6 +487,7 @@ async fn consume_sentence(
     user_message: &str,
     is_final: bool,
     user_message_seq: Option<u32>,
+    thinking_buf: &Mutex<String>,
 ) -> Result<Option<ReplyResponse>> {
     if sentence.is_empty() {
         return Ok(None);
@@ -496,8 +503,16 @@ async fn consume_sentence(
     enrich_segments(deps, &mut segments).await?;
 
     // 3. 构建前端响应
-    let response =
+    let mut response =
         build_reply_response(deps, &segments, user_message, is_final, user_message_seq).await?;
+
+    // 3.5 最终句：快照本轮思考链，挂载到响应与台词行（供历史对话展示思考过程）
+    if is_final {
+        let thinking = thinking_buf.lock().await;
+        if !thinking.is_empty() {
+            response.thinking = Some(thinking.clone());
+        }
+    }
 
     // 4. 写入 GameStatus
     add_assistant_line(deps, &response).await?;
@@ -638,6 +653,7 @@ async fn add_assistant_line(deps: &GeneratorDeps, response: &ReplyResponse) -> R
         tts_content: response.tts_text.clone(),
         action_content: response.motion_text.clone(),
         audio_file: response.audio_file.clone(),
+        thinking: response.thinking.clone(),
         display_name: response.character.clone(),
         attribute: LineAttributeExt(LineAttribute::Assistant),
         ..Default::default()

--- a/src-tauri/src/ai_service/message_system/producer.rs
+++ b/src-tauri/src/ai_service/message_system/producer.rs
@@ -10,12 +10,13 @@
 //! - Python 里还会调用一个 `num_end > 0 && buffer[num_end]=='】'` 的数字拆分分支，
 //!   用于拦截 `【1】` 之类非情绪 tag 的起始符；这里等价处理（仍按 `【...】` 捕获）。
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use futures_util::StreamExt;
 use tauri::AppHandle;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 
 use crate::ai_service::llm::{ChunkStream, LlmChunk};
 use crate::ai_service::message_system::events;
@@ -28,11 +29,23 @@ pub struct StreamProducer {
     llm_stream: ChunkStream,
     tx: mpsc::Sender<SentenceItem>,
     app: AppHandle,
+    /// 与 consumer 共享的思考链缓冲：本轮生成的完整思考文本。
+    thinking_buf: Arc<Mutex<String>>,
 }
 
 impl StreamProducer {
-    pub fn new(llm_stream: ChunkStream, tx: mpsc::Sender<SentenceItem>, app: AppHandle) -> Self {
-        Self { llm_stream, tx, app }
+    pub fn new(
+        llm_stream: ChunkStream,
+        tx: mpsc::Sender<SentenceItem>,
+        app: AppHandle,
+        thinking_buf: Arc<Mutex<String>>,
+    ) -> Self {
+        Self {
+            llm_stream,
+            tx,
+            app,
+            thinking_buf,
+        }
     }
 
     /// 消耗整个 LLM 流；返回原始 accumulated_response（未拆分）。
@@ -40,7 +53,6 @@ impl StreamProducer {
         let mut accumulated = String::new();
         let mut realtime_buffer = String::new();
         let mut last_display = Instant::now();
-        let mut thinking_length: usize = 0;
 
         let mut buffer = String::new();
         let mut sentence = String::new();
@@ -142,9 +154,19 @@ impl StreamProducer {
                     }
                 }
                 LlmChunk::Reasoning(text) => {
-                    // 思考链内容：实时统计字数并通知前端，但不加入正式回复。
+                    // 思考链内容：累积进共享缓冲（供 consumer 挂载到台词行），
+                    // 并实时统计字数通知前端，但不加入正式回复。
                     if !text.is_empty() {
-                        thinking_length += text.chars().count();
+                        let mut buf = self.thinking_buf.lock().await;
+                        // 部分供应商（kimi_code / genai）会在流结束时重发完整快照，
+                        // 若新 chunk 以已有内容为前缀则整体替换，避免重复累积。
+                        if text.starts_with(buf.as_str()) {
+                            *buf = text;
+                        } else {
+                            buf.push_str(&text);
+                        }
+                        let thinking_length = buf.chars().count();
+                        drop(buf);
                         events::emit_thinking_progress(&self.app, thinking_length);
                     }
                 }

--- a/src-tauri/src/ai_service/message_system/responses.rs
+++ b/src-tauri/src/ai_service/message_system/responses.rs
@@ -50,6 +50,8 @@ pub struct ReplyResponse {
     /// 触发此回复的用户消息序号（1-indexed，由 sender_role_id == Some(0) 计数得出）。
     /// `None` 表示主动对话等非用户触发的回复。
     pub user_message_seq: Option<u32>,
+    /// 本轮生成的思考链全文（仅最后一帧 is_final=true 时携带）。
+    pub thinking: Option<String>,
 }
 
 impl ReplyResponse {
@@ -70,6 +72,7 @@ impl ReplyResponse {
             display_name: None,
             display_subtitle: None,
             user_message_seq: None,
+            thinking: None,
         }
     }
 }

--- a/src-tauri/src/ai_service/types.rs
+++ b/src-tauri/src/ai_service/types.rs
@@ -129,6 +129,8 @@ pub struct LineBase {
     pub tts_content: Option<String>,
     pub action_content: Option<String>,
     pub audio_file: Option<String>,
+    /// 该轮生成的思考链（仅挂在每轮最后一条 assistant 行上）。
+    pub thinking: Option<String>,
     pub attribute: LineAttributeExt,
     pub sender_role_id: Option<i32>,
     pub display_name: Option<String>,

--- a/src-tauri/src/api/chat.rs
+++ b/src-tauri/src/api/chat.rs
@@ -303,6 +303,7 @@ pub async fn rollback_conversation(
             audio_file: gl.base.audio_file.clone(),
             perceived_role_ids: gl.perceived_role_ids.clone(),
             user_message_seq: seq,
+            thinking: gl.base.thinking.clone(),
         })
         .collect();
 

--- a/src-tauri/src/api/game.rs
+++ b/src-tauri/src/api/game.rs
@@ -111,6 +111,8 @@ pub struct GameLineInit {
     pub perceived_role_ids: Vec<i32>,
     /// 玩家消息序号（1-indexed），仅对 sender_role_id == Some(0) 的 User 行有值
     pub user_message_seq: Option<u32>,
+    /// 该轮生成的思考链（仅每轮最后一条 assistant 行有值）。
+    pub thinking: Option<String>,
 }
 
 // ========== Tauri 命令 ==========
@@ -429,6 +431,7 @@ pub(crate) async fn build_web_init_data(
                 audio_file: gl.base.audio_file.clone(),
                 perceived_role_ids: gl.perceived_role_ids.clone(),
                 user_message_seq: seq,
+                thinking: gl.base.thinking.clone(),
             })
             .collect();
 

--- a/src-tauri/src/db/entities/line.rs
+++ b/src-tauri/src/db/entities/line.rs
@@ -26,6 +26,8 @@ pub struct Model {
     #[sea_orm(column_type = "Text", nullable)]
     pub action_content: Option<String>,
     pub audio_file: Option<String>,
+    #[sea_orm(column_type = "Text", nullable)]
+    pub thinking: Option<String>,
     pub attribute: LineAttribute,
     pub sender_role_id: Option<i32>,
     pub display_name: Option<String>,

--- a/src-tauri/src/db/managers/save_repo.rs
+++ b/src-tauri/src/db/managers/save_repo.rs
@@ -255,6 +255,7 @@ impl SaveRepo {
                         predicted_emotion: db_line.predicted_emotion,
                         tts_content: db_line.tts_content,
                         action_content: db_line.action_content,
+                        thinking: db_line.thinking,
                         audio_file: db_line.audio_file,
                         attribute: LineAttributeExt(db_line.attribute),
                         sender_role_id: db_line.sender_role_id,
@@ -297,6 +298,7 @@ impl SaveRepo {
                     if db_line.content != input_line.base.content
                         || db_line.attribute != input_line.base.attribute.0
                         || db_line.sender_role_id != input_line.base.sender_role_id
+                        || db_line.thinking != input_line.base.thinking
                     {
                         let mut active: line::ActiveModel = db_line.clone().into();
                         active.content = Set(input_line.base.content.clone());
@@ -307,6 +309,7 @@ impl SaveRepo {
                         active.tts_content = Set(input_line.base.tts_content.clone());
                         active.action_content = Set(input_line.base.action_content.clone());
                         active.audio_file = Set(input_line.base.audio_file.clone());
+                        active.thinking = Set(input_line.base.thinking.clone());
                         active.display_name = Set(input_line.base.display_name.clone());
                         active.update(db).await.map_err(|e| anyhow!("{e}"))?;
                     }
@@ -367,6 +370,7 @@ impl SaveRepo {
                     tts_content: Set(input_line.base.tts_content.clone()),
                     action_content: Set(input_line.base.action_content.clone()),
                     audio_file: Set(input_line.base.audio_file.clone()),
+                    thinking: Set(input_line.base.thinking.clone()),
                     save_id: Set(save_id),
                     parent_line_id: Set(parent_id),
                     ..Default::default()

--- a/src-tauri/src/migration/m20260729_000002_add_line_thinking.rs
+++ b/src-tauri/src/migration/m20260729_000002_add_line_thinking.rs
@@ -1,0 +1,35 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Line::Table)
+                    .add_column(ColumnDef::new(Line::Thinking).text().null())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Line::Table)
+                    .drop_column(Line::Thinking)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Line {
+    Table,
+    Thinking,
+}

--- a/src-tauri/src/migration/mod.rs
+++ b/src-tauri/src/migration/mod.rs
@@ -5,8 +5,12 @@ pub struct Migrator;
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20240101_000001_create_tables::Migration)]
+        vec![
+            Box::new(m20240101_000001_create_tables::Migration),
+            Box::new(m20260729_000002_add_line_thinking::Migration),
+        ]
     }
 }
 
 pub mod m20240101_000001_create_tables;
+pub mod m20260729_000002_add_line_thinking;

--- a/src/api/services/game-info.ts
+++ b/src/api/services/game-info.ts
@@ -36,6 +36,8 @@ export interface GameLineInit {
   perceived_role_ids: number[]
   /** 玩家消息序号（1-indexed），仅 sender_role_id == 0 的 user 行有值 */
   user_message_seq: number | null
+  /** 该轮生成的思考链（仅每轮最后一条 assistant 行有值） */
+  thinking: string | null
 }
 
 // 2. 定义完整的初始化数据接口 (对应 Rust WebInitData)

--- a/src/components/settings/pages/SettingsHistory.vue
+++ b/src/components/settings/pages/SettingsHistory.vue
@@ -37,6 +37,21 @@
                     回溯
                   </button>
                 </div>
+                <div v-if="item.thinking" class="mb-1">
+                  <button
+                    class="inline-flex cursor-pointer items-center gap-1 rounded-full border border-[rgba(121,217,255,0.25)] bg-[rgba(121,217,255,0.08)] px-2.5 py-0.5 text-xs text-[#a8d8f0]/70 transition-all duration-200 hover:border-[rgba(121,217,255,0.5)] hover:text-[#c9e7ff]"
+                    @click.stop="toggleThinking(i)"
+                  >
+                    <span>{{ isThinkingExpanded(i) ? '▼' : '▶' }}</span>
+                    <span>思考过程（{{ item.thinking.length }} 字）</span>
+                  </button>
+                  <div
+                    v-if="isThinkingExpanded(i)"
+                    class="mt-1.5 max-h-64 overflow-y-auto rounded-2xl border border-[rgba(121,217,255,0.15)] bg-[rgba(121,217,255,0.05)] px-4 py-3 text-[15px] leading-normal whitespace-pre-wrap text-white/55 scrollbar-thin"
+                  >
+                    {{ item.thinking }}
+                  </div>
+                </div>
                 <template v-for="(entry, j) in item.lines" :key="j">
                   <div
                     v-for="(seg, k) in entry.segments"
@@ -119,6 +134,7 @@ interface LineEntry {
   segments: Segment[]
   audioFile?: string
   userMessageSeq?: number
+  thinking?: string
 }
 
 interface HistoryBlock {
@@ -126,6 +142,8 @@ interface HistoryBlock {
   isNarration: boolean
   lines: LineEntry[]
   userMessageSeq?: number
+  /** 该对话块（一轮生成）的思考链，取块内最后一条非空值 */
+  thinking?: string
 }
 
 const gameStore = useGameStore()
@@ -143,6 +161,23 @@ const PAGE_SIZE = 100
 
 // 当前页码
 const currentPage = ref(1)
+
+// 思考过程展开状态（key: 对话块索引），默认全部折叠
+const expandedThinking = ref<Set<number>>(new Set())
+
+function isThinkingExpanded(blockIdx: number): boolean {
+  return expandedThinking.value.has(blockIdx)
+}
+
+function toggleThinking(blockIdx: number) {
+  const next = new Set(expandedThinking.value)
+  if (next.has(blockIdx)) {
+    next.delete(blockIdx)
+  } else {
+    next.add(blockIdx)
+  }
+  expandedThinking.value = next
+}
 
 // 计算总页数
 const totalPages = computed(() => Math.ceil(dialogHistory.value.length / PAGE_SIZE))
@@ -175,12 +210,16 @@ const groupedHistory = computed<HistoryBlock[]>(() => {
       segments,
       audioFile: msg.audioFile,
       userMessageSeq: msg.userMessageSeq,
+      thinking: msg.thinking,
     }
 
     const last = blocks.length > 0 ? blocks[blocks.length - 1] : null
     if (last && last.displayName === name && last.isNarration === isNarration) {
       if (entry.userMessageSeq !== undefined && last.userMessageSeq === undefined) {
         last.userMessageSeq = entry.userMessageSeq
+      }
+      if (entry.thinking) {
+        last.thinking = entry.thinking
       }
       last.lines.push(entry)
     } else {
@@ -189,6 +228,7 @@ const groupedHistory = computed<HistoryBlock[]>(() => {
         isNarration,
         lines: [entry],
         userMessageSeq: entry.userMessageSeq,
+        thinking: entry.thinking,
       })
     }
   }
@@ -259,6 +299,7 @@ async function handleBacktrack(messageSeq: number) {
           audio_file: l.audio_file,
           perceived_role_ids: l.perceived_role_ids,
           user_message_seq: l.user_message_seq,
+          thinking: l.thinking ?? null,
         }),
       ),
     )

--- a/src/components/settings_pet/components/tabs/HistoryTab.vue
+++ b/src/components/settings_pet/components/tabs/HistoryTab.vue
@@ -68,6 +68,27 @@
                   回溯
                 </button>
               </div>
+              <div v-if="item.thinking" class="mb-1">
+                <button
+                  class="inline-flex cursor-pointer items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs transition-all duration-200"
+                  :class="isDarkMode
+                    ? 'border-sky-400/25 bg-sky-400/10 text-sky-200/70 hover:border-sky-400/50 hover:text-sky-100'
+                    : 'border-sky-200 bg-sky-50 text-sky-500/80 hover:border-sky-300 hover:text-sky-600'"
+                  @click.stop="toggleThinking(i)"
+                >
+                  <span>{{ isThinkingExpanded(i) ? '▼' : '▶' }}</span>
+                  <span>思考过程（{{ item.thinking.length }} 字）</span>
+                </button>
+                <div
+                  v-if="isThinkingExpanded(i)"
+                  class="mt-1.5 max-h-64 overflow-y-auto rounded-2xl border px-4 py-3 text-[15px] leading-normal whitespace-pre-wrap scrollbar-thin"
+                  :class="isDarkMode
+                    ? 'border-sky-400/15 bg-sky-400/5 text-white/55'
+                    : 'border-sky-100 bg-sky-50/70 text-slate-500'"
+                >
+                  {{ item.thinking }}
+                </div>
+              </div>
               <template v-for="(entry, j) in item.lines" :key="j">
                 <div
                   v-for="(seg, k) in entry.segments"
@@ -180,6 +201,7 @@ interface LineEntry {
   segments: Segment[]
   audioFile?: string
   userMessageSeq?: number
+  thinking?: string
 }
 
 interface HistoryBlock {
@@ -187,6 +209,8 @@ interface HistoryBlock {
   isNarration: boolean
   lines: LineEntry[]
   userMessageSeq?: number
+  /** 该对话块（一轮生成）的思考链，取块内最后一条非空值 */
+  thinking?: string
 }
 
 // --- Store & Refs ---
@@ -204,6 +228,23 @@ const ACTION_RE = /（[^）]*）/
 const PAGE_SIZE = 100
 const currentPage = ref(1)
 const totalPages = computed(() => Math.ceil(dialogHistory.value.length / PAGE_SIZE))
+
+// 思考过程展开状态（key: 对话块索引），默认全部折叠
+const expandedThinking = ref<Set<number>>(new Set())
+
+function isThinkingExpanded(blockIdx: number): boolean {
+  return expandedThinking.value.has(blockIdx)
+}
+
+function toggleThinking(blockIdx: number) {
+  const next = new Set(expandedThinking.value)
+  if (next.has(blockIdx)) {
+    next.delete(blockIdx)
+  } else {
+    next.add(blockIdx)
+  }
+  expandedThinking.value = next
+}
 
 const currentPageHistory = computed(() => {
   const start = (currentPage.value - 1) * PAGE_SIZE
@@ -233,12 +274,16 @@ const groupedHistory = computed<HistoryBlock[]>(() => {
       segments,
       audioFile: msg.audioFile,
       userMessageSeq: msg.userMessageSeq,
+      thinking: msg.thinking,
     }
 
     const last = blocks.length > 0 ? blocks[blocks.length - 1] : null
     if (last && last.displayName === name && last.isNarration === isNarration) {
       if (entry.userMessageSeq !== undefined && last.userMessageSeq === undefined) {
         last.userMessageSeq = entry.userMessageSeq
+      }
+      if (entry.thinking) {
+        last.thinking = entry.thinking
       }
       last.lines.push(entry)
     } else {
@@ -247,6 +292,7 @@ const groupedHistory = computed<HistoryBlock[]>(() => {
         isNarration,
         lines: [entry],
         userMessageSeq: entry.userMessageSeq,
+        thinking: entry.thinking,
       })
     }
   }
@@ -318,6 +364,7 @@ async function handleBacktrack(messageSeq: number) {
           audio_file: l.audio_file,
           perceived_role_ids: l.perceived_role_ids,
           user_message_seq: l.user_message_seq,
+          thinking: l.thinking ?? null,
         }),
       ),
     )

--- a/src/core/events/processors/dialogue-processor.ts
+++ b/src/core/events/processors/dialogue-processor.ts
@@ -38,6 +38,7 @@ export default class DialogueProcessor implements IEventProcessor {
       motionText: event.motionText,
       originalTag: event.originalTag,
       userMessageSeq: event.userMessageSeq,
+      thinking: event.thinking,
     })
 
     // 回溯更新最近一条没有序号标记的用户消息（前端发送消息时尚未拿到序号）

--- a/src/stores/modules/game/actions.ts
+++ b/src/stores/modules/game/actions.ts
@@ -277,6 +277,7 @@ export function convertInitLines(lines: GameLineInit[]): GameMessage[] {
       originalTag: line.original_emotion || undefined,
       timestamp: Date.now(),
       userMessageSeq: line.user_message_seq ?? undefined,
+      thinking: line.thinking || undefined,
     }
   })
 }

--- a/src/stores/modules/game/state.ts
+++ b/src/stores/modules/game/state.ts
@@ -12,6 +12,8 @@ export interface GameMessage {
   timestamp?: number
   /** 玩家消息序号（1-indexed），用于回溯定位 */
   userMessageSeq?: number
+  /** 该轮生成的思考链（仅每轮最后一条回复消息有值） */
+  thinking?: string
 }
 
 export interface FreeDialogueInfo {

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -39,6 +39,8 @@ export interface ScriptDialogueEvent extends ScriptEvent {
   displaySubtitle?: string
   /** 触发此回复的用户消息序号（1-indexed） */
   userMessageSeq?: number
+  /** 本轮生成的思考链（仅最后一帧携带） */
+  thinking?: string
 }
 
 export interface ScriptThinkingEvent extends ScriptEvent {


### PR DESCRIPTION
## 概述

在历史对话面板中为每轮 AI 生成增加可展开/收缩的「思考过程」区域，展示该轮生成的思考链内容；数据落库，重启应用后仍可查看。

## 后端

- `line` 表新增 `thinking` 可空列（迁移 `m20260729_000002_add_line_thinking`，对旧存档自动升级、向后兼容）
- `StreamProducer` 将 `LlmChunk::Reasoning` 文本累积进与 consumer 共享的缓冲（此前仅统计字数后丢弃）；并处理供应商在流末尾重发全量快照导致的重复累积（前缀则替换）
- 每轮生成的最终句（is_final）将思考链快照挂载到台词行与 `ai:reply` 响应（`ReplyResponse.thinking`）
- `web_init` / `rollback_conversation` / 存档读写（save_repo）全链路携带 thinking

## 前端

- 桌面端 `SettingsHistory.vue` 与桌宠端 `HistoryTab.vue`：对话块标题下方新增「思考过程（N 字）」折叠按钮，点击展开/收缩，每块独立状态
- `GameMessage` / `GameLineInit` / `ScriptDialogueEvent` 类型与转换链路同步

## 说明

- 仅主对话管道（run_pipeline）产出的消息带思考链；剧本引擎台词不带（为 None），旧历史消息无数据时不显示按钮
- 已通过 `cargo check` 与 `pnpm build`（vue-tsc + vite）验证