### PR TITLE
fix: 修复多轮工具调用间模型复读台词的问题（1/3）

### DIFF
--- a/src-tauri/src/ai_service/message_system/producer.rs
+++ b/src-tauri/src/ai_service/message_system/producer.rs
@@ -57,6 +57,9 @@ impl StreamProducer {
         let mut buffer = String::new();
         let mut sentence = String::new();
         let mut sentence_index: usize = 0;
+        // 本轮回复内已投递句子的归一化集合：模型在多轮工具调用间容易把
+        // 开场白复读一遍，逐字重复的句子直接丢弃（短句豁免，避免误伤语气词）。
+        let mut seen_sentences = std::collections::HashSet::new();
 
         while let Some(item) = self.llm_stream.next().await {
             let chunk = item?;
@@ -107,6 +110,7 @@ impl StreamProducer {
                                 &mut sentence,
                                 &mut sentence_index,
                                 false,
+                                &mut seen_sentences,
                             )
                             .await?;
                         } else {
@@ -145,6 +149,7 @@ impl StreamProducer {
                                     &mut sentence,
                                     &mut sentence_index,
                                     false,
+                                    &mut seen_sentences,
                                 )
                                 .await?;
                             } else {
@@ -210,13 +215,60 @@ impl StreamProducer {
         sentence: &mut String,
         sentence_index: &mut usize,
         is_final: bool,
+        seen: &mut std::collections::HashSet<String>,
     ) -> Result<()> {
         let s = std::mem::take(sentence);
+        // 复读去重：非最终句与本轮已投递句子逐字重复（忽略空白差异）时丢弃。
+        // 丢弃时不消耗索引，保证 publisher 收到的索引仍然连续；最终句始终放行，
+        // 确保前端一定能收到 is_final 完成信号。
+        if !is_final && Self::is_duplicate(seen, &s) {
+            tracing::info!("[dedupe] 丢弃复读句子: {:.40}", s);
+            return Ok(());
+        }
         let idx = *sentence_index;
         *sentence_index += 1;
         tx.send((s, idx, is_final))
             .await
             .map_err(|_| anyhow::anyhow!("sentence channel closed"))?;
         Ok(())
+    }
+
+    /// 判断句子是否是本轮回复内的逐字复读（忽略所有空白字符）。
+    /// 归一化后不足 8 个字符的短句不去重，避免误伤「嗯」「好哒」等合法重复。
+    fn is_duplicate(seen: &mut std::collections::HashSet<String>, sentence: &str) -> bool {
+        let normalized: String = sentence.chars().filter(|c| !c.is_whitespace()).collect();
+        if normalized.chars().count() < 8 {
+            return false;
+        }
+        !seen.insert(normalized)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_detection_ignores_whitespace() {
+        let mut seen = std::collections::HashSet::new();
+        let first = "【高兴】\n好哒用户酱，进入工程创建阶段～\n<わかりました>";
+        assert!(!StreamProducer::is_duplicate(&mut seen, first));
+        // 逐字复读（仅空白有差异）会被识别并丢弃
+        let repeated = "【高兴】 好哒用户酱，进入工程创建阶段～ \n<わかりました>\n";
+        assert!(StreamProducer::is_duplicate(&mut seen, repeated));
+    }
+
+    #[test]
+    fn short_sentences_are_exempt() {
+        let mut seen = std::collections::HashSet::new();
+        assert!(!StreamProducer::is_duplicate(&mut seen, "【高兴】嗯"));
+        assert!(!StreamProducer::is_duplicate(&mut seen, "【高兴】嗯"));
+    }
+
+    #[test]
+    fn distinct_sentences_pass() {
+        let mut seen = std::collections::HashSet::new();
+        assert!(!StreamProducer::is_duplicate(&mut seen, "【认真】先读取参考文件再动手写"));
+        assert!(!StreamProducer::is_duplicate(&mut seen, "【高兴】已经写好落盘啦"));
     }
 }

--- a/src-tauri/src/ai_service/tools/tool_loop.rs
+++ b/src-tauri/src/ai_service/tools/tool_loop.rs
@@ -23,6 +23,9 @@ const MAX_PERSISTED_TOOL_RESULT_CHARS: usize = 32_000;
 const MAX_PERSISTED_SINGLE_TOOL_RESULT_CHARS: usize = 12_000;
 const TOOL_RESULT_TRUNCATION_MARKER: &str = "\n...[工具结果过长，长期记忆已截断]";
 const FINAL_SYNTHESIS_PROMPT: &str = "工具调用已达到本轮上限。请停止调用工具，基于已有工具结果直接给出最终答复；如仍有未完成事项，请明确说明。";
+/// 工具结果返回后的续写引导。部分模型会把上一轮台词当作已结束回合而重新开场，
+/// 导致同一句话在多轮工具调用间被反复复读；显式要求接着上文继续、禁止重复。
+const CONTINUATION_PROMPT: &str = "工具结果已返回。请接着你上一条回复的内容继续，绝对不要重复之前已经发送过的台词、动作描写或翻译行；直接基于工具结果汇报结果或进行下一步。";
 const TOOL_USE_POLICY_PROMPT: &str = "你可以调用本请求随附的工具。用户要求执行文件读写/删除、命令运行、角色或场景切换等实际操作时，必须先真正调用相应工具，并在收到工具结果后再说明结果。绝不能只在思考中计划调用，或在没有成功工具结果时声称已经执行、删除、写入、切换或完成。需要用户确认的危险操作会由应用弹窗处理，请直接发起工具调用，不要用文字假装已经操作；如果工具失败、被拒绝或没有调用，必须明确说明操作尚未完成。";
 
 /// 工具消息收集槽：流消费过程中由闭环填充，消费完毕后调用方取走。
@@ -207,6 +210,7 @@ pub async fn stream_with_tool_loop(
                 active_role_name = refreshed_name;
             } else {
                 messages.extend(round_messages.clone());
+                messages.push(LlmMessage::system(CONTINUATION_PROMPT));
             }
 
             let persisted_messages = bounded_tool_history(


### PR DESCRIPTION
## 问题

工具调用（execute_command / delete_file 等）成功后，角色的回复会概率性「复读」：同一句台词在历史对话里出现 2～3 遍，连续多轮工具调用时更严重；复读还会把角色卡的日文翻译行 `<...>` 挤乱，漏进正文显示甚至被 TTS 读出来。

## 根因（基于 LLM 请求日志取证）

多轮工具闭环中，部分模型（如 kimi-for-coding）在收到 tool_result 后，会把自己上一轮已经说过的台词当作「已结束的回合」，于是**重新开场**：先把开场白原样再写一遍，才汇报工具结果。请求日志可见 round 2/3 的输出开头逐字重复 round 1 的台词，数据库与前端管线均无复制逻辑问题。

## 修复

- **tool_loop.rs**：每轮工具结果返回后注入续写引导 `CONTINUATION_PROMPT`，明确要求接着上一条回复继续、禁止重复已发送的台词/动作描写/翻译行（角色切换分支不注入，上下文已重建）。
- **producer.rs**：句子级去重作为确定性兜底。本轮回复内逐字重复（忽略空白差异）的句子直接丢弃：
  - 丢弃时不消耗索引，保证 publisher 收到的索引连续（否则按序发布会卡死）；
  - 最终句始终放行，保证前端一定能收到 `is_final` 完成信号；
  - 归一化后不足 8 字的短句豁免，避免误伤「嗯」「好哒」等合法重复。
- 附带 3 个单元测试；`cargo test --lib` 全量 178 个测试通过。

## 验证

本地完整构建实测：此前连续 4 轮工具调用会把开场白复读 3 遍；修复后同场景复读句子被丢弃且日志留下 `[dedupe] 丢弃复读句子` 记录，回复完整收尾。