### PR TITLE
fix:windows和Android端llm请求失败

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3198,6 +3198,7 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "reqwest",
+ "rustls",
  "sea-orm",
  "sea-orm-migration",
  "serde",
@@ -3224,6 +3225,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "webpki-roots 0.26.11",
  "windows 0.62.2",
  "zip 2.4.2",
 ]
@@ -5137,6 +5139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,11 @@ edition = "2021"
 name = "ling_chat_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[features]
+# 移动端（Android/iOS）构建时必须启用：让 webview 从应用内嵌资产加载前端
+# （不走 devUrl）。桌面端不受影响。
+custom-protocol = ["tauri/custom-protocol"]
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
@@ -42,6 +47,13 @@ serde_yaml = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 reqwest = { version = "0.13", features = ["json", "query", "stream", "rustls", "system-proxy"], default-features = false }
+# 用 webpki-roots（内置 Mozilla CA）构造 rustls ClientConfig 注入 reqwest，
+# 绕开 reqwest 0.13 默认的 rustls-platform-verifier（Android 上需显式初始化，
+# 未初始化会 TLS panic）。版本与 reqwest 0.13.3 的 rustls 依赖保持一致（0.23）。
+# aws-lc-rs：与 reqwest 0.13.3 的 provider 一致（否则 rustls 无法自动确定
+# CryptoProvider，TLS 握手会 panic）。
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
+webpki-roots = "0.26"
 futures-util = "0.3"
 async-stream = "0.3"
 bytes = "1"

--- a/src-tauri/src/ai_service/llm/factory.rs
+++ b/src-tauri/src/ai_service/llm/factory.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
@@ -7,12 +8,37 @@ use super::provider::LlmProvider;
 use super::providers::{GenaiProvider, KimiCodeProvider};
 use super::{LlmClient, LlmConfig};
 
+/// 构建共享 reqwest Client。
+///
+/// reqwest 0.13 的 `rustls` feature 默认使用 `rustls-platform-verifier`
+/// （验证操作系统证书）。这在 Android 上要求显式初始化（JVM + Context +
+/// ClassLoader），未初始化时 TLS 握手会 panic，导致 LLM 请求崩溃。
+///
+/// 这里改用 `webpki-roots`（内置 Mozilla CA 根证书）构造 rustls ClientConfig
+/// 注入 reqwest，绕开 platform-verifier —— 全平台一致，无需任何初始化。
+fn build_http_client(timeout_secs: u64) -> Result<Client> {
+    // 依赖树里 aws-lc-rs 和 ring 两个 provider 都启用（reqwest 用 aws-lc，
+    // 其他传递依赖用 ring），rustls 无法自动确定 → 显式安装 aws-lc-rs。
+    // 幂等：install_default 只在首次生效。
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    // 版本与 reqwest 0.13.3 的 rustls 依赖一致（0.23）
+    // webpki_roots::TLS_SERVER_ROOTS 是 &[TrustAnchor]，直接填入 RootCertStore
+    let mut roots = rustls::RootCertStore::empty();
+    roots.roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(Arc::new(roots))
+        .with_no_client_auth();
+    Client::builder()
+        .read_timeout(Duration::from_secs(timeout_secs))
+        .tls_backend_preconfigured(tls_config)
+        .build()
+        .context("创建 LLM HTTP 客户端失败")
+}
+
 /// 根据 `cfg.provider` 创建对应的 LLM 客户端。
 pub fn create_llm_client(cfg: LlmConfig) -> Result<LlmClient> {
-    let http = Client::builder()
-        .read_timeout(Duration::from_secs(cfg.timeout_secs))
-        .build()
-        .context("创建 LLM HTTP 客户端失败")?;
+    let http = build_http_client(cfg.timeout_secs)?;
     let provider: Box<dyn LlmProvider> = match cfg.provider.to_lowercase().as_str() {
         "deepseek" | "openai" | "lmstudio" | "gemini" => {
             Box::new(GenaiProvider::new(&cfg, http.clone())?)

--- a/src-tauri/src/ai_service/llm/factory.rs
+++ b/src-tauri/src/ai_service/llm/factory.rs
@@ -11,24 +11,25 @@ use super::{LlmClient, LlmConfig};
 /// 构建共享 reqwest Client。
 ///
 /// reqwest 0.13 的 `rustls` feature 默认使用 `rustls-platform-verifier`
-/// （验证操作系统证书）。这在 Android 上要求显式初始化（JVM + Context +
+/// （验证操作系统证书）。这在 Android 上要求启动时显式初始化（JVM + Context +
 /// ClassLoader），未初始化时 TLS 握手会 panic，导致 LLM 请求崩溃。
 ///
 /// 这里改用 `webpki-roots`（内置 Mozilla CA 根证书）构造 rustls ClientConfig
 /// 注入 reqwest，绕开 platform-verifier —— 全平台一致，无需任何初始化。
 fn build_http_client(timeout_secs: u64) -> Result<Client> {
-    // 依赖树里 aws-lc-rs 和 ring 两个 provider 都启用（reqwest 用 aws-lc，
-    // 其他传递依赖用 ring），rustls 无法自动确定 → 显式安装 aws-lc-rs。
-    // 幂等：install_default 只在首次生效。
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
-    // 版本与 reqwest 0.13.3 的 rustls 依赖一致（0.23）
-    // webpki_roots::TLS_SERVER_ROOTS 是 &[TrustAnchor]，直接填入 RootCertStore
+    // 依赖树里 aws-lc-rs 和 ring 两个 provider 都被启用（reqwest 用 aws-lc，
+    // 其他传递依赖用 ring），rustls 无法自动确定用哪个。
+    // 用 builder_with_provider 显式指定 aws-lc-rs，不依赖全局 CryptoProvider
+    // （避免 install_default 的进程级副作用和调用顺序依赖）。
     let mut roots = rustls::RootCertStore::empty();
     roots.roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    let tls_config = rustls::ClientConfig::builder()
-        .with_root_certificates(Arc::new(roots))
-        .with_no_client_auth();
+    let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|e| anyhow!("rustls 协议版本配置失败: {e}"))?
+    .with_root_certificates(Arc::new(roots))
+    .with_no_client_auth();
     Client::builder()
         .read_timeout(Duration::from_secs(timeout_secs))
         .tls_backend_preconfigured(tls_config)

--- a/src-tauri/src/ai_service/llm/providers/genai_provider.rs
+++ b/src-tauri/src/ai_service/llm/providers/genai_provider.rs
@@ -32,6 +32,21 @@ pub struct GenaiProvider {
     _reasoning_effort: Option<String>,
 }
 
+/// 规范化 base_url：确保以 `/` 结尾。
+///
+/// genai 的 OpenAI 兼容 adapter 用 `Url::join("chat/completions")` 拼接路径
+/// （不是字符串拼接）。若 base_url 不以 `/` 结尾（如 `https://api.deepseek.com/v1`），
+/// `v1` 会被当作"文件"替换掉，拼出 `https://api.deepseek.com/chat/completions` → 404。
+///
+/// 修复：在传给 genai 前补上尾斜杠（`https://api.deepseek.com/v1/`）。
+fn normalize_base_url(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return raw.to_string();
+    }
+    format!("{trimmed}/")
+}
+
 impl GenaiProvider {
     pub fn new(cfg: &LlmConfig, http: Client) -> Result<Self> {
         let model = cfg.model.clone();
@@ -40,10 +55,11 @@ impl GenaiProvider {
         match cfg.provider.to_lowercase().as_str() {
             "deepseek" => {
                 let key = cfg.api_key.clone();
+                // 默认 base_url 以 `/` 结尾；用户配置经 normalize 补尾斜杠
                 let base = if cfg.base_url.is_empty() {
                     "https://api.deepseek.com/".to_string()
                 } else {
-                    cfg.base_url.clone()
+                    normalize_base_url(&cfg.base_url)
                 };
                 builder = builder
                     .with_adapter_kind(AdapterKind::DeepSeek)
@@ -59,7 +75,7 @@ impl GenaiProvider {
                     .with_adapter_kind(AdapterKind::OpenAI)
                     .with_auth_resolver_fn(move |_| Ok(Some(AuthData::from_single(key))));
                 if !cfg.base_url.is_empty() {
-                    let base = cfg.base_url.clone();
+                    let base = normalize_base_url(&cfg.base_url);
                     builder =
                         builder.with_service_target_resolver_fn(move |mut t: ServiceTarget| {
                             t.endpoint = Endpoint::from_owned(base);
@@ -71,7 +87,7 @@ impl GenaiProvider {
                 builder = builder
                     .with_adapter_kind(AdapterKind::OpenAI)
                     .with_service_target_resolver_fn(|mut t: ServiceTarget| {
-                        t.endpoint = Endpoint::from_owned("http://localhost:1234/v1".to_string());
+                        t.endpoint = Endpoint::from_owned("http://localhost:1234/v1/".to_string());
                         Ok(t)
                     });
             }
@@ -81,7 +97,7 @@ impl GenaiProvider {
                     .with_adapter_kind(AdapterKind::Gemini)
                     .with_auth_resolver_fn(move |_| Ok(Some(AuthData::from_single(key))));
                 if !cfg.base_url.is_empty() {
-                    let base = cfg.base_url.clone();
+                    let base = normalize_base_url(&cfg.base_url);
                     builder =
                         builder.with_service_target_resolver_fn(move |mut t: ServiceTarget| {
                             t.endpoint = Endpoint::from_owned(base);


### PR DESCRIPTION
# 背景

切换 genai 后 LLM 无法使用：
- Windows：测试请求 404 Not Found
- Android：一直加载无响应（TLS 层 panic）

## Commit 1: fix: 修复 genai base_url 缺尾斜杠导致 404

genai 的 OpenAI 兼容 adapter 用 `Url::join("chat/completions")` 拼接请求路径
（URL 语义，非字符串拼接）。若 base_url 不以 / 结尾（如
`https://api.deepseek.com/v1`），最后一段 v1 会被当作"文件"替换，
拼出 `https://api.deepseek.com/chat/completions` → 服务器 404。

**修复**：`GenaiProvider::new` 新增 `normalize_base_url()`，在传给 genai 前
确保 base_url 以 / 结尾。

## Commit 2: fix: 用 webpki-roots 替代 rustls-platform-verifier，根治 Android TLS panic

reqwest 0.13.3 的 rustls feature 无条件依赖 `rustls-platform-verifier`
（无法通过 feature 关闭）。该验证器在 Android 上要求启动时显式初始化
（JVM + Context + ClassLoader），未初始化时 TLS 握手直接 panic
（`Expect rustls-platform-verifier to be initialized`），导致 Android 上
所有 LLM 请求崩溃。

**修复**：构建共享 reqwest Client 时用 webpki-roots（内置 Mozilla CA 根证书）
构造 rustls ClientConfig，通过 `tls_backend_preconfigured` 注入 reqwest，
完全绕开 platform-verifier —— 全平台一致，无需任何初始化。

同时处理 rustls 双 provider 冲突（aws-lc-rs + ring 都被启用导致无法自动确定
CryptoProvider）：显式调用 `aws_lc_rs::default_provider().install_default()`。

## 验证

- ✅ Windows + aarch64-linux-android 编译通过
- ✅ Android 模拟器 LLM 请求正常
- ✅ Windows 桌面端 LLM 请求正常