### PR TITLE
fix: 删除审批回调未加入命令白名单，弹窗确认后仍删除失败

### DIFF
--- a/src-tauri/permissions/app-commands.toml
+++ b/src-tauri/permissions/app-commands.toml
@@ -85,6 +85,7 @@ commands.allow = [
   "save_tool_settings",
   "test_web_search",
   "resolve_command_approval",
+  "resolve_file_delete_approval",
   "get_achievement_list",
   "unlock_achievement",
   "list_character_adventures",

--- a/src-tauri/src/ai_service/tools/skill_files.rs
+++ b/src-tauri/src/ai_service/tools/skill_files.rs
@@ -102,11 +102,15 @@ async fn request_user_approval(
             "无法发送{action}审批请求: {error}"
         )));
     }
+    tracing::info!("[approval] 已向主窗口发送审批事件: event={event} request_id={request_id}");
 
     let decision = tokio::time::timeout(Duration::from_secs(120), rx).await;
     approvals.lock().await.remove(&request_id);
     match decision {
-        Ok(Ok(true)) => Ok(()),
+        Ok(Ok(true)) => {
+            tracing::info!("[approval] 用户已批准: request_id={request_id}");
+            Ok(())
+        }
         Ok(Ok(false)) => Err(ToolError::Execution(format!("{action}已被用户拒绝"))),
         Ok(Err(_)) => Err(ToolError::Execution(format!(
             "审批通道已关闭，{action}未执行"

--- a/src-tauri/src/api/tool_settings.rs
+++ b/src-tauri/src/api/tool_settings.rs
@@ -59,6 +59,7 @@ pub async fn resolve_command_approval(
     request_id: String,
     approved: bool,
 ) -> Result<(), String> {
+    tracing::info!("[approval] resolve_command_approval 收到回传: request_id={request_id} approved={approved}");
     let state = app.state::<AppState>();
     let request = state
         .chat_command_approvals
@@ -70,7 +71,10 @@ pub async fn resolve_command_approval(
             let _ = request.tx.send(approved);
             Ok(())
         }
-        None => Err("审批请求不存在或已过期".into()),
+        None => {
+            tracing::warn!("[approval] resolve_command_approval 未找到请求: request_id={request_id}");
+            Err("审批请求不存在或已过期".into())
+        }
     }
 }
 
@@ -81,6 +85,7 @@ pub async fn resolve_file_delete_approval(
     request_id: String,
     approved: bool,
 ) -> Result<(), String> {
+    tracing::info!("[approval] resolve_file_delete_approval 收到回传: request_id={request_id} approved={approved}");
     let state = app.state::<AppState>();
     let request = state
         .chat_file_delete_approvals
@@ -92,6 +97,9 @@ pub async fn resolve_file_delete_approval(
             let _ = request.tx.send(approved);
             Ok(())
         }
-        None => Err("删除审批请求不存在或已过期".into()),
+        None => {
+            tracing::warn!("[approval] resolve_file_delete_approval 未找到请求: request_id={request_id}");
+            Err("删除审批请求不存在或已过期".into())
+        }
     }
 }


### PR DESCRIPTION
## 问题

主聊天中让 AI 删除文件/文件夹时（`execute_command` 识别到删除命令，或 `delete_file` 工具），前端弹出审批框，用户点击「允许」后操作仍然失败，日志显示 `删除命令审批超时（120 秒），已自动拒绝`。

## 根因

`src-tauri/permissions/app-commands.toml` 的白名单里有 `resolve_command_approval`，但漏了 `resolve_file_delete_approval`。前端弹窗确认后 `invoke('resolve_file_delete_approval')` 被 Tauri ACL 直接拒绝，前端 catch 后只 console.warn 静默吞错，后端等待 120 秒超时自动拒绝。

## 修复

- 把 `resolve_file_delete_approval` 加入 `app-commands` 白名单（一行）。
- 给审批链路补关键节点日志（发送审批事件 / 收到回传 / 用户批准 / 请求未找到），这类静默失败以后能直接在日志里看到断点。

## 验证

本地完整构建后实测：让 AI 删除 `bin/新建文件夹`，弹窗点「允许」后日志完整走通 `发送审批事件 → 前端收到 → 弹窗关闭 approved=true → 回传成功 → 用户已批准`，文件夹被实际删除。