### PR TITLE
fix: 恢复 esaxx-rs 本地补丁配置（上游合并覆盖丢失，修复 Windows LNK2038）

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1953,8 +1953,6 @@ dependencies = [
 [[package]]
 name = "esaxx-rs"
 version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -92,3 +92,10 @@ tauri-plugin-process = "2"
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62.2", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_Graphics_Gdi"] }
 
+
+# 本地补丁：esaxx-rs 0.1.10 上游 build.rs 硬编码 .static_crt(true)（/MT 静态 CRT），
+# 与 ort（onnxruntime，/MD 动态 CRT）在同一链接里混用，导致 MSVC 报
+# LNK2005/LNK2038/LNK4098。这里改用本地副本编译为 /MD，二者统一为动态 CRT。
+# 详见 patches/esaxx-rs/build.rs 的注释。
+[patch.crates-io]
+esaxx-rs = { path = "patches/esaxx-rs" }


### PR DESCRIPTION
## 背景

上游 `bfedead8` 提交了 `patches/esaxx-rs` 目录但未在 Cargo.toml 引用
`[patch.crates-io]`。导致 esaxx-rs 用 /MT 静态 CRT 编译，与 ort
（onnxruntime）的 /MD 动态 CRT 混链，MSVC 报 LNK2038，Windows 构建失败。

## 改动

- `src-tauri/Cargo.toml`：补上 `[patch.crates-io] esaxx-rs = { path = "patches/esaxx-rs" }`
- `src-tauri/Cargo.lock`：移除被 patch 替代的 registry 条目

## 验证

- `cargo check` 通过（Windows x64）
