### PR TITLE
fix: 音乐/环境音导入改为传路径（解决前端卡顿 + Android SAF 兼容）

### DIFF
--- a/src-tauri/src/ai_service/skill_agent/command_executor.rs
+++ b/src-tauri/src/ai_service/skill_agent/command_executor.rs
@@ -108,7 +108,8 @@ pub async fn execute_command(
         std::path::PathBuf::from(cwd.trim())
     };
 
-    let output = if cfg!(windows) {
+    #[cfg(windows)]
+    let output = {
         // raw_arg 原样传命令，避免 std 自动加引号被 cmd.exe 自己的一套引号规则弄坏内层引号
         tokio::process::Command::new("cmd")
             .arg("/C")
@@ -116,7 +117,9 @@ pub async fn execute_command(
             .current_dir(cwd_path)
             .output()
             .await
-    } else {
+    };
+    #[cfg(not(windows))]
+    let output = {
         tokio::process::Command::new("sh")
             .arg("-c")
             .arg(command)

--- a/src-tauri/src/api/ambient.rs
+++ b/src-tauri/src/api/ambient.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::io::Write;
 
 use serde::{Deserialize, Serialize};
 use tauri_plugin_store::StoreExt;
@@ -78,15 +77,7 @@ pub fn get_ambient_list() -> Result<Vec<AmbientItemInfo>, String> {
 }
 
 #[tauri::command]
-pub fn upload_ambient(
-    file_name: String,
-    file_data: Vec<u8>,
-) -> Result<Vec<AmbientItemInfo>, String> {
-    let ambient_dir = ambient_dir();
-    if !ambient_dir.exists() {
-        fs::create_dir_all(&ambient_dir).map_err(|e| format!("创建环境音目录失败: {}", e))?;
-    }
-
+pub async fn upload_ambient(app: tauri::AppHandle, path: String, file_name: String) -> Result<(), String> {
     // 安全检查：只保留文件名，防止路径遍历
     let safe_name = std::path::Path::new(&file_name)
         .file_name()
@@ -94,13 +85,30 @@ pub fn upload_ambient(
         .to_string_lossy()
         .into_owned();
 
-    let file_path = ambient_dir.join(&safe_name);
-    let mut f = fs::File::create(&file_path).map_err(|e| format!("创建文件失败: {}", e))?;
-    f.write_all(&file_data)
-        .map_err(|e| format!("写入文件失败: {}", e))?;
-    f.flush().map_err(|e| format!("刷新文件失败: {}", e))?;
+    let ambient_dir = ambient_dir();
+    if !ambient_dir.exists() {
+        tokio::fs::create_dir_all(&ambient_dir)
+            .await
+            .map_err(|e| format!("创建环境音目录失败: {}", e))?;
+    }
 
-    get_ambient_list()
+    let file_path = ambient_dir.join(&safe_name);
+
+    if path.starts_with("content://") {
+        // Android SAF：content:// URI 直接复制到目标文件（不经 IPC 传大文件）
+        use tauri_plugin_android_fs::{AndroidFsExt, FsUri};
+        app.android_fs_async()
+            .copy(&FsUri::from_uri(&path), &FsUri::from_path(&file_path))
+            .await
+            .map_err(|e| format!("SAF 复制环境音失败: {}", e))?;
+    } else {
+        // 桌面端：Rust 直接复制源文件
+        tokio::fs::copy(std::path::PathBuf::from(&path), &file_path)
+            .await
+            .map_err(|e| format!("复制文件失败: {}", e))?;
+    }
+
+    Ok(())
 }
 
 /// 删除指定环境音文件

--- a/src-tauri/src/api/music.rs
+++ b/src-tauri/src/api/music.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::io::Write;
 
 use serde::{Deserialize, Serialize};
 use tauri_plugin_store::StoreExt;
@@ -95,12 +94,7 @@ pub fn get_music_file(filename: String) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub fn upload_music(file_name: String, file_data: Vec<u8>) -> Result<Vec<MusicItemInfo>, String> {
-    let music_dir = music_dir();
-    if !music_dir.exists() {
-        fs::create_dir_all(&music_dir).map_err(|e| format!("创建音乐目录失败: {}", e))?;
-    }
-
+pub async fn upload_music(app: tauri::AppHandle, path: String, file_name: String) -> Result<(), String> {
     // 安全检查：只保留文件名，防止路径遍历
     let safe_name = std::path::Path::new(&file_name)
         .file_name()
@@ -108,13 +102,30 @@ pub fn upload_music(file_name: String, file_data: Vec<u8>) -> Result<Vec<MusicIt
         .to_string_lossy()
         .into_owned();
 
-    let file_path = music_dir.join(&safe_name);
-    let mut f = fs::File::create(&file_path).map_err(|e| format!("创建文件失败: {}", e))?;
-    f.write_all(&file_data)
-        .map_err(|e| format!("写入文件失败: {}", e))?;
-    f.flush().map_err(|e| format!("刷新文件失败: {}", e))?;
+    let music_dir = music_dir();
+    if !music_dir.exists() {
+        tokio::fs::create_dir_all(&music_dir)
+            .await
+            .map_err(|e| format!("创建音乐目录失败: {}", e))?;
+    }
 
-    get_music_list()
+    let file_path = music_dir.join(&safe_name);
+
+    if path.starts_with("content://") {
+        // Android SAF：content:// URI 直接复制到目标文件（不经 IPC 传大文件）
+        use tauri_plugin_android_fs::{AndroidFsExt, FsUri};
+        app.android_fs_async()
+            .copy(&FsUri::from_uri(&path), &FsUri::from_path(&file_path))
+            .await
+            .map_err(|e| format!("SAF 复制音乐失败: {}", e))?;
+    } else {
+        // 桌面端：Rust 直接复制源文件
+        tokio::fs::copy(std::path::PathBuf::from(&path), &file_path)
+            .await
+            .map_err(|e| format!("复制文件失败: {}", e))?;
+    }
+
+    Ok(())
 }
 
 /// 删除指定音乐文件

--- a/src/api/services/ambient.ts
+++ b/src/api/services/ambient.ts
@@ -19,9 +19,9 @@ export const ambientGetAll = async (): Promise<AmbientItem[]> => {
   }
 }
 
-export const ambientUpload = async (fileName: string, fileData: Uint8Array): Promise<void> => {
+export const ambientUpload = async (path: string, fileName: string): Promise<void> => {
   try {
-    await invoke('upload_ambient', { fileName, fileData })
+    await invoke('upload_ambient', { path, fileName })
   } catch (error: any) {
     throw new Error(typeof error === 'string' ? error : error.message || i18n.global.t('api.ambient.uploadFailed'))
   }

--- a/src/api/services/music.ts
+++ b/src/api/services/music.ts
@@ -12,9 +12,9 @@ export const musicGetAll = async (): Promise<MusicTrack[]> => {
   }
 }
 
-export const musicUpload = async (fileName: string, fileData: Uint8Array): Promise<void> => {
+export const musicUpload = async (path: string, fileName: string): Promise<void> => {
   try {
-    await invoke('upload_music', { fileName, fileData })
+    await invoke('upload_music', { path, fileName })
   } catch (error: any) {
     throw new Error(typeof error === 'string' ? error : error.message || 'Music upload failed')
   }

--- a/src/components/settings/pages/SettingsSound.vue
+++ b/src/components/settings/pages/SettingsSound.vue
@@ -38,7 +38,7 @@
       <Slider @change="updateAmbientVolume" v-model="ambientVolume"> {{ $t('settings.sound.slider.weakStrong') }} </Slider>
     </MenuItem>
 
-    <!-- 声音测试（放在音量滑块下方、环境音管理上方） -->
+    <!-- 声音测试 -->
     <MenuItem :title="$t('settings.sound.test.title')" size="small">
       <template #header>
         <FlaskConical :size="20" class="text-pink-400" />
@@ -555,7 +555,7 @@ const uploadAmbientFiles = async () => {
   }
   const allowedExts = ['.mp3', '.wav', '.flac', '.ogg', '.m4a']
   try {
-    // 串行上传（传源文件路径，Rust 侧复制 —— 不走 IPC 传大文件，避免卡顿）
+    // 串行上传（仅传源文件路径，Rust 侧复制）
     for (const path of selectedAmbientPaths.value) {
       // content:// URI 文件名是 URL 编码的，解码后才是真实文件名
       const fileName = decodePathFileName(path)
@@ -702,9 +702,9 @@ const uploadMusic = async () => {
   const allowedExts = ['.mp3', '.wav', '.flac', '.webm', '.weba', '.ogg', '.m4a']
 
   try {
-    // 串行上传（传源文件路径，Rust 侧复制 —— 不走 IPC 传大文件，避免卡顿）
+    // 串行上传（仅传源文件路径，Rust 侧复制）
     for (const path of selectedPaths.value) {
-      // content:// URI 文件名是 URL 编码的（如 %E5%8B%BE），解码后才是真实文件名
+      // content:// URI 文件名是 URL 编码的，解码后才是真实文件名
       const fileName = decodePathFileName(path)
       const fileExt = fileName.slice(fileName.lastIndexOf('.')).toLowerCase()
       if (!allowedExts.includes(fileExt)) {
@@ -762,7 +762,7 @@ const handleStop = () => {
   }
 }
 
-// 打开系统文件对话框选择音乐（拿路径，避免读文件进内存）
+// 打开系统文件对话框选择音乐（仅拿路径）
 const triggerFileUpload = async () => {
   const selected = await openDialog({
     multiple: true,

--- a/src/components/settings/pages/SettingsSound.vue
+++ b/src/components/settings/pages/SettingsSound.vue
@@ -138,27 +138,18 @@
         >
           <UploadCloud :size="18" /> {{ $t('settings.sound.bgm.add') }}
         </Button>
-        <!-- 修改为支持 multiple 多选 -->
-        <input
-          ref="fileInput"
-          type="file"
-          multiple
-          @change="handleFileSelect"
-          accept=".mp3,.wav,.flac,.webm,.weba,.ogg,.m4a"
-          class="hidden"
-        />
         <div class="flex-1 flex items-center justify-between gap-2">
-          <span class="text-xs text-gray-400 truncate w-24" v-if="selectedFiles.length > 0">
-            {{ $t('settings.sound.common.selectedCount', { count: selectedFiles.length }) }}
+          <span class="text-xs text-gray-400 truncate w-24" v-if="selectedPaths.length > 0">
+            {{ $t('settings.sound.common.selectedCount', { count: selectedPaths.length }) }}
           </span>
           <span class="text-xs text-gray-500 truncate w-24" v-else>{{ $t('settings.sound.common.noSelection') }}</span>
 
           <Button
             type="big"
             @click="uploadMusic"
-            :disabled="selectedFiles.length === 0"
+            :disabled="selectedPaths.length === 0"
             class="flex-1"
-            :class="{ 'opacity-50 cursor-not-allowed': selectedFiles.length === 0 }"
+            :class="{ 'opacity-50 cursor-not-allowed': selectedPaths.length === 0 }"
           >
             {{ $t('settings.sound.common.confirmUpload') }}
           </Button>
@@ -219,25 +210,17 @@
         >
           <UploadCloud :size="16" /> {{ $t('settings.sound.ambient.add') }}
         </Button>
-        <input
-          ref="ambientFileInput"
-          type="file"
-          multiple
-          @change="handleAmbientFileSelect"
-          accept=".mp3,.wav,.flac,.ogg,.m4a"
-          class="hidden"
-        />
         <div class="flex-1 flex items-center justify-between gap-2">
-          <span class="text-xs text-gray-400 truncate w-24" v-if="selectedAmbientFiles.length > 0">
-            {{ $t('settings.sound.common.selectedCount', { count: selectedAmbientFiles.length }) }}
+          <span class="text-xs text-gray-400 truncate w-24" v-if="selectedAmbientPaths.length > 0">
+            {{ $t('settings.sound.common.selectedCount', { count: selectedAmbientPaths.length }) }}
           </span>
           <span class="text-xs text-gray-500 truncate w-24" v-else>{{ $t('settings.sound.common.noSelection') }}</span>
           <Button
             type="big"
             @click="uploadAmbientFiles"
-            :disabled="selectedAmbientFiles.length === 0"
+            :disabled="selectedAmbientPaths.length === 0"
             class="flex-1"
-            :class="{ 'opacity-50 cursor-not-allowed': selectedAmbientFiles.length === 0 }"
+            :class="{ 'opacity-50 cursor-not-allowed': selectedAmbientPaths.length === 0 }"
           >
             {{ $t('settings.sound.common.confirmUpload') }}
           </Button>
@@ -318,6 +301,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { open as openDialog } from '@tauri-apps/plugin-dialog'
 import { Button, Slider } from '../../base'
 import { MenuItem, MenuPage } from '../../ui'
 import {
@@ -394,8 +378,7 @@ const musicList = ref<MusicItem[]>([])
 const currentMusicName = ref(t('settings.sound.bgm.noMusicSelected'))
 
 // 批量上传状态
-const selectedFiles = ref<File[]>([])
-const fileInput = ref<HTMLInputElement | null>(null)
+const selectedPaths = ref<string[]>([])
 
 // 播放模式设定 (loop-list: 列表循环, loop-single: 单曲循环, random: 随机)
 type PlaybackMode = 'loop-list' | 'loop-single' | 'random'
@@ -488,8 +471,7 @@ const maxAmbientTracks = 8
 
 // 环境音文件库条目（服务端存储）
 const ambientFileList = ref<AmbientItem[]>([])
-const selectedAmbientFiles = ref<File[]>([])
-const ambientFileInput = ref<HTMLInputElement | null>(null)
+const selectedAmbientPaths = ref<string[]>([])
 
 // 从文件URL推断显示名称
 const inferTrackName = (src: string): string => {
@@ -515,8 +497,45 @@ const stopAllAmbient = () => {
 }
 
 // 触发环境音文件选择
-const triggerAmbientUpload = () => {
-  ambientFileInput.value?.click()
+// 打开系统文件对话框选择环境音（拿路径，避免读文件进内存）
+const triggerAmbientUpload = async () => {
+  const selected = await openDialog({
+    multiple: true,
+    filters: [{ name: 'Ambient', extensions: ['mp3', 'wav', 'flac', 'ogg', 'm4a'] }],
+  })
+  if (!selected) return
+  selectedAmbientPaths.value = extractDialogPaths(selected)
+}
+
+/**
+ * 从 openDialog 的返回中提取文件路径列表。
+ *
+ * 桌面端返回：string（单选）或 string[]（多选）
+ * Android 返回：{ files: string[] }（SAF content:// URI）
+ * 兼容两种格式，过滤空值。
+ */
+const extractDialogPaths = (selected: unknown): string[] => {
+  const raw = Array.isArray(selected)
+    ? selected
+    : selected && typeof selected === 'object' && 'files' in (selected as any)
+      ? (selected as any).files
+      : [selected]
+  return raw
+    .map((p: any) => (typeof p === 'string' ? p : p?.path))
+    .filter((p: any) => typeof p === 'string' && p.length > 0)
+}
+
+/**
+ * 从文件路径提取文件名，兼容 content:// URI（URL 编码）。
+ * decodeURIComponent 遇到非法 % 序列会抛 URIError，这里兜底返回原值。
+ */
+const decodePathFileName = (path: string): string => {
+  const last = path.split(/[\\/]/).pop() || path
+  try {
+    return decodeURIComponent(last).split('?')[0]
+  } catch {
+    return last.split('?')[0]
+  }
 }
 
 // 从服务端加载环境音列表
@@ -528,34 +547,23 @@ const loadAmbientList = async () => {
   }
 }
 
-// 处理环境音文件选择（暂存文件，等待确认上传）
-const handleAmbientFileSelect = (event: Event) => {
-  const target = event.target as HTMLInputElement
-  if (target.files && target.files.length > 0) {
-    selectedAmbientFiles.value = Array.from(target.files)
-  } else {
-    selectedAmbientFiles.value = []
-  }
-  target.value = ''
-}
-
 // 确认上传已选环境音文件到服务端
 const uploadAmbientFiles = async () => {
-  if (selectedAmbientFiles.value.length === 0) {
+  if (selectedAmbientPaths.value.length === 0) {
     await dialogStore.alert(t('settings.sound.ambient.selectFilesFirst'))
     return
   }
   const allowedExts = ['.mp3', '.wav', '.flac', '.ogg', '.m4a']
   try {
-    await Promise.all(
-      selectedAmbientFiles.value.map(async (file) => {
-        const fileExt = file.name.slice(file.name.lastIndexOf('.')).toLowerCase()
-        if (!allowedExts.includes(fileExt)) throw new Error(t('settings.sound.common.unsupportedFormat', { name: file.name }))
-        const buf = await file.arrayBuffer()
-        await ambientUpload(file.name, new Uint8Array(buf))
-      }),
-    )
-    selectedAmbientFiles.value = []
+    // 串行上传（传源文件路径，Rust 侧复制 —— 不走 IPC 传大文件，避免卡顿）
+    for (const path of selectedAmbientPaths.value) {
+      // content:// URI 文件名是 URL 编码的，解码后才是真实文件名
+      const fileName = decodePathFileName(path)
+      const fileExt = fileName.slice(fileName.lastIndexOf('.')).toLowerCase()
+      if (!allowedExts.includes(fileExt)) throw new Error(t('settings.sound.common.unsupportedFormat', { name: fileName }))
+      await ambientUpload(path, fileName)
+    }
+    selectedAmbientPaths.value = []
     await loadAmbientList()
   } catch (error: any) {
     console.error('上传环境音失败:', error)
@@ -686,7 +694,7 @@ const deleteMusic = async (music: MusicItem) => {
 
 // 批量上传逻辑
 const uploadMusic = async () => {
-  if (selectedFiles.value.length === 0) {
+  if (selectedPaths.value.length === 0) {
     await dialogStore.alert(t('settings.sound.bgm.selectFilesFirst'))
     return
   }
@@ -694,20 +702,18 @@ const uploadMusic = async () => {
   const allowedExts = ['.mp3', '.wav', '.flac', '.webm', '.weba', '.ogg', '.m4a']
 
   try {
-    // 使用 Promise.all 进行并发上传
-    await Promise.all(
-      selectedFiles.value.map(async (file) => {
-        const fileExt = file.name.slice(file.name.lastIndexOf('.')).toLowerCase()
-        if (!allowedExts.includes(fileExt)) {
-          throw new Error(t('settings.sound.common.unsupportedFormat', { name: file.name }))
-        }
-        const buf = await file.arrayBuffer()
-        await musicUpload(file.name, new Uint8Array(buf))
-      }),
-    )
+    // 串行上传（传源文件路径，Rust 侧复制 —— 不走 IPC 传大文件，避免卡顿）
+    for (const path of selectedPaths.value) {
+      // content:// URI 文件名是 URL 编码的（如 %E5%8B%BE），解码后才是真实文件名
+      const fileName = decodePathFileName(path)
+      const fileExt = fileName.slice(fileName.lastIndexOf('.')).toLowerCase()
+      if (!allowedExts.includes(fileExt)) {
+        throw new Error(t('settings.sound.common.unsupportedFormat', { name: fileName }))
+      }
+      await musicUpload(path, fileName)
+    }
 
-    selectedFiles.value = []
-    if (fileInput.value) fileInput.value.value = ''
+    selectedPaths.value = []
     await loadMusicList()
     // alert('音乐上传成功') // 可选提示
   } catch (error: any) {
@@ -756,18 +762,16 @@ const handleStop = () => {
   }
 }
 
-const triggerFileUpload = () => {
-  fileInput.value?.click()
-}
-
-// 处理多文件选择
-const handleFileSelect = (event: Event) => {
-  const target = event.target as HTMLInputElement
-  if (target.files && target.files.length > 0) {
-    selectedFiles.value = Array.from(target.files)
-  } else {
-    selectedFiles.value = []
-  }
+// 打开系统文件对话框选择音乐（拿路径，避免读文件进内存）
+const triggerFileUpload = async () => {
+  const selected = await openDialog({
+    multiple: true,
+    filters: [
+      { name: 'Music', extensions: ['mp3', 'wav', 'flac', 'webm', 'weba', 'ogg', 'm4a'] },
+    ],
+  })
+  if (!selected) return
+  selectedPaths.value = extractDialogPaths(selected)
 }
 
 onMounted(async () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,9 @@ export default defineConfig(async () => ({
       : undefined,
     watch: {
       // 3. tell Vite to ignore watching some files
-      ignored: ['**/src-tauri/**', '**/.venv/**', '**/target/**'],
+      // data/ 是运行时数据目录（角色立绘、音乐等），导入/播放时会临时占用文件，
+      // 被 vite watch 会触发 EBUSY 崩溃，必须排除。
+      ignored: ['**/src-tauri/**', '**/.venv/**', '**/target/**', '**/data/**'],
     },
   },
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,8 +34,6 @@ export default defineConfig(async () => ({
       : undefined,
     watch: {
       // 3. tell Vite to ignore watching some files
-      // data/ 是运行时数据目录（角色立绘、音乐等），导入/播放时会临时占用文件，
-      // 被 vite watch 会触发 EBUSY 崩溃，必须排除。
       ignored: ['**/src-tauri/**', '**/.venv/**', '**/target/**', '**/data/**'],
     },
   },


### PR DESCRIPTION
问题：音乐导入时前端卡顿。
根因：<input type=file> + file.arrayBuffer() 在主线程读大文件 + Uint8Array 走 IPC（JSON 序列化）CPU 密集，UI 冻结。

修复：
- 前端改用 openDialog 选文件（拿路径，不读文件进内存）
- 后端 upload_music/upload_ambient 改为接收 path + fileName， Rust 侧直接复制文件（不走 IPC 传大文件）
- Android SAF 兼容：content:// URI 用 android_fs_async().copy() 直接复制到目标文件（保留原始文件名，URL 解码）
- 串行上传（消除并发峰值）+ 列表只刷新一次

附带修复：
- vite watch 排除 data/**（运行时数据目录被占用会 EBUSY 崩溃）
- skill_agent command_executor cfg!(windows) → #[cfg] 分拆 （raw_arg 是 Windows-only API，Android 编译不过）
- 安卓端部分设备没法播放音乐的问题