### PR TITLE
fix: 剧本玩家台词归因错乱 + 回溯 null 序号

### DIFF
--- a/src-tauri/src/ai_service/game_system/script_engine/events/choice_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/choice_event.rs
@@ -107,7 +107,8 @@ impl ScriptEvent for ChoiceEvent {
                 content: user_choice,
                 attribute: LineAttributeExt(LineAttribute::User),
                 display_name: Some(gs.player.user_name.clone()),
-                sender_role_id: gs.main_role_id,
+                // 玩家台词一律标 sender_role_id=0（玩家），与 handle_user_message 对齐
+                sender_role_id: Some(0),
                 ..Default::default()
             };
             gs.add_line(ctx.db, line).await?;

--- a/src-tauri/src/ai_service/game_system/script_engine/events/free_dialogue_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/free_dialogue_event.rs
@@ -183,6 +183,8 @@ impl ScriptEvent for FreeDialogueEvent {
                     content: user_input.clone(),
                     attribute: LineAttributeExt(LineAttribute::User),
                     display_name: Some(gs.player.user_name.clone()),
+                    // 玩家台词一律标 sender_role_id=0（玩家），与 handle_user_message 对齐
+                    sender_role_id: Some(0),
                     ..Default::default()
                 };
                 gs.add_line(ctx.db, line).await?;

--- a/src-tauri/src/ai_service/game_system/script_engine/events/input_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/input_event.rs
@@ -53,15 +53,17 @@ impl ScriptEvent for InputEvent {
         tracing::info!("[InputEvent] 收到用户输入: {}", user_input);
 
         // Add USER line — read fields under a single lock to avoid deadlock
-        let (user_name, main_role_id) = {
+        let user_name = {
             let gs = ctx.game_status.lock().await;
-            (gs.player.user_name.clone(), gs.main_role_id)
+            gs.player.user_name.clone()
         };
         let line = LineBase {
             content: user_input,
             attribute: LineAttributeExt(LineAttribute::User),
             display_name: Some(user_name),
-            sender_role_id: main_role_id,
+            // 玩家台词一律标 sender_role_id=0（玩家），与 handle_user_message 对齐；
+            // 否则 MemoryBuilder 会把玩家的话当钦灵自己说的，导致回合错乱、模型自导自演。
+            sender_role_id: Some(0),
             ..Default::default()
         };
         ctx.game_status.lock().await.add_line(ctx.db, line).await?;

--- a/src-tauri/src/ai_service/game_system/script_engine/events/player_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/player_event.rs
@@ -51,7 +51,8 @@ impl ScriptEvent for PlayerEvent {
             content: self.text.clone(),
             attribute: LineAttributeExt(LineAttribute::User),
             display_name: Some(display_name),
-            sender_role_id: ctx.game_status.lock().await.main_role_id,
+            // 玩家台词一律标 sender_role_id=0（玩家），与 handle_user_message 对齐
+            sender_role_id: Some(0),
             ..Default::default()
         };
         ctx.game_status.lock().await.add_line(ctx.db, line).await?;

--- a/src-tauri/src/ai_service/game_system/script_engine/utils/script_function.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/utils/script_function.rs
@@ -296,6 +296,8 @@ pub async fn handle_actions(
                     content,
                     attribute: LineAttributeExt(LineAttribute::User),
                     display_name: Some(game_status.player.user_name.clone()),
+                    // 玩家台词一律标 sender_role_id=0（玩家），与 handle_user_message 对齐
+                    sender_role_id: Some(0),
                     ..Default::default()
                 };
                 game_status.add_line(db, line).await?;

--- a/src-tauri/src/ai_service/message_system/responses.rs
+++ b/src-tauri/src/ai_service/message_system/responses.rs
@@ -48,7 +48,9 @@ pub struct ReplyResponse {
     pub display_name: Option<String>,
     pub display_subtitle: Option<String>,
     /// 触发此回复的用户消息序号（1-indexed，由 sender_role_id == Some(0) 计数得出）。
-    /// `None` 表示主动对话等非用户触发的回复。
+    /// `None` 表示主动对话等非用户触发的回复。`None` 时不序列化该字段，
+    /// 避免前端把 `null` 当成有效序号回填进用户消息、导致回溯传 null 报错。
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_message_seq: Option<u32>,
     /// 本轮生成的思考链全文（仅最后一帧 is_final=true 时携带）。
     pub thinking: Option<String>,

--- a/src/components/settings/pages/SettingsHistory.vue
+++ b/src/components/settings/pages/SettingsHistory.vue
@@ -29,7 +29,7 @@
                     {{ item.displayName }}
                   </span>
                   <button
-                    v-if="item.userMessageSeq !== undefined"
+                    v-if="typeof item.userMessageSeq === 'number' && !gameStore.runningScript"
                     class="shrink-0 cursor-pointer rounded border border-white/10 bg-transparent px-2 py-0.5 text-xs text-white/40 transition-all duration-200 hover:border-red-400/50 hover:bg-red-500/20 hover:text-white"
                     :title="$t('settings.history.backtrackTip')"
                     @click.stop="handleBacktrack(item.userMessageSeq!)"

--- a/src/components/settings_pet/components/tabs/HistoryTab.vue
+++ b/src/components/settings_pet/components/tabs/HistoryTab.vue
@@ -60,7 +60,7 @@
                   {{ item.displayName }}
                 </span>
                 <button
-                  v-if="item.userMessageSeq !== undefined"
+                  v-if="typeof item.userMessageSeq === 'number' && !gameStore.runningScript"
                   class="shrink-0 cursor-pointer rounded border border-white/10 bg-transparent px-2 py-0.5 text-xs text-white/40 transition-all duration-200 hover:border-red-400/50 hover:bg-red-500/20 hover:text-white"
                   :title="$t('pet.history.backtrackTitle')"
                   @click.stop="handleBacktrack(item.userMessageSeq!)"

--- a/src/core/events/processors/dialogue-processor.ts
+++ b/src/core/events/processors/dialogue-processor.ts
@@ -45,8 +45,11 @@ export default class DialogueProcessor implements IEventProcessor {
       ttsText: event.ttsText,
     })
 
-    // 回溯更新最近一条没有序号标记的用户消息（前端发送消息时尚未拿到序号）
-    if (event.userMessageSeq !== undefined) {
+    // 回溯更新最近一条没有序号标记的用户消息（前端发送消息时尚未拿到序号）。
+    // 只接受 number：主动对话 / 剧本 ai_dialogue / God Agent 第 2+ 轮的回复没有
+    // 用户触发，event.userMessageSeq 是 undefined（后端 None 不序列化）；若传 null，
+    // 这里不能把它当有效序号写进用户消息，否则回溯会拿到 null。
+    if (typeof event.userMessageSeq === 'number') {
       const history = gameStore.dialogHistory
       for (let i = history.length - 1; i >= 0; i--) {
         if (history[i].type === 'message' && history[i].userMessageSeq === undefined) {


### PR DESCRIPTION
## 问题

剧本对话出现两类数据混乱：

1. **玩家台词归因错乱**：剧本模式所有"玩家说的话"路径（`input` / `choice` 自由输入 / `player` / `free_dialogue` / `add_line` 动作）此前把 `sender_role_id` 写成 `main_role_id`（AI 角色）。`MemoryBuilder` 按 `sender == target` 判定自说自话 → 玩家的话被当成钦灵自己的 assistant 台词灌进记忆 → 钦灵视角里"玩家从没回过话" → 回合错乱 → 模型自导自演、泄漏玩家口吻（例如把玩家本要说的 `你平时写代码会用AI吗？` 写进钦灵台词，并以 `\n\n\n` 伪句合并进同一条）。
2. **回溯 null 序号**：`ai_dialogue` 等无用户触发的回复 `user_message_seq = None`，因缺 `skip_serializing_if` 序列化成 `null`；前端回填逻辑 `event.userMessageSeq !== undefined` 把 `null` 当有效序号写进玩家消息 → 历史页回溯按钮全亮 → 点任何一处传 `null` → 报 `invalid type: null, expected u32`。

## 修复

- 剧本玩家台词 `sender_role_id` 统一 `Some(0)`（与 `handle_user_message` 对齐）：`input_event.rs` / `choice_event.rs` / `player_event.rs` / `free_dialogue_event.rs` / `script_function.rs`
- `responses.rs`：`user_message_seq` 加 `#[serde(skip_serializing_if = "Option::is_none")]`，`None` 不序列化
- `dialogue-processor.ts`：回填条件 `!== undefined` → `typeof === 'number'`
- `SettingsHistory.vue` / `HistoryTab.vue`：回溯按钮条件 `typeof === 'number' && !runningScript`（剧本运行中隐藏回溯按钮）

## 验证

- `cargo check --target aarch64-linux-android --lib --features tauri/custom-protocol`：`REAL_EXIT=0`
- `npx vue-tsc --noEmit`：`VUE_EXIT=0`
