### PR TITLE
feat: 剧本编辑器支持自定义背景与外观设置页（上传/裁剪/模糊/暗化）

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tauri-apps/plugin-process": "^2",
     "@tauri-apps/plugin-updater": "^2",
     "axios": "^1.16.0",
+    "cropperjs": "^1.6.2",
     "lucide-vue-next": "^1.0.0",
     "marked": "^18.0.7",
     "opencc-js": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,10 @@ importers:
         version: 2.10.1
       axios:
         specifier: ^1.16.0
-        version: 1.16.0
+        version: 1.16.0(debug@4.4.3)
+      cropperjs:
+        specifier: ^1.6.2
+        version: 1.6.2
       lucide-vue-next:
         specifier: ^1.0.0
         version: 1.0.0(vue@3.5.34(typescript@5.6.3))
@@ -954,6 +957,11 @@ packages:
 
   '@volar/typescript@2.4.15':
     resolution: {integrity: sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue-macros/common@3.1.2':
     resolution: {integrity: sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==}
@@ -1122,6 +1130,9 @@ packages:
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
+
+  cropperjs@1.6.2:
+    resolution: {integrity: sha512-nhymn9GdnV3CqiEHJVai54TULFAE3VshJTXSqSJKa8yXAKyBKDWdhHarnlIPrshJ0WMFTGuFvG02YjLXfPiuOA==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1707,6 +1718,7 @@ packages:
     engines: {node: '>=v14.21.3'}
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: '*'
 
   vite-plugin-vue-inspector@6.0.0:
     resolution: {integrity: sha512-OpyITJLgZNibxlrik1EmRtvXHDjLRxNPsWkGFTERZs2LgMEdG4W0WoFt5GIgp3a3jRou+eJR8U1zOBk/XQgEbw==}
@@ -2466,11 +2478,13 @@ snapshots:
 
   '@volar/source-map@2.4.15': {}
 
-  '@volar/typescript@2.4.15':
+  '@volar/typescript@2.4.15(typescript@5.6.3)':
     dependencies:
       '@volar/language-core': 2.4.15
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 5.6.3
 
   '@vue-macros/common@3.1.2(vue@3.5.34(typescript@5.6.3))':
     dependencies:
@@ -2640,9 +2654,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.16.0:
+  axios@1.16.0(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -2694,6 +2708,8 @@ snapshots:
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
+
+  cropperjs@1.6.2: {}
 
   csstype@3.2.3: {}
 
@@ -2787,7 +2803,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
 
   form-data@4.0.5:
     dependencies:
@@ -3194,10 +3212,10 @@ snapshots:
       vite: 6.4.2(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
       vite-plugin-inspect: 11.3.3(vite@6.4.2(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       vite-plugin-vue-inspector: 6.0.0(vite@6.4.2(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      vue: 3.5.34(typescript@5.6.3)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - supports-color
-      - vue
 
   vite-plugin-vue-inspector@6.0.0(vite@6.4.2(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
     dependencies:
@@ -3264,7 +3282,7 @@ snapshots:
 
   vue-tsc@2.2.12(typescript@5.6.3):
     dependencies:
-      '@volar/typescript': 2.4.15
+      '@volar/typescript': 2.4.15(typescript@5.6.3)
       '@vue/language-core': 2.2.12(typescript@5.6.3)
       typescript: 5.6.3
 

--- a/src-tauri/permissions/app-commands.toml
+++ b/src-tauri/permissions/app-commands.toml
@@ -135,6 +135,8 @@ commands.allow = [
   "editor_create_script",
   "editor_delete_script",
   "editor_upload_asset",
+  "editor_upload_editor_bg",
+  "editor_upload_editor_bg_data",
   "editor_create_character",
   "editor_list_global_assets",
   "editor_list_asset_files",

--- a/src-tauri/src/api/script_editor/commands.rs
+++ b/src-tauri/src/api/script_editor/commands.rs
@@ -8,6 +8,8 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+// base64 0.21+ 的 decode 是 Engine trait 方法，必须引入 trait 才能调用
+use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as JsonValue};
 use tauri::{AppHandle, Manager};
@@ -946,6 +948,86 @@ pub fn editor_upload_asset(
     }
     std::fs::copy(src, &target).map_err(|e| format!("复制素材失败: {}", e))?;
     Ok(name)
+}
+
+/// 上传编辑器自定义背景。
+///
+/// 与 `editor_upload_asset` 同一模式：只收**源文件路径**，由 Rust 复制 —— 用户从
+/// 任意位置选的文件不在 fs scope 内，大图走 IPC 又会 OOM。
+///
+/// 落盘为 `<data_dir>/editor/<清洗后的原文件名>`，保留用户原名便于识别；复制前
+/// 清空整个 `editor/` 目录（该目录专属于编辑器背景），磁盘上始终只有当前一张。
+#[tauri::command]
+pub fn editor_upload_editor_bg(src_path: String) -> Result<String, String> {
+    let src = Path::new(&src_path);
+    if !src.is_file() {
+        return Err(format!("源文件不存在: {}", src_path));
+    }
+
+    let ext = src
+        .extension()
+        .map(|e| e.to_string_lossy().to_lowercase())
+        .unwrap_or_default();
+    let allowed = ["png", "jpg", "jpeg", "webp", "bmp", "gif"];
+    if !allowed.contains(&ext.as_str()) {
+        return Err(format!(
+            "不支持的文件类型 .{}；背景图支持: {}",
+            ext,
+            allowed.join(" / ")
+        ));
+    }
+
+    // 只取文件名，杜绝用源路径拼出目标路径；保留原名，清洗掉非法字符
+    let raw_name = src
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .ok_or_else(|| "无法从源路径取出文件名".to_string())?;
+    let name = paths::sanitize_file_name(&raw_name)?;
+
+    let dir = data_dir().join("editor");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("无法创建背景目录: {}", e))?;
+    clear_editor_bg_dir(&dir)?;
+    let target = dir.join(&name);
+    std::fs::copy(src, &target).map_err(|e| format!("复制背景图失败: {}", e))?;
+    Ok(target.to_string_lossy().to_string())
+}
+
+/// 上传裁剪后的编辑器背景（base64 形式）。
+///
+/// 裁剪在浏览器端完成（cropperjs → canvas → webp），这里只负责解码落盘；
+/// `name` 为前端生成的输出文件名（原名去扩展名 + `_crop.webp`），同样做清洗。
+#[tauri::command]
+pub fn editor_upload_editor_bg_data(data: String, name: String) -> Result<String, String> {
+    // 兼容 data:image/webp;base64, 前缀与纯 base64 两种输入
+    let b64 = data.split(',').next_back().unwrap_or(&data).trim();
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .map_err(|e| format!("背景图数据解码失败: {}", e))?;
+    if bytes.len() < 4 {
+        return Err("背景图数据无效".to_string());
+    }
+
+    let name = paths::sanitize_file_name(&name)?;
+    let dir = data_dir().join("editor");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("无法创建背景目录: {}", e))?;
+    clear_editor_bg_dir(&dir)?;
+    let target = dir.join(&name);
+    std::fs::write(&target, &bytes).map_err(|e| format!("写入背景图失败: {}", e))?;
+    Ok(target.to_string_lossy().to_string())
+}
+
+/// 清空编辑器背景目录下的所有文件。
+///
+/// 该目录只属于「编辑器背景」一个功能，同一时刻磁盘上只允许存在当前这一张，
+/// 换扩展名/换文件名上传时旧文件必须被清掉，否则形成"覆盖不干净"的残留。
+fn clear_editor_bg_dir(dir: &Path) -> Result<(), String> {
+    for entry in std::fs::read_dir(dir).map_err(|e| format!("无法读取背景目录: {}", e))? {
+        let entry = entry.map_err(|e| format!("读取背景目录失败: {}", e))?;
+        if entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            std::fs::remove_file(entry.path()).map_err(|e| format!("清理旧背景图失败: {}", e))?;
+        }
+    }
+    Ok(())
 }
 
 /// 递归复制目录，供 rename 跨设备失败时兜底。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -578,6 +578,8 @@ pub fn run() {
             api::script_editor::editor_create_script,
             api::script_editor::editor_delete_script,
             api::script_editor::editor_upload_asset,
+            api::script_editor::editor_upload_editor_bg,
+            api::script_editor::editor_upload_editor_bg_data,
             api::script_editor::editor_create_character,
             api::script_editor::editor_list_global_assets,
             api::script_editor::editor_list_asset_files,

--- a/src/api/services/script-editor.ts
+++ b/src/api/services/script-editor.ts
@@ -249,6 +249,21 @@ export type AssetScope = 'script' | 'global'
 export const uploadAsset = (key: string, kind: AssetKind, scope: AssetScope, srcPath: string) =>
   invoke<string>('editor_upload_asset', { key, kind, scope, srcPath })
 
+/**
+ * 上传编辑器自定义背景。只传源文件路径，由 Rust 复制到数据目录（与 uploadAsset
+ * 同一模式，见其后注释）；返回绝对路径，用 convertFileSrc 转 asset URL 显示。
+ * 重复导入覆盖旧图，'editorBg.path = ""' 即恢复默认背景。
+ */
+export const uploadEditorBg = (srcPath: string) =>
+  invoke<string>('editor_upload_editor_bg', { srcPath })
+
+/**
+ * 上传裁剪后的编辑器背景：dataUrl（data:image/webp;base64,...）由前端 cropperjs
+ * 裁剪输出，`name` 为输出文件名（原名去扩展名 + `_crop.webp`），后端解码落盘。
+ */
+export const uploadEditorBgData = (dataUrl: string, name: string) =>
+  invoke<string>('editor_upload_editor_bg_data', { data: dataUrl, name })
+
 /** 全局素材（game_data/backgrounds、musics、ambient） */
 export const listGlobalAssets = () => invoke<AssetIndex>('editor_list_global_assets')
 
@@ -271,6 +286,16 @@ export interface AssetFileIndex {
 /** 列素材（带路径与体积）。与只给文件名的两个命令并存，那两个喂下拉框 */
 export const listAssetFiles = (key: string, scope: AssetScope) =>
   invoke<AssetFileIndex>('editor_list_asset_files', { key, scope })
+
+/**
+ * 全局背景库（game_data/backgrounds）的文件列表，带绝对路径。
+ * 复用 editor_list_asset_files 的 global 落点：该落点不校验剧本 key，传空串即可。
+ * 供外观页「从已有背景选择」使用，选中即直接设为编辑器背景。
+ */
+export const listGlobalBackgrounds = () =>
+  invoke<AssetFileIndex>('editor_list_asset_files', { key: '', scope: 'global' }).then(
+    (idx) => idx.background,
+  )
 
 /** 删除素材。与章节、剧本一致，移到同级 .trash/ 而不是真删 */
 export const deleteAsset = (key: string, kind: AssetKind, scope: AssetScope, name: string) =>

--- a/src/components/base/widget/Icon.vue
+++ b/src/components/base/widget/Icon.vue
@@ -1,5 +1,9 @@
 <template>
-  <span v-html="svg" :style="`width:${size}px; height:${size}px`" @click="$emit('click')"></span>
+  <span
+    v-html="svg"
+    :style="`width:${size}px; height:${size}px`"
+    @click="$emit('click')"
+  ></span>
 </template>
 
 <script setup lang="ts">
@@ -33,6 +37,7 @@ export type IconType =
   | 'log'
   | 'bot'
   | 'sliders'
+  | 'palette'
 
 // 定义组件属性
 const props = defineProps({
@@ -83,6 +88,7 @@ const html: Record<IconType, string> = {
   log: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-scroll-text"><path d="M15 12h-5"/><path d="M15 8h-5"/><path d="M19 17V5a2 2 0 0 0-2-2H4"/><path d="M8 21h12a2 2 0 0 0 2-2v-1a1 1 0 0 0-1-1H11a1 1 0 0 0-1 1v1a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v2a1 1 0 0 0 1 1h3"/></svg>`,
   bot: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-bot"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>`,
   sliders: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sliders-horizontal"><line x1="21" x2="14" y1="4" y2="4"/><line x1="10" x2="3" y1="4" y2="4"/><line x1="21" x2="12" y1="12" y2="12"/><line x1="8" x2="3" y1="12" y2="12"/><line x1="21" x2="16" y1="20" y2="20"/><line x1="12" x2="3" y1="20" y2="20"/><line x1="14" x2="14" y1="2" y2="6"/><line x1="8" x2="8" y1="10" y2="14"/><line x1="16" x2="16" y1="18" y2="22"/></svg>`,
+  palette: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-palette"><circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"/></svg>`,
 }
 </script>
 

--- a/src/components/base/widget/Slider.vue
+++ b/src/components/base/widget/Slider.vue
@@ -65,6 +65,15 @@ const slots: Slots = useSlots()
 // 使用计算属性处理v-model绑定
 const value = ref(Number(props.modelValue))
 
+// 外部值变化时同步滑块位置（如「恢复默认」后回到初始值）；
+// 本组件只 emit change/input，不 emit update:modelValue，外部需用 :model-value + @change
+watch(
+  () => props.modelValue,
+  (v) => {
+    value.value = Number(v)
+  },
+)
+
 // 分别设置滑块两端内容
 const leftLabel = computed(() => {
   if (slots.default) {

--- a/src/components/script-editor/AppearanceTab.vue
+++ b/src/components/script-editor/AppearanceTab.vue
@@ -1,0 +1,300 @@
+<template>
+  <div class="flex
+    w-full
+    flex-col
+    gap-4">
+    <div class="flex
+      items-center
+      justify-between">
+      <p class="text-[0.78rem]
+        text-white/50">编辑器背景与遮挡效果，改动即时生效并自动保存。</p>
+    </div>
+
+    <!-- 背景图 -->
+    <MenuItem title="背景图">
+      <template #header>
+        <Icon
+          icon="background"
+          :size="16"
+          class="text-brand"
+        />
+      </template>
+      <div class="flex
+        flex-col
+        gap-3">
+        <div class="rounded-lg
+          border
+          border-white/10
+          bg-black/20
+          px-3
+          py-2.5">
+          <div class="mb-1
+            text-[0.72rem]
+            text-white/45">当前背景</div>
+          <div class="flex
+            items-center
+            gap-2
+            font-mono
+            text-[0.78rem]
+            text-white/85">
+            <Icon
+              icon="background"
+              :size="13"
+              class="shrink-0
+                text-white/40"
+            />
+            <span class="truncate">{{ bgFileName }}</span>
+          </div>
+        </div>
+
+        <div class="flex
+          gap-2">
+          <button
+            class="inline-flex
+              flex-1
+              items-center
+              justify-center
+              gap-1.5
+              rounded-lg
+              border
+              border-brand/45
+              bg-brand/14
+              px-3
+              py-2
+              text-[0.8rem]
+              text-brand
+              transition-colors
+              hover:bg-brand/24"
+            @click="pickImage"
+          >
+            <Icon
+              icon="background"
+              :size="14"
+            />
+            选择图片…
+          </button>
+          <button
+            class="inline-flex
+              items-center
+              justify-center
+              gap-1.5
+              rounded-lg
+              border
+              border-white/10
+              bg-white/6
+              px-3
+              py-2
+              text-[0.8rem]
+              text-white/70
+              transition-colors
+              hover:bg-white/[0.12]
+              hover:text-white"
+            title="恢复为内置默认背景"
+            :disabled="!store.editorBg.path"
+            @click="store.resetEditorBg()"
+          >
+            <Icon
+              icon="history"
+              :size="14"
+            />
+            恢复默认
+          </button>
+        </div>
+        <p class="text-[0.72rem]
+          leading-relaxed
+          text-white/40">
+          默认背景与主菜单同款；自定义图片会复制到应用数据目录，本地文件可随时移动。选择图片后可在裁剪弹窗中调整范围。
+        </p>
+
+        <!-- 从已有背景选择 -->
+        <div>
+          <div class="mb-1.5
+            text-[0.72rem]
+            text-white/45">从已有背景选择</div>
+          <div class="flex
+            flex-col
+            gap-1.5">
+            <button
+              v-for="f in store.globalBgFiles"
+              :key="f.path"
+              class="flex
+                items-center
+                gap-2
+                rounded-[10px]
+                border
+                px-3
+                py-2
+                text-left
+                transition-all
+                duration-200"
+              :class="
+                store.editorBg.path === f.path
+                  ? `border-brand/40
+                    bg-brand/10`
+                  : `border-white/10
+                    bg-white/6
+                    hover:border-brand/40`
+              "
+              @click="store.setEditorBgPath(f.path)"
+            >
+              <Icon
+                icon="background"
+                :size="14"
+                class="shrink-0
+                  text-white/40"
+              />
+              <span class="min-w-0
+                flex-1
+                truncate
+                text-[0.8rem]
+                text-white/85">{{ f.name }}</span>
+              <span class="shrink-0
+                text-[0.68rem]
+                text-white/35">{{ humanSize(f.size) }}</span>
+            </button>
+            <p
+              v-if="!store.globalBgFiles.length"
+              class="text-[0.72rem]
+                text-white/35"
+            >
+              （暂无全局背景，可在素材页导入）
+            </p>
+          </div>
+        </div>
+      </div>
+    </MenuItem>
+
+    <!-- 视觉效果 -->
+    <MenuItem title="视觉效果">
+      <template #header>
+        <Icon
+          icon="sliders"
+          :size="16"
+          class="text-brand"
+        />
+      </template>
+      <div class="flex
+        flex-col
+        gap-4">
+        <div>
+          <label
+            class="mb-1
+              inline-flex
+              items-center
+              gap-1.5
+              text-[0.84rem]
+              font-medium
+              text-white/80"
+          >
+            模糊
+          </label>
+          <Slider
+            :model-value="store.editorBg.blur"
+            :min="0"
+            :max="24"
+            :step="1"
+            @change="onBlurChange"
+          >
+            清晰/柔和
+          </Slider>
+        </div>
+
+        <div>
+          <label
+            class="mb-1
+              inline-flex
+              items-center
+              gap-1.5
+              text-[0.84rem]
+              font-medium
+              text-white/80"
+          >
+            压暗遮罩
+          </label>
+          <Slider
+            :model-value="dimPercent"
+            :min="0"
+            :max="90"
+            :step="1"
+            @change="onDimChange"
+          >
+            明亮/深暗
+          </Slider>
+          <p class="mt-1
+            text-[0.72rem]
+            leading-relaxed
+            text-white/40">
+            调节背景上方的黑色遮罩，保证文字与面板可读。
+          </p>
+        </div>
+      </div>
+    </MenuItem>
+
+    <!-- 裁剪弹窗：选图后打开 -->
+    <ImageCropModal
+      v-if="cropSrc"
+      :src-path="cropSrc"
+      @confirm="onCropConfirm"
+      @cancel="cropSrc = null"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { open as openDialog } from '@tauri-apps/plugin-dialog'
+import { Icon, Slider } from '@/components/base'
+import { MenuItem } from '@/components/ui'
+import ImageCropModal from '@/components/script-editor/ImageCropModal.vue'
+import { useScriptEditorStore } from '@/stores/modules/script-editor'
+
+const store = useScriptEditorStore()
+
+const IMAGE_EXT = ['png', 'jpg', 'jpeg', 'webp', 'bmp', 'gif']
+
+/** 当前正在裁剪的源文件路径；非空时显示裁剪弹窗 */
+const cropSrc = ref<string | null>(null)
+
+/** 当前背景显示名：自定义时取落盘文件名，默认时说明内置背景 */
+const bgFileName = computed(() => {
+  const path = store.editorBg.path
+  if (!path) return '内置默认背景（主菜单同款）'
+  return path.split(/[\\/]/).pop() || path
+})
+
+/** 压暗遮罩：UI 用 0~90 整数显示，store 存 0~1 小数 */
+const dimPercent = computed(() => Math.round(store.editorBg.dim * 100))
+
+// 本组件只 emit change，不 emit update:modelValue，这里显式回写 store
+const onBlurChange = (v: number) => {
+  store.editorBg = { ...store.editorBg, blur: v }
+}
+const onDimChange = (v: number) => {
+  store.editorBg = { ...store.editorBg, dim: v / 100 }
+}
+
+const humanSize = (n: number) => {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`
+  return `${(n / 1024 / 1024).toFixed(1)} MB`
+}
+
+/** 选图后进入裁剪弹窗（默认选区铺满整图，不拖框即等于不裁剪） */
+const pickImage = async () => {
+  const picked = await openDialog({
+    multiple: false,
+    filters: [{ name: '图片', extensions: IMAGE_EXT }],
+  })
+  if (typeof picked !== 'string' || !picked) return
+  cropSrc.value = picked
+}
+
+const onCropConfirm = async (dataUrl: string, name: string) => {
+  cropSrc.value = null
+  await store.uploadEditorBgData(dataUrl, name)
+}
+
+onMounted(() => {
+  void store.refreshGlobalBgFiles()
+})
+</script>

--- a/src/components/script-editor/EditorHeader.vue
+++ b/src/components/script-editor/EditorHeader.vue
@@ -19,11 +19,20 @@ type TabKey =
   | 'validate'
   | 'agent-chat'
   | 'agent-settings'
+  | 'appearance'
 
 const tabs: {
   key: TabKey
   label: string
-  icon: 'adventure' | 'setting' | 'character' | 'background' | 'achievement' | 'bot' | 'sliders'
+  icon:
+    | 'adventure'
+    | 'setting'
+    | 'character'
+    | 'background'
+    | 'achievement'
+    | 'bot'
+    | 'sliders'
+    | 'palette'
 }[] = [
   { key: 'flow', label: '章节流程', icon: 'adventure' },
   { key: 'config', label: '剧本设置', icon: 'setting' },
@@ -32,6 +41,7 @@ const tabs: {
   { key: 'validate', label: '校验', icon: 'achievement' },
   { key: 'agent-chat', label: 'AI 助手', icon: 'bot' },
   { key: 'agent-settings', label: '助手设置', icon: 'sliders' },
+  { key: 'appearance', label: '外观', icon: 'palette' },
 ]
 
 // ---- nav 指示条（与 SettingsNav 同一套做法）----
@@ -78,8 +88,14 @@ const moveIndicator = async (animate = true) => {
   bar.style.width = `${box.width}px`
 }
 
-watch(() => store.tab, () => moveIndicator())
-watch(() => store.detail?.package.key, () => moveIndicator())
+watch(
+  () => store.tab,
+  () => moveIndicator(),
+)
+watch(
+  () => store.detail?.package.key,
+  () => moveIndicator(),
+)
 
 let navObserver: ResizeObserver | null = null
 
@@ -92,7 +108,7 @@ const observeNav = () => {
 }
 
 const switchTab = (key: TabKey) => {
-  if (!store.detail && key !== 'flow' && key !== 'agent-chat' && key !== 'agent-settings') return
+  if (!store.detail && !['flow', 'agent-chat', 'agent-settings', 'appearance'].includes(key)) return
   store.tab = key
   if (key === 'validate') void store.runValidation()
   if (key === 'assets') {
@@ -110,9 +126,10 @@ const saveLabel = computed(() => {
   if (store.dirty) return '有未保存改动'
   if (store.lastSavedAt) {
     const d = new Date(store.lastSavedAt)
-    return `已自动保存 · ${String(d.getHours()).padStart(2, '0')}:${String(
-      d.getMinutes(),
-    ).padStart(2, '0')}`
+    return `已自动保存 · ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(
+      2,
+      '0',
+    )}`
   }
   return '已保存'
 })
@@ -131,15 +148,45 @@ onUnmounted(() => {
 <template>
   <div>
     <!-- 顶栏：与 SettingsNav 同构 -->
-    <div class="flex w-full items-center justify-between px-5 py-2">
-      <span class="ml-5 text-[0.95rem] font-bold tracking-[0.5px] text-brand whitespace-nowrap">LingChat 剧本编辑器</span>
+    <div class="flex
+      w-full
+      items-center
+      justify-between
+      px-5
+      py-2">
+      <span class="ml-5
+        text-[0.95rem]
+        font-bold
+        tracking-[0.5px]
+        text-brand
+        whitespace-nowrap"
+        >LingChat 剧本编辑器</span
+      >
       <nav
         ref="navEl"
-        class="relative flex h-full w-full flex-nowrap items-center justify-center gap-1 overflow-x-auto overflow-y-hidden px-2"
+        class="relative
+          flex
+          h-full
+          w-full
+          flex-nowrap
+          items-center
+          justify-center
+          gap-1
+          overflow-x-auto
+          overflow-y-hidden
+          px-2"
       >
         <div
           ref="indicatorEl"
-          class="absolute bottom-0 left-0 z-10 h-1 w-0 rounded-sm bg-brand shadow-[0_0_10px_rgba(121,217,255,0.4)]"
+          class="absolute
+            bottom-0
+            left-0
+            z-10
+            h-1
+            w-0
+            rounded-sm
+            bg-brand
+            shadow-[0_0_10px_rgba(121,217,255,0.4)]"
         ></div>
         <Button
           v-for="t in tabs"
@@ -149,14 +196,20 @@ onUnmounted(() => {
           :icon="t.icon"
           :active="store.tab === t.key"
           :disabled="
-            !store.detail && !['flow', 'agent-chat', 'agent-settings'].includes(t.key)
+            !store.detail && !['flow', 'agent-chat', 'agent-settings', 'appearance'].includes(t.key)
           "
           @click="switchTab(t.key)"
         >
-          <p class="hidden xl:block">{{ t.label }}</p>
+          <p class="hidden
+            xl:block">{{ t.label }}</p>
           <span
             v-if="t.key === 'validate' && store.report && store.report.errorCount > 0"
-            class="ml-1 rounded-full px-[5px] text-[0.6rem] text-white bg-red-500"
+            class="ml-1
+              rounded-full
+              px-[5px]
+              text-[0.6rem]
+              text-white
+              bg-red-500"
             >{{ store.report.errorCount }}</span
           >
         </Button>
@@ -164,16 +217,35 @@ onUnmounted(() => {
       <Icon
         icon="close"
         :size="40"
-        class="flex items-center justify-center rounded-full p-1.5 text-white cursor-pointer transition-all duration-300 ease-in-out hover:text-brand hover:bg-white/10 hover:rotate-90"
+        class="flex
+          items-center
+          justify-center
+          rounded-full
+          p-1.5
+          text-white
+          cursor-pointer
+          transition-all
+          duration-300
+          ease-in-out
+          hover:text-brand
+          hover:bg-white/10
+          hover:rotate-90"
         @click="emit('leave')"
       />
     </div>
 
     <!-- 面包屑 -->
-    <div class="flex items-center gap-2 px-8 pb-1 text-[0.8rem] text-white/55">
+    <div class="flex
+      items-center
+      gap-2
+      px-8
+      pb-1
+      text-[0.8rem]
+      text-white/55">
       <button
         v-if="store.detail"
-        class="text-brand hover:underline"
+        class="text-brand
+          hover:underline"
         @click="store.closeScript()"
       >
         ‹ 剧本列表
@@ -184,38 +256,69 @@ onUnmounted(() => {
         <span class="opacity-40">›</span>
         <button
           v-if="store.level === 'chapter'"
-          class="text-brand hover:underline"
+          class="text-brand
+            hover:underline"
           @click="store.backToFlow()"
         >
           {{ store.detail.package.scriptName }}
         </button>
         <b
           v-else
-          class="font-semibold text-white"
+          class="font-semibold
+            text-white"
           >{{ store.detail.package.scriptName }}</b
         >
 
         <template v-if="store.level === 'chapter' && store.chapter">
           <span class="opacity-40">›</span>
-          <b class="font-semibold text-white">{{ store.chapter.name || store.chapter.id }}</b>
-          <span class="text-[0.72rem] opacity-35">{{ store.chapter.id }}.yaml</span>
+          <b class="font-semibold
+            text-white">{{ store.chapter.name || store.chapter.id }}</b>
+          <span class="text-[0.72rem]
+            opacity-35">{{ store.chapter.id }}.yaml</span>
         </template>
       </template>
 
-      <span class="flex items-center gap-3 ml-auto">
+      <span class="flex
+        items-center
+        gap-3
+        ml-auto">
         <span
           v-if="store.detail"
-          class="inline-flex items-center gap-[5px] text-[0.75rem] text-white/50"
+          class="inline-flex
+            items-center
+            gap-[5px]
+            text-[0.75rem]
+            text-white/50"
         >
           <i
-            class="inline-block w-1.5 h-1.5 rounded-full"
+            class="inline-block
+              w-1.5
+              h-1.5
+              rounded-full"
             :class="store.dirty ? 'bg-amber-300' : 'bg-green-400'"
           ></i>
           {{ saveLabel }}
         </span>
         <template v-if="store.level === 'chapter'">
           <button
-            class="inline-flex items-center gap-1 border border-white/10 rounded-lg px-3 py-[0.3rem] text-[0.8rem] whitespace-nowrap text-white/70 bg-white/6 transition-all duration-200 hover:enabled:text-white hover:enabled:bg-white/[0.12] disabled:cursor-not-allowed disabled:opacity-40"
+            class="inline-flex
+              items-center
+              gap-1
+              border
+              border-white/10
+              rounded-lg
+              px-3
+              py-[0.3rem]
+              text-[0.8rem]
+              whitespace-nowrap
+              text-white/70
+              bg-white/6
+              transition-all
+              duration-200
+              hover:enabled:text-white
+              hover:enabled:bg-white/[0.12]
+              disabled:cursor-not-allowed
+              disabled:opacity-40"
             :disabled="!store.canUndo"
             title="撤销（Ctrl / ⌘ + Z）"
             @click="store.undo()"
@@ -223,7 +326,24 @@ onUnmounted(() => {
             ↩ 撤销
           </button>
           <button
-            class="inline-flex items-center gap-1 border border-white/10 rounded-lg px-3 py-[0.3rem] text-[0.8rem] whitespace-nowrap text-white/70 bg-white/6 transition-all duration-200 hover:enabled:text-white hover:enabled:bg-white/[0.12] disabled:cursor-not-allowed disabled:opacity-40"
+            class="inline-flex
+              items-center
+              gap-1
+              border
+              border-white/10
+              rounded-lg
+              px-3
+              py-[0.3rem]
+              text-[0.8rem]
+              whitespace-nowrap
+              text-white/70
+              bg-white/6
+              transition-all
+              duration-200
+              hover:enabled:text-white
+              hover:enabled:bg-white/[0.12]
+              disabled:cursor-not-allowed
+              disabled:opacity-40"
             :disabled="!store.canRedo"
             title="恢复（Ctrl / ⌘ + Shift + Z）"
             @click="store.redo()"
@@ -232,7 +352,24 @@ onUnmounted(() => {
           </button>
         </template>
         <button
-          class="inline-flex items-center gap-1 border border-white/10 rounded-lg px-3 py-[0.3rem] text-[0.8rem] whitespace-nowrap text-white/70 bg-white/6 transition-all duration-200 hover:enabled:text-white hover:enabled:bg-white/[0.12] disabled:cursor-not-allowed disabled:opacity-40"
+          class="inline-flex
+            items-center
+            gap-1
+            border
+            border-white/10
+            rounded-lg
+            px-3
+            py-[0.3rem]
+            text-[0.8rem]
+            whitespace-nowrap
+            text-white/70
+            bg-white/6
+            transition-all
+            duration-200
+            hover:enabled:text-white
+            hover:enabled:bg-white/[0.12]
+            disabled:cursor-not-allowed
+            disabled:opacity-40"
           title="查看全部快捷键（? 键）"
           @click="emit('toggle-shortcut-help')"
         >
@@ -240,7 +377,21 @@ onUnmounted(() => {
         </button>
         <template v-if="store.detail">
           <button
-            class="inline-flex items-center gap-1 rounded-lg px-3 py-[0.3rem] text-[0.8rem] whitespace-nowrap transition-all duration-200 border border-brand/45 text-brand bg-brand/14 hover:bg-brand/24"
+            class="inline-flex
+              items-center
+              gap-1
+              rounded-lg
+              px-3
+              py-[0.3rem]
+              text-[0.8rem]
+              whitespace-nowrap
+              transition-all
+              duration-200
+              border
+              border-brand/45
+              text-brand
+              bg-brand/14
+              hover:bg-brand/24"
             title="Ctrl / ⌘ + Enter"
             @click="emit('playtest')"
           >
@@ -254,9 +405,33 @@ onUnmounted(() => {
          一个卡住不动的画面困惑一阵 —— 那正是这条横幅要省掉的时间。 -->
     <div
       v-if="store.detail && store.readiness && !store.readiness.ok"
-      class="flex items-center gap-2.5 mx-5 mb-2 border border-amber-300/30 rounded-lg px-3 py-[7px] text-[0.76rem] leading-[1.7] text-amber-100/90 bg-amber-300/10"
+      class="flex
+        items-center
+        gap-2.5
+        mx-5
+        mb-2
+        border
+        border-amber-300/30
+        rounded-lg
+        px-3
+        py-[7px]
+        text-[0.76rem]
+        leading-[1.7]
+        text-amber-100/90
+        bg-amber-300/10"
     >
-      <span class="shrink-0 border border-amber-300/40 rounded-full px-2 py-px text-[0.66rem] font-semibold text-amber-300">试玩会卡住</span>
+      <span
+        class="shrink-0
+          border
+          border-amber-300/40
+          rounded-full
+          px-2
+          py-px
+          text-[0.66rem]
+          font-semibold
+          text-amber-300"
+        >试玩会卡住</span
+      >
       <span>{{ store.readiness.reason }}</span>
     </div>
   </div>

--- a/src/components/script-editor/ImageCropModal.vue
+++ b/src/components/script-editor/ImageCropModal.vue
@@ -1,0 +1,178 @@
+<template>
+  <Teleport to="body">
+    <div
+      class="modal-mask
+        fixed
+        inset-0
+        z-[9999]
+        flex
+        items-center
+        justify-center
+        p-4
+        backdrop-blur-md
+        bg-black/55"
+      @click.self="emit('cancel')"
+    >
+      <div
+        class="flex
+          w-[min(760px,92vw)]
+          flex-col
+          overflow-hidden
+          rounded-xl
+          border
+          border-white/12.5
+          bg-[rgba(12,20,30,0.94)]
+          shadow-[0_8px_32px_rgba(0,0,0,0.45)]"
+      >
+        <div class="flex
+          items-center
+          justify-between
+          gap-4
+          border-b
+          border-white/10
+          px-5
+          py-3">
+          <h4 class="font-semibold
+            text-white">裁剪背景图</h4>
+          <span class="text-[0.7rem]
+            text-white/45"
+            >选区比例与编辑器窗口一致，框内即最终显示效果</span
+          >
+        </div>
+
+        <div class="relative
+          max-h-[52vh]
+          min-h-[300px]
+          overflow-hidden
+          bg-black/70">
+          <img
+            ref="imgEl"
+            :src="imgSrc"
+            class="max-w-full"
+            alt="背景裁剪预览"
+          />
+        </div>
+
+        <div class="flex
+          items-center
+          justify-end
+          gap-2
+          px-5
+          py-3">
+          <button
+            class="rounded-lg
+              border
+              border-white/10
+              bg-white/6
+              px-4
+              py-1.5
+              text-[0.8rem]
+              text-white/70
+              transition-colors
+              hover:bg-white/[0.12]
+              hover:text-white"
+            @click="emit('cancel')"
+          >
+            取消
+          </button>
+          <button
+            class="rounded-lg
+              border
+              border-brand/45
+              bg-brand/14
+              px-4
+              py-1.5
+              text-[0.8rem]
+              text-brand
+              transition-colors
+              hover:bg-brand/24"
+            @click="confirm"
+          >
+            确认使用
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import Cropper from 'cropperjs'
+import 'cropperjs/dist/cropper.css'
+import { convertFileSrc } from '@tauri-apps/api/core'
+
+const props = defineProps<{ srcPath: string }>()
+const emit = defineEmits<{
+  confirm: [dataUrl: string, name: string]
+  cancel: []
+}>()
+
+const imgEl = ref<HTMLImageElement | null>(null)
+let cropper: Cropper | null = null
+
+/** 原图以 asset URL 加载（与编辑器背景同一套资源访问方式） */
+const imgSrc = convertFileSrc(props.srcPath)
+
+// 选区比例取当前编辑器窗口宽高比：背景是 cover 铺满窗口，只有比例一致时
+// 裁剪框内看到的内容才等于最终显示，不会再有"看不见的二次裁切"
+const windowRatio = window.innerWidth / window.innerHeight
+
+const initCropper = () => {
+  if (!imgEl.value || cropper) return
+  cropper = new Cropper(imgEl.value, {
+    viewMode: 1,
+    dragMode: 'move',
+    aspectRatio: windowRatio,
+    // 默认选区铺满整图 = 不裁剪直接使用，用户拖动缩放后才改变范围
+    autoCropArea: 1,
+    guides: true,
+    center: true,
+    background: false,
+  })
+}
+
+onMounted(() => {
+  const img = imgEl.value
+  if (!img) return
+  // 图片可能已在缓存中（load 不再触发），complete 后直接初始化
+  if (img.complete) initCropper()
+  else img.addEventListener('load', initCropper)
+})
+
+onBeforeUnmount(() => {
+  cropper?.destroy()
+  cropper = null
+})
+
+const confirm = () => {
+  if (!cropper) return
+  // 输出上限 1920 宽：背景只需铺满窗口，太大浪费内存；webp 保持体积小
+  const canvas = cropper.getCroppedCanvas({ maxWidth: 1920, maxHeight: 1080 })
+  const dataUrl = canvas.toDataURL('image/webp', 0.92)
+  // 输出文件名沿用原图名（去扩展名 + _crop），便于在数据目录里识别
+  const raw = props.srcPath.split(/[\\/]/).pop() || 'background'
+  const base = raw.replace(/\.[^.]+$/, '')
+  emit('confirm', dataUrl, `${base}_crop.webp`)
+}
+</script>
+
+<style scoped>
+/* cropperjs 默认白色主题，覆写为编辑器暗色风格 */
+:deep(.cropper-modal) {
+  opacity: 0.65;
+  background-color: #000;
+}
+:deep(.cropper-view-box) {
+  outline-color: rgba(121, 217, 255, 0.65);
+}
+:deep(.cropper-line) {
+  background-color: rgba(121, 217, 255, 0.75);
+}
+:deep(.cropper-point) {
+  background-color: #79d9ff;
+}
+:deep(.cropper-container) {
+  max-width: 100%;
+}
+</style>

--- a/src/components/views/ScriptEditor.vue
+++ b/src/components/views/ScriptEditor.vue
@@ -3,14 +3,30 @@
     背景层必须自己造。窗口是 transparent: true（tauri.conf.json），设置面板之所以
     能透出画面是因为它盖在 MainChat 上；/script-editor 是独立路由，底下什么都没有，
     不给背景就直接透出桌面。Credits.vue 同理显式加了 bg-[#0a0a0c]。
-    这里用渐变而不是背景图，避免依赖 Git LFS 资源。
+
+    结构：bg-layer（渐变兜底）→ bg-image（背景图，模糊+压暗）→ bg-dim-mask（可调遮罩）。
+    默认背景图是主菜单同款的 background2.png —— 它是 Git LFS 资产，无 LFS 的
+    开发环境读出来是 131 字节指针，加载失败时浏览器自动跳过该图层露出渐变，
+    因此本地开发看到兜底渐变、CI 构建产物看到真实图，两种环境都不会破图。
   -->
   <div class="editor-root
     relative
     w-full
     h-full
     overflow-hidden">
-    <div class="bg-layer"></div>
+    <div
+      class="bg-layer"
+      :style="{
+        '--bg-blur': `${store.editorBg.blur}px`,
+        '--bg-dim': String(store.editorBg.dim),
+      }"
+    >
+      <div
+        class="bg-image"
+        :style="{ backgroundImage: `url(${bgImageSrc})` }"
+      ></div>
+      <div class="bg-dim-mask"></div>
+    </div>
 
     <EditorHeader
       @playtest="playtest"
@@ -101,6 +117,11 @@
         <AgentSettingsPanel />
       </MenuPage>
 
+      <!-- ============ 外观（背景/模糊/压暗） ============ -->
+      <MenuPage v-else-if="store.tab === 'appearance'">
+        <AppearanceTab />
+      </MenuPage>
+
       <!-- ============ 校验 ============ -->
       <ValidateTab v-else />
     </div>
@@ -120,7 +141,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { onBeforeRouteLeave, useRouter } from 'vue-router'
 import { MenuPage } from '@/components/ui'
 import { useScriptEditorStore } from '@/stores/modules/script-editor'
@@ -135,278 +156,23 @@ import EditorModals from '@/components/script-editor/EditorModals.vue'
 import ShortcutHelpPanel from '@/components/script-editor/ShortcutHelpPanel.vue'
 import AgentChatPanel from '@/components/script-editor/agent/AgentChatPanel.vue'
 import AgentSettingsPanel from '@/components/script-editor/agent/AgentSettingsPanel.vue'
+import AppearanceTab from '@/components/script-editor/AppearanceTab.vue'
 import PreviewStage from '@/components/script-editor/PreviewStage.vue'
 import { eventQueue } from '@/core/events/event-queue'
-import { AssetKind, AssetScope, AssetFile, Diagnostic } from '@/api/services/script-editor'
 import { convertFileSrc } from '@tauri-apps/api/core'
-import { open as openDialog } from '@tauri-apps/plugin-dialog'
+// 默认背景与主菜单同款。Git LFS 资产：无 LFS 环境读出来是 131 字节指针，
+// 背景图加载失败会露出渐变兜底层（见模板注释），构建产物则是真实图。
+import defaultBg from '@/assets/images/background2.png'
 
 const router = useRouter()
 const store = useScriptEditorStore()
 
-type TabKey =
-  | 'flow'
-  | 'config'
-  | 'characters'
-  | 'assets'
-  | 'validate'
-  | 'agent-chat'
-  | 'agent-settings'
-
-const tabs: {
-  key: TabKey
-  label: string
-  icon: 'adventure' | 'setting' | 'character' | 'background' | 'achievement' | 'bot' | 'sliders'
-}[] = [
-  { key: 'flow', label: '章节流程', icon: 'adventure' },
-  { key: 'config', label: '剧本设置', icon: 'setting' },
-  { key: 'characters', label: '角色', icon: 'character' },
-  { key: 'assets', label: '素材', icon: 'background' },
-  { key: 'validate', label: '校验', icon: 'achievement' },
-  { key: 'agent-chat', label: '剧本导师', icon: 'bot' },
-  { key: 'agent-settings', label: '导师设置', icon: 'sliders' },
-]
-
-const assetKinds: { key: AssetKind; label: string }[] = [
-  { key: 'background', label: '背景图' },
-  { key: 'pic', label: '插图' },
-  { key: 'music', label: '背景音乐' },
-  { key: 'sound', label: '音效' },
-  { key: 'ambient', label: '环境音' },
-]
-
-// ---- 素材页 ----
-
-const isImageKind = (k: AssetKind) => k === 'background' || k === 'pic'
-
-/** 绝对路径 → webview 能加载的 asset URL，与 GameBackground / GameRoleAvatar 同一套 */
-const assetUrl = (path: string) => convertFileSrc(path)
-
-const filesOf = (scope: AssetScope, kind: AssetKind): AssetFile[] =>
-  store.assetFiles[scope]?.[kind] ?? []
-
-// 音效没有全局目录（issue #6），只展示「本剧本」一列；其余素材仍是「本剧本 + 全局」
-const scopesFor = (kind: AssetKind): AssetScope[] =>
-  kind === 'sound' ? ['script'] : ['script', 'global']
-
-const humanSize = (n: number) => {
-  if (n < 1024) return `${n} B`
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`
-  return `${(n / 1024 / 1024).toFixed(1)} MB`
-}
-
-// ---- 素材音频播放速度 ----
-const audioEls: Record<string, HTMLAudioElement | null> = {}
-const audioRates = reactive<Record<string, number>>({})
-const speedMenu = ref<string | null>(null)
-const setAudioRef = (path: string) => (el: unknown) => {
-  audioEls[path] = el as HTMLAudioElement | null
-  if (!(path in audioRates)) audioRates[path] = 1
-}
-const onDocClick = () => {
-  speedMenu.value = null
-}
-const setRate = (path: string, rate: number) => {
-  const a = audioEls[path]
-  if (a) {
-    a.playbackRate = rate
-    audioRates[path] = rate
-  }
-}
-
-// ---- nav 指示条（与 SettingsNav 同一套做法）----
-const navEl = ref<HTMLElement | null>(null)
-const indicatorEl = ref<HTMLElement | null>(null)
-const tabRefs: Record<string, HTMLElement | null> = {}
-
-const setTabRef = (key: string, el: unknown) => {
-  tabRefs[key] = (el as { $el?: HTMLElement } | null)?.$el ?? null
-}
-
-/**
- * 指示条定位。
- *
- * 之前它经常停在空白处，原因是位置只在「切标签」和「换剧本」时算一次，而
- * 按钮宽度会在别的时刻变：校验跑完后「校验」上多一个错误数角标、窗口跨过
- * xl 断点时文字标签整体显隐、字体加载完成后每个字的宽度都变。nav 是
- * `justify-content: center`，任何一个按钮变宽都会把**所有**按钮推走，于是
- * 上一次算出来的 left 就落到了两个按钮中间的空当里。
- *
- * 所以这里不再指望「在正确的时刻算一次」，而是让尺寸变化自己来触发重算：
- * ResizeObserver 同时盯着 nav 和每一个按钮。另外用 getBoundingClientRect
- * 相对 nav 求差而不是 offsetLeft —— 后者依赖 offsetParent 恰好是 nav，
- * 一旦有人给中间层加了 position 就会静默偏移。
- */
-const moveIndicator = async (animate = true) => {
-  await nextTick()
-  const bar = indicatorEl.value
-  const nav = navEl.value
-  if (!bar || !nav) return
-  const target = tabRefs[store.tab]
-  bar.style.transition = animate
-    ? 'left 0.3s cubic-bezier(0.18, 0.89, 0.32, 1), width 0.3s cubic-bezier(0.18, 0.89, 0.32, 1)'
-    : 'none'
-  if (!target) {
-    // 目标不在了就收起来。早先这里是直接 return，于是指示条保持在上一次的
-    // 位置不动 —— 那正是「出现在空白处」最刺眼的一种。
-    bar.style.width = '0px'
-    return
-  }
-  const navBox = nav.getBoundingClientRect()
-  const box = target.getBoundingClientRect()
-  bar.style.left = `${box.left - navBox.left + nav.scrollLeft}px`
-  bar.style.width = `${box.width}px`
-}
-
-watch(
-  () => store.tab,
-  () => moveIndicator(),
+/** 编辑器背景图源：自定义时用 asset URL，默认时用内置背景图。
+ *  追加 `?v=` 版本号做缓存击穿：同扩展名覆盖上传时 asset URL 不变，
+ *  asset protocol 无缓存头，WebView 启发式缓存会显示旧图，版本号强制重新请求。 */
+const bgImageSrc = computed(() =>
+  store.editorBg.path ? `${convertFileSrc(store.editorBg.path)}?v=${store.bgVersion}` : defaultBg,
 )
-watch(
-  () => store.detail?.package.key,
-  () => moveIndicator(),
-)
-
-let navObserver: ResizeObserver | null = null
-
-const observeNav = () => {
-  if (typeof ResizeObserver === 'undefined' || !navEl.value) return
-  // 不加动画：这类重算是「布局变了跟着修正」，滑一下反而像在乱动
-  navObserver = new ResizeObserver(() => void moveIndicator(false))
-  navObserver.observe(navEl.value)
-  for (const el of Object.values(tabRefs)) if (el) navObserver.observe(el)
-}
-
-const switchTab = (key: TabKey) => {
-  if (!store.detail && key !== 'flow' && key !== 'agent-chat' && key !== 'agent-settings') return
-  store.tab = key
-  if (key === 'validate') void store.runValidation()
-  if (key === 'assets') {
-    void store.refreshGlobalAssets()
-    void store.refreshAssetFiles()
-  }
-  if (key === 'characters') void store.refreshGlobalCharacters()
-  if (key === 'flow') {
-    // 有剧本：回到流程图时强制走一遍「落盘 → 重新校验」，图上画的才是磁盘里的真状态
-    if (store.detail && store.level === 'flow') void store.backToFlow()
-    // 无剧本：AI 助手可能刚写好新剧本，回来时刷新列表让它出现
-    else if (!store.detail) void store.refreshScripts()
-  }
-}
-
-// ---- 面包屑 ----
-/** 没打开剧本时，顶部面包屑按当前 tab 显示所在区块（AI 助手无剧本也能进） */
-const noDetailTitle = computed(() => {
-  switch (store.tab) {
-    case 'agent-chat':
-      return '剧本导师'
-    case 'agent-settings':
-      return '导师设置'
-    default:
-      return '剧本列表'
-  }
-})
-
-const saveLabel = computed(() => {
-  if (store.saving) return '正在保存…'
-  if (store.dirty) return '有未保存改动'
-  if (store.lastSavedAt) {
-    const d = new Date(store.lastSavedAt)
-    return `已自动保存 · ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(
-      2,
-      '0',
-    )}`
-  }
-  return '已保存'
-})
-
-// ---- 校验页 ----
-const diagnosticsOf = (chapterId: string) =>
-  (store.report?.diagnostics ?? []).filter((d) => d.chapter === chapterId)
-
-const chapterHas = (chapterId: string) => diagnosticsOf(chapterId).length > 0
-
-const jumpTo = async (d: Diagnostic) => {
-  if (!d.chapter) {
-    store.tab = 'config'
-    return
-  }
-  store.tab = 'flow'
-  if (store.chapter?.id !== d.chapter) {
-    // openChapter 可能失败（读盘出错），失败时不要把 selectedEvent 设成别的章节的下标
-    if (!(await store.openChapter(d.chapter))) return
-  } else {
-    store.level = 'chapter'
-  }
-  if (d.eventIndex !== undefined) store.selectedEvent = d.eventIndex
-}
-
-// ---- 剧本设置 ----
-const configDraft = reactive<Record<string, unknown>>({})
-
-watch(
-  () => store.detail?.storyConfig,
-  (cfg) => {
-    for (const k of Object.keys(configDraft)) delete configDraft[k]
-    Object.assign(configDraft, JSON.parse(JSON.stringify(cfg ?? {})))
-  },
-  { immediate: true, deep: false },
-)
-
-const setConfig = (key: string, value: unknown) => {
-  configDraft[key] = value
-}
-
-const adventureObj = computed<Record<string, unknown>>(() => {
-  const a = configDraft.adventure
-  return a && typeof a === 'object' ? (a as Record<string, unknown>) : {}
-})
-
-const isAdventure = computed(() => adventureObj.value.is_adventure === true)
-
-const adventureField = (k: string) => {
-  const v = adventureObj.value[k]
-  return v === undefined || v === null ? '' : String(v)
-}
-
-const setAdventure = (k: string, v: unknown) => {
-  const next = { ...adventureObj.value, [k]: v }
-  configDraft.adventure = next
-}
-
-/** 抽出来是因为内联写法要带 `(e.target as HTMLInputElement)`，模板里读起来太吵 */
-const onAdventureText = (k: string, e: Event) =>
-  setAdventure(k, (e.target as HTMLInputElement).value)
-
-const onAdventureNumber = (k: string, e: Event) =>
-  setAdventure(k, Number((e.target as HTMLInputElement).value) || 0)
-
-const toggleAdventure = (on: boolean) => {
-  if (on) {
-    setAdventure('is_adventure', true)
-  } else {
-    // 关掉只改标志，其余字段原样留着 —— 作者可能只是临时关掉
-    setAdventure('is_adventure', false)
-  }
-}
-
-const saveConfig = () => {
-  void store.saveStoryConfig(JSON.parse(JSON.stringify(configDraft)))
-}
-
-// ---- 素材导入 ----
-const IMAGE_EXT = ['png', 'jpg', 'jpeg', 'webp', 'bmp', 'gif']
-const AUDIO_EXT = ['mp3', 'wav', 'ogg', 'flac', 'm4a']
-
-const importAsset = async (kind: AssetKind, scope: AssetScope) => {
-  const isImage = kind === 'background' || kind === 'pic'
-  const picked = await openDialog({
-    multiple: false,
-    filters: [{ name: isImage ? '图片' : '音频', extensions: isImage ? IMAGE_EXT : AUDIO_EXT }],
-  })
-  if (typeof picked !== 'string') return
-  await store.uploadAsset(kind, scope, picked)
-}
 
 // ---- 弹窗 ----
 const modal = ref<'script' | 'chapter' | 'character' | 'importChar' | null>(null)
@@ -562,10 +328,30 @@ onUnmounted(async () => {
   position: absolute;
   inset: 0;
   z-index: 0;
+  overflow: hidden;
+  /* 渐变兜底：背景图缺失（无 LFS 的本地环境）或加载失败时露出的底色，
+     与改造前的实现一致 */
   background:
     radial-gradient(900px 500px at 78% 12%, rgba(121, 217, 255, 0.1), transparent 62%),
     radial-gradient(700px 600px at 15% 88%, rgba(90, 140, 190, 0.12), transparent 64%),
     linear-gradient(168deg, #101a26 0%, #16202c 45%, #1b2430 100%);
+}
+.bg-image {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  /* 默认背景图亮度过高（主菜单那张，亮度均值 ~211/255），直接铺白字没法读，
+     固定压暗再叠加可调模糊；模糊半径由滑块写入 --bg-blur */
+  filter: brightness(0.35) blur(var(--bg-blur, 12px));
+  /* 放大一点，避免模糊后四周露出透明边缘 */
+  transform: scale(1.02);
+}
+.bg-dim-mask {
+  position: absolute;
+  inset: 0;
+  /* 压暗遮罩不随图模糊；不透明度由滑块写入 --bg-dim */
+  background: rgba(0, 0, 0, var(--bg-dim, 0.3));
 }
 .editor-root > *:not(.bg-layer) {
   position: relative;

--- a/src/stores/modules/script-editor/actions.ts
+++ b/src/stores/modules/script-editor/actions.ts
@@ -20,7 +20,13 @@ import { useUIStore } from '@/stores/modules/ui/ui'
 import { useDialogStore } from '@/stores/modules/ui/dialog'
 import { firstVisibleIndex } from '@/composables/useEventFolding'
 import { eventQueue } from '@/core/events/event-queue'
-import { AUTOSAVE_DELAY, UNDO_LIMIT, VALIDATE_DELAY, useEditorState } from './state'
+import {
+  AUTOSAVE_DELAY,
+  DEFAULT_EDITOR_BG,
+  UNDO_LIMIT,
+  VALIDATE_DELAY,
+  useEditorState,
+} from './state'
 import type { UndoFrame } from './state'
 import { useEditorGetters } from './getters'
 import { particleEffectOptions, canonicalEffectKey } from '@/components/game/standard/particles'
@@ -32,7 +38,9 @@ type Getters = ReturnType<typeof useEditorGetters>
  * 把 schema 里由后端常量驱动的下拉，改由前端注册表驱动。
  * 目前只有「背景特效」：用前端粒子注册表覆盖该字段 options，新增粒子只改前端。
  */
-function applyFrontendOverrides(schema: { events: { typeKey: string; fields: { key: string; options?: unknown[] }[] }[] } | null) {
+function applyFrontendOverrides(
+  schema: { events: { typeKey: string; fields: { key: string; options?: unknown[] }[] }[] } | null,
+) {
   if (!schema) return
   const effectField = schema.events
     .find((e) => e.typeKey === 'background_effect')
@@ -672,14 +680,61 @@ export const useEditorActions = (s: StateRefs, g: Getters) => {
       }
       // 素材页开着的时候要跟着变，否则刚导进来的图不出现在列表里
       if (s.assetFiles.value.script || s.assetFiles.value.global) void refreshAssetFiles()
-      notifyOk(
-        scope === 'global' ? '已导入为全局素材' : '已导入为剧本素材',
-        saved,
-      )
+      notifyOk(scope === 'global' ? '已导入为全局素材' : '已导入为剧本素材', saved)
       return saved
     } catch (e) {
       notifyError('导入素材失败', e)
       return null
+    }
+  }
+
+  /**
+   * 上传编辑器自定义背景。成功后将 `editorBg.path` 指向复制后的文件
+   * （Rust 落盘在数据目录），返回该路径；`path` 为空串表示用默认背景。
+   */
+  async function uploadEditorBg(srcPath: string): Promise<string | null> {
+    try {
+      const saved = await api.uploadEditorBg(srcPath)
+      setEditorBgPath(saved)
+      notifyOk('背景图已设置', '可在「外观」页调整模糊与压暗')
+      return saved
+    } catch (e) {
+      notifyError('设置背景图失败', e)
+      return null
+    }
+  }
+
+  /** 设置编辑器背景路径并自增版本号：asset URL 相同而内容变化时，`?v=` 参数强制绕过缓存 */
+  function setEditorBgPath(path: string) {
+    s.editorBg.value = { ...s.editorBg.value, path }
+    s.bgVersion.value += 1
+  }
+
+  /** 上传裁剪后的编辑器背景（cropperjs 输出 base64），成功后更新 path 并自增版本号 */
+  async function uploadEditorBgData(dataUrl: string, name: string): Promise<string | null> {
+    try {
+      const saved = await api.uploadEditorBgData(dataUrl, name)
+      setEditorBgPath(saved)
+      notifyOk('背景图已设置', '可在「外观」页调整模糊与压暗')
+      return saved
+    } catch (e) {
+      notifyError('设置背景图失败', e)
+      return null
+    }
+  }
+
+  /** 恢复默认背景（path 置空 + 版本自增，同上规避缓存） */
+  function resetEditorBg() {
+    s.editorBg.value = { ...DEFAULT_EDITOR_BG }
+    s.bgVersion.value += 1
+  }
+
+  /** 刷新全局背景库列表（game_data/backgrounds），供外观页「从已有背景选择」 */
+  async function refreshGlobalBgFiles() {
+    try {
+      s.globalBgFiles.value = await api.listGlobalBackgrounds()
+    } catch (e) {
+      notifyError('加载全局背景列表失败', e)
     }
   }
 
@@ -714,9 +769,7 @@ export const useEditorActions = (s: StateRefs, g: Getters) => {
     if (!ok) return
     try {
       await api.deleteCharacter(key, folder)
-      s.detail.value.characters = s.detail.value.characters.filter(
-        (c) => c.folder !== folder,
-      )
+      s.detail.value.characters = s.detail.value.characters.filter((c) => c.folder !== folder)
       void refreshGlobalCharacters()
       await runValidation()
       notifyOk('角色已删除', `${displayName} 已被永久删除`)
@@ -745,9 +798,7 @@ export const useEditorActions = (s: StateRefs, g: Getters) => {
     if (!key) return
     const dialog = useDialogStore()
     const where =
-      scope === 'global'
-        ? '（全局素材）删掉之后所有引用它的剧本都会找不到文件。'
-        : '（本剧本素材）'
+      scope === 'global' ? '（全局素材）删掉之后所有引用它的剧本都会找不到文件。' : '（本剧本素材）'
     const ok = await dialog.confirm(
       `确定删除「${name}」吗？\n\n${where}\n如果还有事件在引用它，删完校验会报「素材找不到」。`,
       '删除素材',
@@ -756,11 +807,7 @@ export const useEditorActions = (s: StateRefs, g: Getters) => {
     try {
       await api.deleteAsset(key, kind, scope, name)
       // 三份列表都要刷：素材页的详情、属性面板下拉用的剧本内清单与全局清单
-      await Promise.all([
-        refreshAssetFiles(),
-        refreshGlobalAssets(),
-        reloadDetailAssets(),
-      ])
+      await Promise.all([refreshAssetFiles(), refreshGlobalAssets(), reloadDetailAssets()])
       await runValidation()
       notifyOk('素材已删除', `${name} 已被永久删除`)
     } catch (e) {
@@ -896,6 +943,11 @@ export const useEditorActions = (s: StateRefs, g: Getters) => {
     startPreview,
     stopPreview,
     uploadAsset,
+    uploadEditorBg,
+    uploadEditorBgData,
+    setEditorBgPath,
+    resetEditorBg,
+    refreshGlobalBgFiles,
     createCharacter,
     deleteCharacter,
     refreshAssetFiles,

--- a/src/stores/modules/script-editor/index.ts
+++ b/src/stores/modules/script-editor/index.ts
@@ -46,6 +46,8 @@ export const useScriptEditorStore = defineStore(
         'readiness',
         'globalCharacters',
         'assetFiles',
+        'bgVersion',
+        'globalBgFiles',
       ],
     },
   },

--- a/src/stores/modules/script-editor/state.ts
+++ b/src/stores/modules/script-editor/state.ts
@@ -7,6 +7,7 @@
  */
 import { ref } from 'vue'
 import type {
+  AssetFile,
   AssetIndex,
   ChapterContent,
   GlobalCharacter,
@@ -18,6 +19,18 @@ import type {
   AssetFileIndex,
 } from '@/api/services/script-editor'
 import type { ScriptEventData } from '@/api/services/script-editor'
+
+/** 编辑器外观偏好（背景图 + 模糊/压暗），持久化于 script-editor-ui */
+export interface EditorBg {
+  /** 自定义背景绝对路径；'' 表示用内置默认背景（background2.png，加载失败回退渐变） */
+  path: string
+  /** 背景模糊半径（px） */
+  blur: number
+  /** 压暗遮罩不透明度（0~1） */
+  dim: number
+}
+
+export const DEFAULT_EDITOR_BG: EditorBg = { path: '', blur: 12, dim: 0.3 }
 
 /** 撤销栈里的一帧：某个章节某一时刻的完整事件列表 */
 export interface UndoFrame {
@@ -61,7 +74,13 @@ interface State {
     | 'validate'
     | 'agent-chat'
     | 'agent-settings'
+    | 'appearance'
   foldCompounds: boolean
+  editorBg: EditorBg
+  /** 背景图版本号：path 变更时自增，用于 asset URL 缓存击穿（不持久化） */
+  bgVersion: number
+  /** 全局背景库文件列表（game_data/backgrounds，带绝对路径），供外观页选择 */
+  globalBgFiles: AssetFile[]
 }
 
 /** 撤销栈深度上限 */
@@ -112,6 +131,9 @@ export const useEditorState = () => {
   const level = ref<State['level']>('flow')
   const tab = ref<State['tab']>('flow')
   const foldCompounds = ref(true)
+  const editorBg = ref<EditorBg>({ ...DEFAULT_EDITOR_BG })
+  const bgVersion = ref(0)
+  const globalBgFiles = ref<AssetFile[]>([])
 
   return {
     schema,
@@ -136,5 +158,8 @@ export const useEditorState = () => {
     level,
     tab,
     foldCompounds,
+    editorBg,
+    bgVersion,
+    globalBgFiles,
   }
 }


### PR DESCRIPTION
## 变更说明
本次为剧本编辑器新增「外观」设置页，将原先的渐变背景升级为图片背景渲染，并支持自定义背景图（上传 / 裁剪 / 从全局背景库选择）与模糊、压暗调节：

## 新增功能

- 背景层图片渲染：默认使用主菜单同款 background2.png（Git LFS 资产），无 LFS 环境加载失败时自动回退原有渐变兜底；自定义图片经 convertFileSrc 加载
- 外观页（新 Tab）：同风格MenuPage + MenuItem，无剧本也可访问
- 模糊滑块（024px）、压暗遮罩滑块（090%），改动即时生效并自动持久化

## 当前运作逻辑
- 自定义背景上传：对话框选图 → Rust 复制到数据目录，保留原文件名（sanitize_file_name 清洗）；重复上传先清空专用目录，磁盘始终只保留当前一张
- 图片裁剪：选图后进入裁剪弹窗（cropperjs v1），选区锁定当前窗口宽高比（cover 铺满不二次裁切，所见即所得），默认全图选区=不裁剪；输出 1920 宽 webp（base64）经新命令 editor_upload_editor_bg_data 落盘
- 从已有背景选择：复用 editor_list_asset_files 的 global 落点列出 game_data/backgrounds，点击即设为背景（当前项高亮）

## 代码清理

清理 ScriptEditor.vue 拆分子组件后遗留的死代码（素材/导航/校验/配置块，约 200 行）及未使用 import，文件从 568 行减至 360 行

## 检查清单
- [x] 实机测试

截图/示例
<img width="1478" height="796" alt="image" src="https://github.com/user-attachments/assets/ae2429ab-838b-4e51-b34b-d795652ed9fa" />
<img width="1489" height="769" alt="image" src="https://github.com/user-attachments/assets/b9288b2a-385e-45f0-8350-92f967908c6f" />
