### PR TITLE
fix: 游戏主界面按钮纵向溢出修复+剧本编辑器（一级标题）按钮改为创意工坊

### DIFF
--- a/src/components/views/menu/base/StartItem.vue
+++ b/src/components/views/menu/base/StartItem.vue
@@ -6,7 +6,6 @@
       border-none
       mt-[15px]
       p-[5px]
-      text-[clamp(40px,4vw,72px)]
       font-['Maoken_Assorted_Sans',-apple-system,BlinkMacSystemFont,'Segoe_UI',Roboto,'Helvetica_Neue',Arial,sans-serif]
       cursor-pointer
       text-justify
@@ -23,7 +22,14 @@
       disabled:cursor-not-allowed
       hover:disabled:text-white
       hover:disabled:text-shadow-[0_2px_4px_rgba(0,0,0,0.5)]"
+    :class="isUltraWide ? 'text-[clamp(28px,3vw,52px)]' : 'text-[clamp(40px,4vw,72px)]'"
   >
     <slot />
   </button>
 </template>
+
+<script setup lang="ts">
+import { inject } from 'vue'
+
+const isUltraWide = inject<{ value: boolean }>('isUltraWide', { value: false })
+</script>

--- a/src/components/views/menu/base/StartList.vue
+++ b/src/components/views/menu/base/StartList.vue
@@ -3,8 +3,48 @@
     class="flex
       flex-col
       items-stretch"
+    :class="responsive && isUltraWide ? 'grid grid-cols-2' : ''"
     v-bind="$attrs"
   >
     <slot />
   </nav>
 </template>
+
+<script setup lang="ts">
+import { inject, onUnmounted, provide, ref } from 'vue'
+
+interface Props {
+  /** 是否启用超宽屏 2 列切换（仅主菜单开启，二级菜单保持单列） */
+  responsive?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  responsive: false,
+})
+
+const isUltraWide = ref(false)
+
+let mq: MediaQueryList | null = null
+let mqListener: ((e: MediaQueryListEvent) => void) | null = null
+
+function update() {
+  const matched = mq ? mq.matches : false
+  // matchMedia 的 min-aspect-ratio: 2/1 在恰好 2.0 时返回 true，需求是严格 > 2，用 JS 计算修正
+  isUltraWide.value = matched && window.innerWidth / window.innerHeight > 2
+}
+
+if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+  mq = window.matchMedia('(min-aspect-ratio: 2/1)')
+  update()
+  mqListener = () => update()
+  mq.addEventListener('change', mqListener)
+}
+
+provide('isUltraWide', isUltraWide)
+
+onUnmounted(() => {
+  if (mq && mqListener) {
+    mq.removeEventListener('change', mqListener)
+  }
+})
+</script>

--- a/src/components/views/menu/page/MainMenuOptions.vue
+++ b/src/components/views/menu/page/MainMenuOptions.vue
@@ -1,5 +1,5 @@
 <template>
-  <StartList>
+  <StartList responsive>
     <StartLine>
       <StartItem @click="() => emit('start-game')">{{ $t('views.menu.startGame') }}</StartItem>
     </StartLine>

--- a/src/locales/en/views.ts
+++ b/src/locales/en/views.ts
@@ -54,7 +54,7 @@ export default {
     exitGame: "Exit Game",
     freeDialogue: "Free Chat Mode",
     storyMode: "Story Mode",
-    scriptEditor: "Script Editor",
+    scriptEditor: "Workshop",
     miniGame: "Mini Games (In Development)",
     back: "Back",
   },

--- a/src/locales/ja/views.ts
+++ b/src/locales/ja/views.ts
@@ -53,7 +53,7 @@ export default {
     exitGame: 'ゲーム終了',
     freeDialogue: 'フリー会話モード',
     storyMode: 'ストーリーモード',
-    scriptEditor: 'シナリオエディタ',
+    scriptEditor: 'クリエイティブ工房',
     miniGame: 'ミニゲーム（開発中）',
     back: '戻る',
   },

--- a/src/locales/zh-CN/views.ts
+++ b/src/locales/zh-CN/views.ts
@@ -53,7 +53,7 @@ export default {
     exitGame: '退出游戏',
     freeDialogue: '自由对话模式',
     storyMode: '剧情模式',
-    scriptEditor: '剧本编辑器',
+    scriptEditor: '创意工坊',
     miniGame: '小游戏（开发中）',
     back: '返回',
   },

--- a/src/locales/zh-HK/views.ts
+++ b/src/locales/zh-HK/views.ts
@@ -54,7 +54,7 @@ export default {
     "exitGame": "退出遊戲",
     "freeDialogue": "自由傾偈模式",
     "storyMode": "劇情模式",
-    "scriptEditor": "劇本編輯器",
+    "scriptEditor": "創意工坊",
     "miniGame": "小遊戲（開發緊）",
     "back": "返回"
   },


### PR DESCRIPTION
## 功能
主菜单在超宽屏（视口宽高比 > 2，如 2560×1080）下按钮自动切换为 2 列 × 3 行网格（列优先），避免单列 6 个按钮纵向溢出；同时将「剧本编辑器」按钮文案改为「创意工坊」（4 语言）。

### 实现
StartList 新增 responsive prop（默认关闭），仅主菜单启用；matchMedia 监听 min-aspect-ratio: 2/1 + JS width/height > 2 严格判断
超宽下字号从 clamp(40px,4vw,72px) 缩为 clamp(28px,3vw,52px)
二级菜单（创意工坊/游戏模式/剧本模式）不传 responsive，保持单列不受影响
### 验证
桌面端超宽窗口（比例 > 2）2×3 网格生效，普通窗口单列不变
恰好 2.0 不切换（严格大于）
真机测试+模拟器验证

### 实机截图
<img width="2772" height="1280" alt="Screenshot_2026-08-04-19-30-04-421_com noiq lingc" src="https://github.com/user-attachments/assets/9331cc51-e104-4eeb-8eae-1af9027bef2f" />
