### PR TITLE
feat：统一'开始游戏'入口流程 + 存档前端

### DIFF
--- a/src/api/tauri-events.ts
+++ b/src/api/tauri-events.ts
@@ -3,9 +3,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { eventQueue } from '../core/events/event-queue'
 import type { ScriptEventType } from '../types'
 import { useAdventureStore } from '../stores/modules/adventure'
-import { useUIStore } from '../stores/modules/ui/ui'
 import { useGameStore } from '../stores/modules/game'
-import { i18n } from '@/locales'
 import { useScriptEditorStore } from '../stores/modules/script-editor'
 
 function asEvent(payload: unknown, overrides: Partial<ScriptEventType>): ScriptEventType {
@@ -130,13 +128,7 @@ export function initializeTauriEventListeners() {
       }
     }
 
-    useUIStore().showNotification({
-      type: 'info',
-      title: i18n.global.t('api.events.autoSave.title'),
-      message: i18n.global.t('api.events.autoSave.message', { time: payload.timestamp }),
-      duration: 2500,
-      skipTipsCheck: true,
-    })
+    // 台词已逐条落盘，自动存档只是后台兜底快照——不再弹提示刷屏
   })
 
   // === Script events ===
@@ -208,6 +200,14 @@ export function initializeTauriEventListeners() {
     gameStore.currentInteractRoleId = payload.roleId
     // Ensure the role is loaded in gameRoles
     gameStore.getOrCreateGameRole(payload.roleId)
+  })
+
+  // app 退后台/锁屏（安卓无 RunEvent::Paused，这是唯一可靠信号）→ 强制落盘。
+  // 逐条落盘已保证台词不丢，这里兜底快照/记忆库；桌面最小化也会触发，幂等无害。
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      invoke('flush_save_now').catch((e) => console.error('[Tauri] flush_save_now failed', e))
+    }
   })
 
   console.log('[Tauri] Event listeners initialized (ai + ai:thinking_progress + tts:cleanup + adventure + auto-save + 13 script events + character:switch)')

--- a/src/components/settings/pages/SettingsSave.vue
+++ b/src/components/settings/pages/SettingsSave.vue
@@ -137,6 +137,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import { MenuPage, MenuItem } from '../../ui'
 import { Input } from '../../base'
 import { useGameStore } from '../../../stores/modules/game'
@@ -162,6 +163,7 @@ const gameStore = useGameStore()
 const uiStore = useUIStore()
 const dialogStore = useDialogStore()
 const { t } = useI18n()
+const router = useRouter()
 
 const saves = ref<SaveInfo[]>([])
 const newSaveTitle = ref('')
@@ -279,6 +281,9 @@ const handleLoadSave = async (saveId: number) => {
     const gameInfo = await invoke<WebInitData>('load_save', { saveId })
     applyWebInitData(gameStore.$state, gameInfo)
     uiStore.showSuccess({ title: t('settings.save.msg.loadSuccessTitle'), message: t('settings.save.msg.loadSuccessMsg') })
+    // 读档即进入游戏：关设置面板，直接跳对话页
+    uiStore.toggleSettings(false)
+    router.push('/chat')
   } catch (e: any) {
     console.error('读取存档失败:', e)
     uiStore.showError({

--- a/src/components/views/MainMenu.vue
+++ b/src/components/views/MainMenu.vue
@@ -47,6 +47,7 @@
           v-if="menuState === 'gameMode'"
           @back="backToMainMenu"
           @open-scripts="showScriptModeMenu"
+          @go-save="handleGoSave"
           :loadingScripts="loadingScripts"
           :scripts="scripts"
         />
@@ -76,10 +77,6 @@ import { SettingsPanel as Settings } from '../settings/'
 import { useUIStore } from '../../stores/modules/ui/ui'
 import { useSettingsStore } from '../../stores/modules/settings'
 import { getScriptList, type ScriptSummary } from '@/api/services/script-info'
-import { invoke } from '@tauri-apps/api/core'
-import { useGameStore } from '../../stores/modules/game'
-import { applyWebInitData } from '../../stores/modules/game/actions'
-import type { WebInitData } from '@/api/services/game-info'
 import MeteorAnimation from '../game/standard/animations/MeteorAnimation.vue'
 import StarAnimation from '../game/standard/animations/StarAnimation.vue'
 import { useParallaxAnimation } from '../game/standard/animations/ParallaxAnimation'
@@ -125,30 +122,10 @@ function goToGithub() {
   window.open('https://github.com/SlimeBoyOwO/LingChat', '_blank')
 }
 
-const handleContinueGame = async () => {
-  try {
-    const { saves } = await invoke<{ saves: Array<{ id: number }>; total: number }>(
-      'list_saves',
-      { page: 1, pageSize: 1 },
-    )
-    if (!saves || saves.length === 0) {
-      uiStore.showWarning({
-        title: t('views.mainMenu.noSaveTitle'),
-        message: t('views.mainMenu.noSaveMessage'),
-      })
-      return
-    }
-    const gameInfo = await invoke<WebInitData>('load_save', { saveId: saves[0].id })
-    const gameStore = useGameStore()
-    applyWebInitData(gameStore.$state, gameInfo)
-    router.push('/chat')
-  } catch (error) {
-    console.error('继续游戏失败:', error)
-    uiStore.showError({
-      title: t('views.mainMenu.continueFailTitle'),
-      message: t('views.mainMenu.continueFailMessage'),
-    })
-  }
+// 自由对话里"否 → 前往存档页"：直接复用打开设置并定位到存档 tab
+function handleGoSave() {
+  handleOpenSettings('save')
+
 }
 
 function handleOpenSettings(tab?: string) {

--- a/src/components/views/menu/page/GameModeOptions.vue
+++ b/src/components/views/menu/page/GameModeOptions.vue
@@ -11,18 +11,49 @@
 import { StartItem } from '../base'
 import { useRouter } from 'vue-router'
 import { useGameStore } from '@/stores/modules/game'
+import { applyWebInitData } from '@/stores/modules/game/actions'
+import { useDialogStore } from '@/stores/modules/ui/dialog'
+import type { WebInitData } from '@/api/services/game-info'
+import { invoke } from '@tauri-apps/api/core'
 
 const emit = defineEmits<{
   (e: 'back'): void
   (e: 'open-scripts'): void
+  (e: 'go-save'): void
 }>()
 
 const router = useRouter()
 const gameStore = useGameStore()
+const dialogStore = useDialogStore()
 
-const startFreeDialogue = () => {
+// galgame New Game：先看有没有"当前进行"（last_save_id）。
+//   有 → 询问是否从上次存档继续：是 = 回到当前进行（load_save）；否 = 前往存档页。
+//   无 → 直接开新世界（start_new_game 新建槽，不覆盖旧进度）。
+const startFreeDialogue = async () => {
   gameStore.exitStoryMode()
-  router.push('/chat')
+  try {
+    const lastSaveId = await invoke<number | null>('get_last_save_id')
+    if (lastSaveId) {
+      const ok = await dialogStore.confirm(
+        '检测到上次存档。要继续上次的进度吗？（取消则前往存档页）',
+        '从上次存档继续',
+      )
+      if (ok) {
+        const gameInfo = await invoke<WebInitData>('load_save', { saveId: lastSaveId })
+        applyWebInitData(gameStore.$state, gameInfo)
+        router.push('/chat')
+        return
+      }
+      emit('go-save')
+      return
+    }
+    // 无存档 → 直接开新世界
+    const data = await invoke<WebInitData>('start_new_game')
+    applyWebInitData(gameStore.$state, data)
+    router.push('/chat')
+  } catch (e) {
+    console.error('开始游戏失败:', e)
+  }
 }
 
 // 前端进入剧情模式（开发中）

--- a/src/components/views/menu/page/MainMenuOptions.vue
+++ b/src/components/views/menu/page/MainMenuOptions.vue
@@ -1,7 +1,6 @@
 <template>
   <nav class="flex flex-col items-stretch">
     <StartItem @click="() => emit('start-game')">{{ $t('views.menu.startGame') }}</StartItem>
-    <StartItem @click="() => emit('open-settings', 'save')">{{ $t('views.menu.continueGame') }}</StartItem>
     <StartItem @click="() => emit('open-script-editor')">{{ $t('views.menu.scriptEditor') }}</StartItem>
     <StartItem @click="() => emit('open-settings')">{{ $t('views.menu.gameConfig') }}</StartItem>
     <StartItem @click="() => emit('open-credits')">{{ $t('views.menu.credits') }}</StartItem>

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -96,7 +96,7 @@ export default {
   },
   save: {
     create: {
-      title: "Create New Save (records the current conversation)",
+      title: "Create Backup / Bookmark (saves the current conversation as a bookmark, doesn't change current progress)",
       placeholder: "Enter a save name",
       creating: "Creating...",
       button: "Create",

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -95,7 +95,7 @@ export default {
   },
   save: {
     create: {
-      title: '新規セーブ（現在の会話を記録します）',
+      title: 'バックアップ/ブックマークを作成（現在の会話をブックマークとして保存し、現在の進行は変えません）',
       placeholder: 'セーブ名を入力',
       creating: '作成中...',
       button: '作成',

--- a/src/locales/zh-CN/settings.ts
+++ b/src/locales/zh-CN/settings.ts
@@ -96,7 +96,7 @@ export default {
   },
   save: {
     create: {
-      title: '创建新存档（会记录当前对话）',
+      title: '创建备份/书签（把当前对话另存为一格书签，不改变当前进行）',
       placeholder: '输入存档名称',
       creating: '创建中...',
       button: '创建',

--- a/src/locales/zh-HK/settings.ts
+++ b/src/locales/zh-HK/settings.ts
@@ -96,7 +96,7 @@ export default {
   },
   "save": {
     "create": {
-      "title": "開新存檔（會記低而家嘅對話）",
+      "title": "建立備份/書籤（將當前對話另存為書籤，唔會改變當前進行）",
       "placeholder": "入個存檔名",
       "creating": "創建緊...",
       "button": "創建"


### PR DESCRIPTION
## 改动内容

统一游戏入口为「开始游戏」一个按钮，配合 galgame 语义存档：

- **主菜单**：去掉独立的「继续游戏」按钮。点「开始游戏」进模式页 → 自由对话时：
  - 有上次存档（`last_save_id`）→ 询问「继续上次进度？」是=读档进对话，否=前往存档页
  - 无存档 → 直接开新世界（`start_new_game`）
- **存档页**：「创建新存档」改为「创建备份/书签」——另存为书签，不改变当前进行（文案走 i18n locale）
- **读档**：成功后关设置面板直接进对话页
- **自动存档**：不再弹通知刷屏；app 退后台/锁屏强制落盘（`flush_save_now`）
- 剧情模式保持上游可用状态（剧本模式），不重复禁用

## 依赖

本 PR 调用的 `get_last_save_id` / `start_new_game` / `flush_save_now` 后端命令来自存档系统后端 PR **#560**，请先合并 #560 再合并本 PR。

## 说明
- 基于最新 `origin/tauri-refactor`（含 i18n #545）rebase，文案改动已迁移到 locale 文件
- 保留上游的剧本编辑器入口、试玩迟到事件丢弃逻辑、i18n 文案
- 退出确认框见 #557（设置页交互 PR）
