### PR TITLE
fix(i18n): make i18n Ally load TypeScript locales

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,10 @@
   "i18n-ally.sourceLanguage": "zh-CN",
   "i18n-ally.displayLanguages": ["zh-CN", "zh-HK", "ja", "en"],
   "i18n-ally.enabledParsers": ["ts", "json"],
+  "i18n-ally.parsers.typescript.compilerOptions": {
+    "moduleResolution": "node"
+  },
+  "i18n-ally.ignoreFiles": ["src/locales/index.ts", "src/locales/*/index.ts"],
   "i18n-ally.enabledFrameworks": ["vue"],
   "i18n-ally.indent": 2,
   "i18n-ally.translate.fallbackToSourceLanguage": true


### PR DESCRIPTION
## Summary

- configure i18n Ally's TypeScript parser to use Node module resolution
- ignore aggregate locale `index.ts` files during locale discovery

## Root cause

i18n Ally executes TypeScript locale modules as CommonJS. The project-level TypeScript configuration uses `moduleResolution: "bundler"`, which is incompatible with that execution mode and causes TS5095 while loading every locale file.

As a result, the extension discovered translation keys in source files but loaded zero locale resources and reported that no locale files were found.

## Impact

VS Code can load and display the bundled `zh-CN`, `zh-HK`, `ja`, and `en` translations without changing the application's Vite or TypeScript build configuration.

## Validation

- parsed `.vscode/settings.json` successfully
- loaded `src/locales/{zh-CN,zh-HK,ja,en}/api.ts` through i18n Ally's bundled TypeScript loader with the compatibility override
- confirmed the branch diff against `tauri-refactor` contains only `.vscode/settings.json`
