### PR TITLE
fix: Android 端本地 TTS 模型下载失败（TLS panic），改用 webpki-roots 修复

### DIFF
--- a/src-tauri/src/utils/download.rs
+++ b/src-tauri/src/utils/download.rs
@@ -158,10 +158,24 @@ pub async fn download_to_file(
 /// - 最多 10 次重定向
 /// - 标准 User-Agent
 pub fn build_download_client() -> Result<reqwest::Client, String> {
+    // 与 ai_service/llm/factory.rs 的 TLS 修复一致：reqwest 0.13 默认用
+    // rustls-platform-verifier 验证系统证书，Android 上未显式初始化会 TLS panic，
+    // 导致下载请求崩溃（无进度、无响应）。改用 webpki-roots 内置 Mozilla CA。
+    let mut roots = rustls::RootCertStore::empty();
+    roots.roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|e| format!("rustls 协议版本配置失败: {e}"))?
+    .with_root_certificates(Arc::new(roots))
+    .with_no_client_auth();
+
     reqwest::Client::builder()
         .timeout(Duration::from_secs(600))
         .user_agent("LingChat/0.4.6")
         .redirect(reqwest::redirect::Policy::limited(10))
+        .tls_backend_preconfigured(tls_config)
         .build()
         .map_err(|e| format!("build http client: {e}"))
 }


### PR DESCRIPTION
## 问题

Android 端本地 TTS（Style-Bert-VITS2）模型下载无法使用：
- 点击下载无进度条、无响应
- DeBERTa / 语音模型均无法安装，界面持续提示"缺少 DeBERTa 模型"
- 手动导入语音模型（本地文件）可用，但 DeBERTa 是共享基础模型必须联网下载

## 根因

`src-tauri/src/utils/download.rs` 的 `build_download_client()` 使用 reqwest 0.13
默认 TLS 配置（`rustls-platform-verifier`，验证操作系统证书）。该验证器在
Android 上需要在启动时显式初始化（JVM + Context + ClassLoader），未初始化时
TLS 握手直接 panic：

thread 'tokio-rt-worker' panicked at ...rustls-platform-verifier-0.7.0\src\android.rs:90:10:
Expect rustls-platform-verifier to be initialized


下载线程崩溃导致请求无进度、无响应。LLM 客户端（`ai_service/llm/factory.rs`）
此前已踩过同一问题并有专门修复（webpki-roots），但下载客户端未同步该修复。

## 修复

`build_download_client()` 改用 `webpki-roots`（内置 Mozilla CA 根证书）构造
rustls ClientConfig 注入 reqwest，与 LLM 客户端 `factory.rs` 的既有修复保持一致：
- 全平台一致，无需任何初始化
- 显式指定 `aws-lc-rs` provider（依赖树中同时存在 aws-lc-rs 和 ring，避免歧义）
- 不依赖全局 CryptoProvider（避免进程级副作用和调用顺序依赖）

## 验证

- 真机（arm64, Android 14, MIUI）：TTS 模型下载正常显示进度条，DeBERTa + 语音模型安装成功
- 本地 TTS 引擎初始化正常，语音合成可用
- `cargo check` 通过（Windows + Android 目标）

## 影响范围

仅 `build_download_client()`（TTS 下载、LAN 同步、角色包下载共用的下载工具），
不涉及其他模块。行为上无变化（webpki-roots 是 Mozilla CA 标准根证书）。
