### PR TITLE
fix: 番茄钟改为时间戳制计时，修复丢时/完成态/折叠停止问题，新增暂停反馈与圆环拖动调时

### DIFF
--- a/src/components/pomodoro/PomodoroPanel.vue
+++ b/src/components/pomodoro/PomodoroPanel.vue
@@ -10,7 +10,12 @@
       v-show="!uiStore.showSettings"
     >
       <span class="text-xl">🍅</span>
-      <h3 class="text-lg font-bold m-0 hidden xl:block">番茄钟(实验)</h3>
+      <h3 class="text-lg font-bold m-0 hidden xl:block">
+        番茄钟
+        <span v-if="isRunning" class="ml-1 text-sm font-normal tabular-nums opacity-80">
+          {{ minutes }}:{{ seconds }}
+        </span>
+      </h3>
     </Button>
 
     <Transition
@@ -43,11 +48,20 @@
                 r="45"
                 :style="progressStyle"
               />
+              <!-- 隐形加宽轨道：圆环的拖动热区（不显示拖动手柄） -->
+              <circle
+                class="fill-none stroke-transparent cursor-pointer"
+                style="stroke-width: 14; touch-action: none"
+                cx="50"
+                cy="50"
+                r="45"
+                @pointerdown="onScrubStart"
+              />
             </svg>
 
-            <div class="absolute inset-0 flex flex-col items-center justify-center z-10">
+            <div class="absolute inset-0 flex flex-col items-center justify-center z-10 pointer-events-none">
               <div
-                class="h-6 flex items-center justify-center mb-1 cursor-pointer group"
+                class="h-6 flex items-center justify-center mb-1 cursor-pointer group pointer-events-auto"
                 @click="startEditLabel"
                 title="点击修改名称"
               >
@@ -237,6 +251,8 @@ const STORAGE_KEY_CYCLES_TOTAL = 'pomodoro_cycles_total'
 const STORAGE_KEY_WORK_MS = 'pomodoro_work_ms'
 const STORAGE_KEY_BREAK_MS = 'pomodoro_break_ms'
 const STORAGE_KEY_WORK_LABEL = 'pomodoro_work_label'
+const STORAGE_KEY_PHASE_END_AT = 'pomodoro_phase_end_at'
+const STORAGE_KEY_COMPLETED = 'pomodoro_completed'
 
 type Mode = 'work' | 'break'
 
@@ -257,6 +273,11 @@ const cyclesTotal = ref<number>(DEFAULT_CYCLES_TOTAL)
 const cycleIndex = ref<number>(1)
 
 const remainingMs = ref<number>(DEFAULT_WORK_MS)
+// 当前阶段的结束时刻（时间戳，毫秒）。运行中以它为准计算剩余时间，
+// 页面被节流/挂起/刷新后可以用 Date.now() 一次性补跑，不会丢时间。
+const phaseEndAt = ref<number>(0)
+// 全部轮次已完成（对应参考游戏的 Complete 状态），下次开始会从第一轮专注重新起步
+const justCompleted = ref(false)
 let timerId: number | null = null
 
 const workMinutesInput = ref(25)
@@ -282,25 +303,28 @@ const progress = computed(() => {
   const p = 1 - remainingMs.value / total
   return Math.min(1, Math.max(0, p))
 })
+// 正在拖动圆环调整时间（不显示拖动手柄，圆环本身就是热区）
+const scrubbing = ref(false)
+
 const progressStyle = computed(() => ({
   strokeDasharray: `${circumference}`,
   strokeDashoffset: `${(1 - progress.value) * circumference}`,
   transformOrigin: '50% 50%',
+  // 拖动时禁用过渡动画，否则圆环跟不上指针
+  transition: scrubbing.value ? 'none' : undefined,
 }))
 
 const statusText = computed(() => {
-  if (
-    !isRunning.value &&
-    remainingMs.value === currentTotalMs.value &&
-    cycleIndex.value === 1 &&
-    mode.value === 'work'
-  ) {
-    return '空闲中'
+  if (isRunning.value) {
+    return mode.value === 'work' ? '专注中' : '休息中'
   }
-  if (!isRunning.value) {
-    return '空闲中'
+  if (justCompleted.value) {
+    return '已完成'
   }
-  return mode.value === 'work' ? '专注中' : '休息中'
+  // 从未启动过的初始状态才算空闲，停在半途中属于暂停
+  const isPristine =
+    remainingMs.value === currentTotalMs.value && cycleIndex.value === 1 && mode.value === 'work'
+  return isPristine ? '空闲中' : '已暂停'
 })
 
 const pendingPrompts = ref<string[]>([])
@@ -373,6 +397,8 @@ function persistState() {
   localStorage.setItem(STORAGE_KEY_WORK_MS, JSON.stringify(workDurationMs.value))
   localStorage.setItem(STORAGE_KEY_BREAK_MS, JSON.stringify(breakDurationMs.value))
   localStorage.setItem(STORAGE_KEY_WORK_LABEL, workLabel.value)
+  localStorage.setItem(STORAGE_KEY_PHASE_END_AT, JSON.stringify(phaseEndAt.value))
+  localStorage.setItem(STORAGE_KEY_COMPLETED, JSON.stringify(justCompleted.value))
 }
 
 function clearTimer() {
@@ -382,45 +408,132 @@ function clearTimer() {
   }
 }
 
-function tick() {
-  const prevMode = mode.value
-  const prevCycle = cycleIndex.value
+// ─── 圆环拖动调时间 ─────────────────────────────────
+// 指针位置 → 从 12 点方向顺时针的进度比例（与圆环绘制方向一致）
+let scrubEl: Element | null = null
 
-  remainingMs.value = Math.max(0, remainingMs.value - 1000)
-  if (remainingMs.value === 0) {
-    if (mode.value === 'work') {
-      mode.value = 'break'
-      remainingMs.value = breakDurationMs.value
-      sendUserPrompt(
-        `{番茄钟提醒：第${prevCycle}/${cyclesTotal.value}轮专注结束，开始休息 ${formatMinutes(breakDurationMs.value)} 分钟。}`,
-      )
-    } else {
-      if (cycleIndex.value < cyclesTotal.value) {
-        cycleIndex.value += 1
-        mode.value = 'work'
-        remainingMs.value = workDurationMs.value
-        sendUserPrompt(
-          `{番茄钟提醒：休息结束，开始第${cycleIndex.value}/${cyclesTotal.value}轮专注（${workLabel.value}），时长 ${formatMinutes(workDurationMs.value)} 分钟}`,
-        )
-      } else {
-        clearTimer()
-        isRunning.value = false
-        sendUserPrompt(
-          `{番茄钟提醒：本次番茄钟已完成（专注 ${formatMinutes(workDurationMs.value)} 分钟 + 休息 ${formatMinutes(breakDurationMs.value)} 分钟 × ${cyclesTotal.value} 轮）。}`,
-        )
-      }
-    }
+function scrubFraction(e: PointerEvent) {
+  if (!scrubEl) return 0
+  const rect = scrubEl.getBoundingClientRect()
+  const dx = e.clientX - (rect.left + rect.width / 2)
+  const dy = e.clientY - (rect.top + rect.height / 2)
+  return (Math.atan2(dx, -dy) / (2 * Math.PI) + 1) % 1
+}
+
+function applyScrub(e: PointerEvent) {
+  const total = currentTotalMs.value
+  // 圆环进度 = 1 - 剩余/总时长；限制在 1 秒 ~ 总时长之间，避免误触阶段切换
+  const next = Math.round(((1 - scrubFraction(e)) * total) / 1000) * 1000
+  remainingMs.value = Math.min(total, Math.max(1000, next))
+  if (isRunning.value) {
+    phaseEndAt.value = Date.now() + remainingMs.value
   }
+}
+
+function onScrubStart(e: PointerEvent) {
+  scrubEl = e.currentTarget as Element
+  scrubbing.value = true
+  applyScrub(e)
+  window.addEventListener('pointermove', onScrubMove)
+  window.addEventListener('pointerup', onScrubEnd, { once: true })
+  e.preventDefault()
+}
+
+function onScrubMove(e: PointerEvent) {
+  if (!scrubbing.value) return
+  applyScrub(e)
+}
+
+function onScrubEnd() {
+  if (!scrubbing.value) return
+  scrubbing.value = false
+  scrubEl = null
+  window.removeEventListener('pointermove', onScrubMove)
+  persistState()
+}
+
+// 推进到下一个阶段，返回需要发给 AI 的提示文本。
+// 下一阶段的结束时刻沿用上一次的结束时间链式推算，长时间挂起后可以逐阶段补跑。
+function advancePhase(): string | null {
+  const prevCycle = cycleIndex.value
+  const endedAt = phaseEndAt.value
+
+  if (mode.value === 'work') {
+    mode.value = 'break'
+    phaseEndAt.value = endedAt + breakDurationMs.value
+    return `{番茄钟提醒：第${prevCycle}/${cyclesTotal.value}轮专注结束，开始休息 ${formatMinutes(breakDurationMs.value)} 分钟。}`
+  }
+
+  if (cycleIndex.value < cyclesTotal.value) {
+    cycleIndex.value += 1
+    mode.value = 'work'
+    phaseEndAt.value = endedAt + workDurationMs.value
+    return `{番茄钟提醒：休息结束，开始第${cycleIndex.value}/${cyclesTotal.value}轮专注（${workLabel.value}），时长 ${formatMinutes(workDurationMs.value)} 分钟}`
+  }
+
+  // 所有轮次完成：回到第一轮专注的待启动状态，下次按开始才能正确从专注起步
+  clearTimer()
+  isRunning.value = false
+  justCompleted.value = true
+  mode.value = 'work'
+  cycleIndex.value = 1
+  remainingMs.value = workDurationMs.value
+  phaseEndAt.value = 0
+  return `{番茄钟提醒：本次番茄钟已完成（专注 ${formatMinutes(workDurationMs.value)} 分钟 + 休息 ${formatMinutes(breakDurationMs.value)} 分钟 × ${cyclesTotal.value} 轮）。}`
+}
+
+function tick() {
+  if (!isRunning.value || phaseEndAt.value <= 0) return
+
+  const now = Date.now()
+  let remaining = phaseEndAt.value - now
+  const prompts: string[] = []
+  let guard = 0
+
+  // 页面被节流/挂起/刷新时 remaining 可能已跨过多个阶段，循环补跑直到追上当前时刻
+  while (remaining <= 0 && guard++ < 10000) {
+    const prompt = advancePhase()
+    if (prompt) prompts.push(prompt)
+    if (!isRunning.value) break // 全部轮次完成
+    remaining = phaseEndAt.value - now
+  }
+
+  if (isRunning.value) {
+    remainingMs.value = Math.max(0, remaining)
+  }
+
+  // 补跑跨过了多个阶段时只发最后一条提示，避免恢复时连续刷屏
+  const lastPrompt = prompts[prompts.length - 1]
+  if (lastPrompt) sendUserPrompt(lastPrompt)
+
   persistState()
 }
 
 function start() {
   if (isRunning.value) return
-  if (remainingMs.value <= 0) remainingMs.value = currentTotalMs.value
+  // 已完成或剩余时间异常归零时，从第一轮专注重新开始，
+  // 否则会错误地以上一次结束时的休息阶段启动
+  if (justCompleted.value || remainingMs.value <= 0) {
+    mode.value = 'work'
+    cycleIndex.value = 1
+    remainingMs.value = workDurationMs.value
+  }
+  // 中途继续和全新启动发给 AI 的提示不同（全新启动的消息格式被成就系统识别，不可改动）
+  const isResume = remainingMs.value > 0 && remainingMs.value < currentTotalMs.value
+  justCompleted.value = false
   isRunning.value = true
+  phaseEndAt.value = Date.now() + remainingMs.value
   clearTimer()
   timerId = window.setInterval(tick, 1000)
   persistState()
+
+  if (isResume) {
+    const resumePhase = mode.value === 'work' ? `专注（${workLabel.value}）` : '休息'
+    sendUserPrompt(
+      `{番茄钟提醒：我继续番茄钟，第${cycleIndex.value}/${cyclesTotal.value}轮${resumePhase}，剩余 ${minutes.value}:${seconds.value}。}`,
+    )
+    return
+  }
 
   const phaseText = mode.value === 'work' ? `开始专注（${workLabel.value}）` : '开始休息'
   sendUserPrompt(
@@ -430,15 +543,26 @@ function start() {
 
 function pause() {
   if (!isRunning.value) return
+  // 把剩余时间落盘为固定值，恢复时再折算成新的结束时刻
+  remainingMs.value = Math.max(0, phaseEndAt.value - Date.now())
+  phaseEndAt.value = 0
   isRunning.value = false
   clearTimer()
   persistState()
+
+  // 暂停也告知 AI，方便角色做出反应（与阶段切换提醒同格式）
+  const phaseText = mode.value === 'work' ? `专注（${workLabel.value}）` : '休息'
+  sendUserPrompt(
+    `{番茄钟提醒：我暂停了番茄钟，第${cycleIndex.value}/${cyclesTotal.value}轮${phaseText}，剩余 ${minutes.value}:${seconds.value}。}`,
+  )
 }
 
 function reset() {
   mode.value = 'work'
   cycleIndex.value = 1
   remainingMs.value = workDurationMs.value
+  justCompleted.value = false
+  phaseEndAt.value = 0
   isRunning.value = false
   clearTimer()
   persistState()
@@ -497,11 +621,9 @@ function adjustCycles(delta: number) {
   applyCycles()
 }
 
-watch(enabled, (val) => {
-  if (!val) {
-    clearTimer()
-    isRunning.value = false
-  }
+// 折叠面板只隐藏界面，计时在后台继续（对应参考游戏的后台计时行为）：
+// 重新展开时剩余时间由 tick 持续刷新，阶段切换的 AI 提醒也照常触发
+watch(enabled, () => {
   persistState()
 })
 
@@ -524,6 +646,8 @@ onMounted(() => {
       localStorage.getItem(STORAGE_KEY_BREAK_MS) || String(DEFAULT_BREAK_MS),
     )
     const savedWorkLabel = localStorage.getItem(STORAGE_KEY_WORK_LABEL) || '工作'
+    const savedPhaseEndAt = JSON.parse(localStorage.getItem(STORAGE_KEY_PHASE_END_AT) || '0')
+    const savedCompleted = JSON.parse(localStorage.getItem(STORAGE_KEY_COMPLETED) || 'false')
 
     enabled.value = !!savedEnabled
     workDurationMs.value = Number.isFinite(savedWorkMs) ? savedWorkMs : DEFAULT_WORK_MS
@@ -533,21 +657,28 @@ onMounted(() => {
     mode.value = savedMode === 'break' ? 'break' : 'work'
     remainingMs.value = Number.isFinite(savedRemaining) ? savedRemaining : workDurationMs.value
     workLabel.value = savedWorkLabel || '工作'
-    isRunning.value = !!savedRunning && enabled.value && savedRemaining > 0
+    justCompleted.value = !!savedCompleted
+    // 不再要求面板处于展开状态：折叠状态下退出，下次启动计时也在后台恢复
+    isRunning.value = !!savedRunning && (savedPhaseEndAt > 0 || savedRemaining > 0)
 
     workMinutesInput.value = workDurationMs.value / 60000
     breakMinutesInput.value = breakDurationMs.value / 60000
     cyclesInput.value = cyclesTotal.value
 
     if (isRunning.value) {
+      // 兼容旧版存档：没有保存结束时刻时用剩余时间折算出一个新的
+      phaseEndAt.value = savedPhaseEndAt > 0 ? savedPhaseEndAt : Date.now() + remainingMs.value
       clearTimer()
       timerId = window.setInterval(tick, 1000)
+      // 立即补跑页面关闭/挂起期间流逝的时间（含跨阶段推进）
+      tick()
     }
   } catch {}
 })
 
 onUnmounted(() => {
   clearTimer()
+  window.removeEventListener('pointermove', onScrubMove)
 })
 </script>
 


### PR DESCRIPTION
## 修复说明

番茄钟（`PomodoroPanel.vue`）此前存在多个计时与状态问题：页面节流/挂起会丢失计时、全部轮次完成后无法正确重新启动、折叠面板即停止计时、暂停状态误显示为"空闲中"、刷新/重启后丢失关闭期间的时间。

本 PR 参考《Chill with You: Lo-Fi Story》番茄钟的核心设计（时间戳制计时 + 挂起后补跑）重构了前端计时逻辑，并顺带做了交互改进。

## 修复的问题

- [ ] 解决了崩溃问题
- [x] 修复了功能异常
- [x] 修复了显示问题
- [ ] 修复了性能问题
- [x] 其他：交互改进（暂停/继续 LLM 反馈、圆环拖动调时）

## 相关 Issue

无

## 修复方法

- **时间戳制计时**：由 `setInterval` 每秒固定 -1s 改为记录阶段结束时刻（`phaseEndAt`），tick 时用 `Date.now()` 计算剩余时间；页面被节流/挂起/刷新后通过 while 循环逐阶段补跑，补跑跨多个阶段时只发送最后一条 AI 提醒避免刷屏
- **完成态修复**：全部轮次完成后回到第 1 轮专注待命状态，修复了完成后再按"开始"会错误地以休息阶段启动的问题
- **折叠不再停止计时**：折叠面板（含打开设置时的自动折叠）只隐藏界面，计时在后台继续；标题栏在计时运行时直接显示剩余时间
- **状态文本修正**：新增"已暂停 / 已完成"状态，暂停不再误显示为"空闲中"
- **重启不丢进度**：结束时刻持久化到 localStorage，启动时自动补跑关闭期间流逝的时间（兼容旧版存档）
- **新增暂停/继续反馈**：暂停和中途继续时向 LLM 发送 `{番茄钟提醒：...}` 系统消息；全新启动的 `{我启动了番茄钟：...}` 消息格式保持不变，成就识别逻辑不受影响
- **新增圆环拖动调时**：圆环本身作为隐形热区（无拖动手柄），按住沿轨道拖动即可调整剩余时间，运行中拖动会实时校正结束时刻

## 检查清单

- [x] 代码已经本地测试（vue-tsc 类型检查 + vite 构建通过；实机验证：正常倒计时、挂起 37 分钟/2 小时补跑、完成后重启、折叠后台计时、暂停冻结恢复）

## 截图/示例

计时运行时标题栏直接显示剩余时间：`🍅 番茄钟  01:42`
