### PR TITLE
Fix: 修复无法截图 / Feat: 截图界面i18n

### DIFF
--- a/public/screenshot-overlay.html
+++ b/public/screenshot-overlay.html
@@ -73,6 +73,56 @@
   </div>
 
   <script type="module">
+    // ─── i18n：覆盖窗口是独立静态页，不走 vue-i18n，这里内嵌各语言词条 ───
+    // 语言读取逻辑与 src/locales/index.ts 保持一致：主应用把界面语言持久化在
+    // localStorage['lingchat-settings']（settings store persist，key=lingchat-settings），
+    // 覆盖窗口与主窗口同源（dev: localhost:1420 / prod: tauri.localhost），可直接读取。
+    const I18N = {
+      'zh-CN': {
+        hint: '拖拽鼠标框选区域<br>Enter 确认 · Esc 取消',
+        loadFailed: '加载截图失败，请按 Esc 关闭',
+        cancel: '取消 (Esc)',
+        confirm: '确认 (Enter)',
+      },
+      'zh-HK': {
+        hint: '拖拽鼠標框選區域<br>Enter 確認 · Esc 取消',
+        loadFailed: '載入截圖失敗，請按 Esc 關閉',
+        cancel: '取消 (Esc)',
+        confirm: '確認 (Enter)',
+      },
+      ja: {
+        hint: 'ドラッグで範囲を選択<br>Enter で確定 · Esc でキャンセル',
+        loadFailed: 'スクリーンショットの読み込みに失敗しました。Esc で閉じてください',
+        cancel: 'キャンセル (Esc)',
+        confirm: '確定 (Enter)',
+      },
+      en: {
+        hint: 'Drag to select an area<br>Enter to confirm · Esc to cancel',
+        loadFailed: 'Failed to load screenshot. Press Esc to close.',
+        cancel: 'Cancel (Esc)',
+        confirm: 'Confirm (Enter)',
+      },
+    }
+    const FALLBACK_LOCALE = 'zh-CN'
+
+    // 读取当前界面语言；localStorage 缺失 / 解析失败 / 语言不受支持时回退 zh-CN。
+    function detectLocale() {
+      try {
+        const raw = localStorage.getItem('lingchat-settings')
+        const locale = raw ? JSON.parse(raw)?.display?.locale : undefined
+        if (locale && I18N[locale]) return locale
+      } catch {
+        /* 解析失败走 fallback */
+      }
+      return FALLBACK_LOCALE
+    }
+
+    // 取词：目标语言缺键时逐键回退到中文，保证任何情况都有文案。
+    const UI_LOCALE = detectLocale()
+    function t(key) {
+      return I18N[UI_LOCALE][key] ?? I18N[FALLBACK_LOCALE][key]
+    }
+
     async function tauriInvoke(cmd, args) {
       if (typeof window.__TAURI_INTERNALS__ !== 'undefined') {
         return window.__TAURI_INTERNALS__.invoke(cmd, args);
@@ -88,6 +138,12 @@
     const toolbar = document.getElementById('toolbar');
     const hint = document.getElementById('hint');
     const dimensions = document.getElementById('dimensions');
+
+    // 应用界面语言（覆盖 HTML 里写死的中文默认文案）
+    document.documentElement.lang = UI_LOCALE;
+    hint.innerHTML = t('hint');
+    document.getElementById('confirm-btn').textContent = t('confirm');
+    document.getElementById('cancel-btn').textContent = t('cancel');
 
     let startX = 0, startY = 0;
     let isDragging = false;
@@ -131,7 +187,7 @@
         img.src = 'data:image/jpeg;base64,' + base64;
       } catch (err) {
         console.error('Failed to load screenshot:', err);
-        hint.textContent = '加载截图失败，请按 Esc 关闭';
+        hint.innerHTML = t('loadFailed');
       }
     }
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main", "settings", "log"],
+  "windows": ["main", "settings", "log" , "screenshot-overlay"],
   "permissions": [
     "core:default",
     "core:webview:allow-create-webview-window",

--- a/src-tauri/src/api/character.rs
+++ b/src-tauri/src/api/character.rs
@@ -695,7 +695,7 @@ pub async fn delete_character(
             let base = characters_dir();
             let target = base.join(folder);
             // 路径穿越防护
-            super::validate_path_in_base(&target, &base)?;
+            crate::utils::path::validate_path_in_base(&target, &base)?;
             if target.exists() {
                 if let Err(e) = fs::remove_dir_all(&target) {
                     return Err(format!("删除资源目录失败: {}", e));

--- a/src-tauri/src/api/screenshot.rs
+++ b/src-tauri/src/api/screenshot.rs
@@ -28,7 +28,10 @@ pub async fn start_screenshot(app: AppHandle) -> Result<(), String> {
     }
 
     // 捕获全分辨率桌面截图并编码为 base64
-    let jpeg_bytes = capture_screen_raw_jpeg().ok_or("屏幕捕获失败（仅支持 Windows）")?;
+    let Some(jpeg_bytes) = capture_screen_raw_jpeg() else {
+        tracing::error!("[Screenshot] Failed to capture full screen.");
+        return Err("屏幕捕获失败（仅支持 Windows）".to_string());
+    };
     let base64 = base64::Engine::encode(&base64::prelude::BASE64_STANDARD, &jpeg_bytes);
 
     // 存储到临时状态，供覆盖窗口启动后获取

--- a/src/components/ui/ImageSourcePicker.vue
+++ b/src/components/ui/ImageSourcePicker.vue
@@ -109,8 +109,13 @@ function onEsc() {
 
 // 用户切到后台(扣 home / 拉下通知中心 / 弹出权限框等)时自动 cancel,
 // 避免 useScreenshot.isCapturing 永远卡 true。
+// 仅在 picker 会话真正打开时取消,桌面端 isOpen 恒为 false,不会误触发 cancel_screenshot。
 function onVisibilityChange() {
-  if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+  if (
+    typeof document !== 'undefined' &&
+    document.visibilityState === 'hidden' &&
+    isOpen.value
+  ) {
     cancel()
   }
 }
@@ -131,8 +136,9 @@ onMounted(() => {
 })
 
 // 路由切换 / 父组件卸载时兜底 cancel,防止 isCapturing 卡死。
+// 仅当 picker 会话真正打开时才取消,避免桌面端切路由误触发 cancel_screenshot。
 onBeforeUnmount(() => {
-  cancel()
+  if (isOpen.value) cancel()
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
### 简述
日常bug修复捏，这次集中在截图功能上~
### 修复的问题

- 原本的ACL配置忽略了截图时的覆盖式窗口，导致页面无法调用tauri API，出现卡死问题。已通过添加ACL规则解决
- ImageSourcePicker卸载时会强制调用cancel_screenshot，导致电脑端误触发清除截图。通过添加条件限制其只在安卓端起效
- 顺手加上了截图时的i18n 不过需要注意的是我没有走vue-i18n链路（主要考虑是因为截图页面不是Vue组件，应用起来改动会比较多，况且这个页面文字少，于是直接在HTML里写了，只改了一个文件nya~）
### 补充

- screenshot.rs中的改动原本是为debug写的，功能上等效，增加了日志输出，还是保留了~~（可能会增加一点鲁棒性？）~~
- character.rs是为了编译通过而改的（原本代码报错）

