### PR TITLE
feat: 诺一钦灵切换 GPT-SoVITS 派蒙音色并随包附带参考音频

### DIFF
--- a/data/game_data/characters/诺一钦灵/settings.yml
+++ b/data/game_data/characters/诺一钦灵/settings.yml
@@ -125,16 +125,17 @@ system_prompt_example_old: |-
   2.“【生气】不允许和我说恶心的东西！<気持ち悪いことを言ってはいけない！>【慌张】被那种东西碰到的话，感觉浑身都不干净啦！<そんなものに触られると、体中が不潔になってしまう気がします！>”
 thinking_message: 灵灵正在思考中...
 title: 可爱的小狼娘
-tts_type: sbv2
+tts_type: gsv
 user_name: 莱姆
 user_subtitle: Bilibili
+voice_lang: zh
 voice_models:
   aivis_model_uuid: 44f93196-7485-45af-9616-f33adee71846
   bv2_speaker_id: '0'
-  gsv_gpt_model_name: ''
-  gsv_sovits_model_name: ''
-  gsv_voice_filename: ''
-  gsv_voice_text: ''
+  gsv_gpt_model_name: H:/LingChat/GPT-SoVITS/GPT_weights_v4/paimeng_v4-e15.ckpt
+  gsv_sovits_model_name: H:/LingChat/GPT-SoVITS/SoVITS_weights_v4/paimeng_v4_e2_s192_l32.pth
+  gsv_voice_filename: paimeng_ref.wav
+  gsv_voice_text: 爱丽丝已经做好准备。嗯，听说马上又有新游戏发售了，老师会一起玩的吧？
   sbv2_name: Ling-v2
   sbv2_speaker_id: '0'
   sbv2api_name: Ling v2

--- a/data/game_data/characters/诺一钦灵/voice/paimeng_ref.wav
+++ b/data/game_data/characters/诺一钦灵/voice/paimeng_ref.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28740dbfb9e06b5e215e3982a92fe2eb6de4ebd92194649d5c37b5a3d8a8ff9d
+size 630862

--- a/scripts/prepare-desktop-resources.mjs
+++ b/scripts/prepare-desktop-resources.mjs
@@ -60,6 +60,12 @@ const SKIP_PATTERNS = [
 
 const gameDataFiles = [];
 
+// 本地定制发行版需要随角色携带的参考音频。它们可以保持未跟踪状态，
+// 但只要文件存在，就必须进入桌面安装包和数据清单。
+const LOCAL_RELEASE_FILES = [
+  "game_data/characters/诺一钦灵/voice/paimeng_ref.wav",
+];
+
 for (const relPath of gitFiles) {
   // 去掉 "data/" 前缀
   const subPath = relPath.slice("data/".length);
@@ -75,6 +81,13 @@ for (const relPath of gitFiles) {
   }
 
   gameDataFiles.push(subPath);
+}
+
+for (const subPath of LOCAL_RELEASE_FILES) {
+  const src = join(projectRoot, "data", subPath);
+  if (existsSync(src) && !gameDataFiles.includes(subPath)) {
+    gameDataFiles.push(subPath);
+  }
 }
 
 console.log(`   game_data: ${gameDataFiles.length} 个文件`);


### PR DESCRIPTION
## 概述

诺一钦灵的 TTS 配置从 SBV2 切换为 GPT-SoVITS（派蒙 v4 模型），并把参考音频打进桌面安装包。拆分自本地工作区改动（按 #546 评审意见单独成 PR）。

## 改动（3 项）

- `data/game_data/characters/诺一钦灵/settings.yml`：`tts_type: sbv2 → gsv`，`voice_lang: zh`，配置 gsv 模型与参考音频/参考文本
- `data/game_data/characters/诺一钦灵/voice/paimeng_ref.wav`：新增参考音频（630KB）
- `scripts/prepare-desktop-resources.mjs`：新增 `LOCAL_RELEASE_FILES` 机制——未被 git 跟踪的本地发行文件（如此参考音频）也会复制进 `.bundled_resources` 并写入数据清单，确保进入桌面安装包

## ⚠️ 需要维护者确认的一点

`settings.yml` 中 `gsv_gpt_model_name` / `gsv_sovits_model_name` 目前是我本机的**绝对路径**（`H:/LingChat/GPT-SoVITS/...`）。模型本体（GB 级）不在本 PR 内，只有参考音频。请维护者决定：改为相对/约定路径、改成你侧的实际模型路径，或另行提供模型分发方式后再调整这两行。

## 验证

- `node scripts/prepare-desktop-resources.mjs` 本地构建通过，参考音频已进入 `.bundled_resources` 与 `data_manifest.json`