### PR TITLE
fix: 修复桌宠/主对话模式切换后立绘消失与当前台词清空问题

### DIFF
--- a/src/components/game/standard/GameDialog.vue
+++ b/src/components/game/standard/GameDialog.vue
@@ -403,7 +403,7 @@ watch(
     if (newStatus === 'thinking') {
       const currentInteractRole = gameStore.currentInteractRole
       if (currentInteractRole) {
-        currentInteractRole.emotion = 'AI思考'
+        //currentInteractRole.emotion = 'AI思考'
         uiStore.showCharacterTitle = currentInteractRole.roleName
         uiStore.showCharacterSubtitle = currentInteractRole.roleSubTitle
       }

--- a/src/components/game/standard/GameDialog.vue
+++ b/src/components/game/standard/GameDialog.vue
@@ -551,7 +551,7 @@ let unlistenCancelled: (() => void) | null = null
 onMounted(async () => {
   // 模式切换重挂载：立即从 store 恢复当前台词（不重播打字动画）
   const restoreLine = uiStore.showCharacterLine
-  if (restoreLine && restoreLine !== '' && gameStore.currentStatus !== 'input') {
+  if (restoreLine && restoreLine !== '' && gameStore.currentStatus === 'responding') {
     renderLineInstant(restoreLine)
   }
 

--- a/src/components/game/standard/GameDialog.vue
+++ b/src/components/game/standard/GameDialog.vue
@@ -293,6 +293,20 @@ function writeInlineHtml(_element: HTMLElement, text: string): void {
   }
 }
 
+// 立即把当前台词写入显示元素（不经过打字动画；供挂载恢复使用）
+function renderLineInstant(line: string) {
+  currentDisplayedText.value = line
+  if (settingsStore.text.inlineMotionText) {
+    const text = uiStore.showCharacterMotionText
+      ? line + '\n' + uiStore.showCharacterMotionText
+      : line
+    if (inlineDisplayRef.value) writeInlineHtml(inlineDisplayRef.value, text)
+  } else if (textareaRef.value) {
+    textareaRef.value.value = line
+    inputMessage.value = line // 与 v-model 同步，防止重渲染把值重置为空
+  }
+}
+
 // 标准模式 TypeWriter（textarea）
 const {
   startTyping: startTextTyping,
@@ -535,6 +549,12 @@ let unlistenScreenshot: (() => void) | null = null
 let unlistenCancelled: (() => void) | null = null
 
 onMounted(async () => {
+  // 模式切换重挂载：立即从 store 恢复当前台词（不重播打字动画）
+  const restoreLine = uiStore.showCharacterLine
+  if (restoreLine && restoreLine !== '' && gameStore.currentStatus !== 'input') {
+    renderLineInstant(restoreLine)
+  }
+
   document.addEventListener('contextmenu', handleDialogShow)
   // 初始化语音识别对象
   speechRecognition = initSpeechRecognition()

--- a/src/components/game/standard/GameRoleAvatar.vue
+++ b/src/components/game/standard/GameRoleAvatar.vue
@@ -148,11 +148,6 @@ async function resolveAvatar() {
   const emotion = r.emotion
   const mappedEmotion = EMOTION_CONFIG_EMO[emotion] || '正常'
 
-  if (emotion === 'AI思考') {
-    targetAvatarUrl.value = 'none'
-    return
-  }
-
   const currentId = ++resolveAvatarId
   try {
     const path = await invoke<string>('get_avatar_file', {
@@ -233,6 +228,44 @@ watch(
     }
   },
   { immediate: true },
+)
+
+// 思考中反馈：气泡 + 音效（由 currentStatus 驱动，与 emotion 解耦）
+watch(
+  () => gameStore.currentStatus,
+  (newStatus) => {
+    if (newStatus === 'thinking') {
+      const config = EMOTION_CONFIG['AI思考']
+      if (config && config.bubbleImage && config.bubbleImage !== 'none') {
+        currentBubbleImageUrl.value = config.bubbleImage
+        currentBubbleClass.value = config.bubbleClass
+
+        if (bubbleTimeoutId !== null) {
+          window.clearTimeout(bubbleTimeoutId)
+          bubbleTimeoutId = null
+        }
+        if (!isBubbleVisible.value) {
+          isBubbleVisible.value = true
+        }
+        bubbleTimeoutId = window.setTimeout(() => {
+          isBubbleVisible.value = false
+          bubbleTimeoutId = null
+        }, 2000)
+      }
+      if (config?.audio && config.audio !== 'none' && bubbleAudio.value) {
+        bubbleAudio.value.src = config.audio
+        bubbleAudio.value.load()
+        bubbleAudio.value.play().catch((e) => console.error('Play error:', e))
+      }
+    } else {
+      // 离开思考态：隐藏思考气泡、停掉定时器
+      isBubbleVisible.value = false
+      if (bubbleTimeoutId !== null) {
+        window.clearTimeout(bubbleTimeoutId)
+        bubbleTimeoutId = null
+      }
+    }
+  },
 )
 
 const handleAnimationEnd = () => {

--- a/src/components/pet/ChatInput.vue
+++ b/src/components/pet/ChatInput.vue
@@ -92,7 +92,7 @@ watch(
     if (newStatus === 'thinking') {
       const currentInteractRole = gameStore.currentInteractRole
       if (currentInteractRole) {
-        currentInteractRole.emotion = 'AI思考'
+        // 思考态不再写入 'AI思考' 伪情感，避免立绘组件因 emotion 残留而无法加载
         uiStore.showCharacterTitle = currentInteractRole.roleName
         uiStore.showCharacterSubtitle = currentInteractRole.roleSubTitle
       }

--- a/src/components/pet/DialogueBox.vue
+++ b/src/components/pet/DialogueBox.vue
@@ -91,7 +91,7 @@ watch([() => uiStore.showCharacterLine, () => gameStore.currentStatus], ([newLin
 // 模式切换重挂载：立即从 store 恢复当前台词（不重播打字动画）
 onMounted(() => {
   const line = uiStore.showCharacterLine
-  if (line && line !== '' && gameStore.currentStatus !== 'input' && textareaRef.value) {
+  if (line && line !== '' && gameStore.currentStatus === 'responding' && textareaRef.value) {
     textareaRef.value.textContent = line
     currentDisplayedText.value = line
   }

--- a/src/components/pet/DialogueBox.vue
+++ b/src/components/pet/DialogueBox.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, onMounted } from 'vue'
 import { useGameStore } from '../../stores/modules/game'
 import { eventQueue } from '../../core/events/event-queue'
 import { useUIStore } from '../../stores/modules/ui/ui'
@@ -85,6 +85,15 @@ watch([() => uiStore.showCharacterLine, () => gameStore.currentStatus], ([newLin
   } else if (newStatus === 'input') {
     stopTyping()
     currentDisplayedText.value = ''
+  }
+})
+
+// 模式切换重挂载：立即从 store 恢复当前台词（不重播打字动画）
+onMounted(() => {
+  const line = uiStore.showCharacterLine
+  if (line && line !== '' && gameStore.currentStatus !== 'input' && textareaRef.value) {
+    textareaRef.value.textContent = line
+    currentDisplayedText.value = line
   }
 })
 

--- a/src/components/pet/GameRoleAvatar.vue
+++ b/src/components/pet/GameRoleAvatar.vue
@@ -87,6 +87,7 @@ import BAParticles from './BAParticles.vue'
 import ImageCrossFade from '@/components/ui/ImageAcrossFade.vue'
 import StarField from '../game/standard/particles/StarField.vue'
 import type { GameRole } from '@/stores/modules/game/state'
+import { useGameStore } from '@/stores/modules/game'
 import { EMOTION_CONFIG, EMOTION_CONFIG_EMO } from '@/controllers/emotion/config'
 import { useUIStore } from '@/stores/modules/ui/ui'
 import './avatar-animation.css'
@@ -98,6 +99,7 @@ const emit = defineEmits(['avatar-click'])
 const bubbleAudio = ref<HTMLAudioElement | null>(null)
 const imageFadeRef = ref<InstanceType<typeof ImageCrossFade> | null>(null)
 const uiStore = useUIStore()
+const gameStore = useGameStore()
 
 const activeAnimationClass = ref('normal')
 const isBubbleVisible = ref(false)
@@ -147,11 +149,6 @@ async function resolveAvatar() {
   const clothesName = r.clothesName === '默认' || !r.clothesName ? 'default' : r.clothesName
   const emotion = r.emotion
   const mappedEmotion = EMOTION_CONFIG_EMO[emotion] || '正常'
-
-  if (emotion === 'AI思考') {
-    targetAvatarUrl.value = 'none'
-    return
-  }
 
   const currentId = ++resolveAvatarId
   try {
@@ -223,6 +220,44 @@ watch(
     }
   },
   { immediate: true },
+)
+
+// 思考中反馈：气泡 + 音效（由 currentStatus 驱动，与 emotion 解耦）
+watch(
+  () => gameStore.currentStatus,
+  (newStatus) => {
+    if (newStatus === 'thinking') {
+      const config = EMOTION_CONFIG['AI思考']
+      if (config && config.bubbleImage && config.bubbleImage !== 'none') {
+        currentBubbleImageUrl.value = config.bubbleImage
+        currentBubbleClass.value = config.bubbleClass
+
+        if (bubbleTimeoutId !== null) {
+          window.clearTimeout(bubbleTimeoutId)
+          bubbleTimeoutId = null
+        }
+        if (!isBubbleVisible.value) {
+          isBubbleVisible.value = true
+        }
+        bubbleTimeoutId = window.setTimeout(() => {
+          isBubbleVisible.value = false
+          bubbleTimeoutId = null
+        }, 2000)
+      }
+      if (config?.audio && config.audio !== 'none' && bubbleAudio.value) {
+        bubbleAudio.value.src = config.audio
+        bubbleAudio.value.load()
+        bubbleAudio.value.play().catch((e) => console.error('Play error:', e))
+      }
+    } else {
+      // 离开思考态：隐藏思考气泡、停掉定时器
+      isBubbleVisible.value = false
+      if (bubbleTimeoutId !== null) {
+        window.clearTimeout(bubbleTimeoutId)
+        bubbleTimeoutId = null
+      }
+    }
+  },
 )
 </script>
 

--- a/src/controllers/emotion/config.ts
+++ b/src/controllers/emotion/config.ts
@@ -34,7 +34,6 @@ export const EMOTION_CONFIG_EMO: EmotionMap = {
   惊讶: '惊讶',
   正常: '正常',
   平静: '平静',
-  AI思考: 'none',
 }
 
 export const EMOTION_CONFIG: EmotionConfigMap = {
@@ -158,6 +157,7 @@ export const EMOTION_CONFIG: EmotionConfigMap = {
     bubbleClass: 'none',
     audio: 'none',
   },
+  // 思考态反馈（由 currentStatus === 'thinking' 驱动，非真实情感）
   AI思考: {
     animation: 'none',
     bubbleImage: '../pictures/animation/AI思考.webp',

--- a/src/controllers/emotion/config.ts
+++ b/src/controllers/emotion/config.ts
@@ -157,7 +157,6 @@ export const EMOTION_CONFIG: EmotionConfigMap = {
     bubbleClass: 'none',
     audio: 'none',
   },
-  // 思考态反馈（由 currentStatus === 'thinking' 驱动，非真实情感）
   AI思考: {
     animation: 'none',
     bubbleImage: '../pictures/animation/AI思考.webp',


### PR DESCRIPTION
### 问题简述
1. 切到桌宠、退出桌宠时如果正处于**AI思考**状态，立绘会在切换后消失，如图：

<img width="200" height="200" alt="屏幕截图 2026-07-30 131552" src="https://github.com/user-attachments/assets/756db48a-ca75-4459-b95a-7e8d1fd6c871" />

2. 同样，切到桌宠、退出桌宠会导致当前角色的台词被清空，如图：
<img width="590" height="386" alt="屏幕截图 2026-07-31 204226" src="https://github.com/user-attachments/assets/126edc84-cdea-463a-8033-03980b1b5ed6" />

### 改动概要
> [!IMPORTANT]
> 抱歉啦＞﹏＜，关于问题1，我想不出更好的解决方法，只能舍弃了原有的设计。
> 请务必给点建议~
1. 抛弃了将"AI思考"作为情感的设计，转而使用currentStatus驱动音效和气泡
2. 挂载时从 store 瞬时恢复当前句（不重播打字动画），与现有 watch（负责新台词打字动画）职责分离
