### PR TITLE
feat: 工具调用参数生成进度实时显示（顶栏「正在生成…N 字」）（2/3）

### DIFF
--- a/src-tauri/src/ai_service/llm/mod.rs
+++ b/src-tauri/src/ai_service/llm/mod.rs
@@ -74,6 +74,9 @@ pub enum LlmChunk {
     Reasoning(String),
     /// 一轮流式请求结束后得到的完整工具调用，仅供工具闭环内部消费。
     ToolCalls(Vec<crate::ai_service::types::ToolCall>),
+    /// 工具调用参数的流式生成进度（工具名 + 已生成字符数）。
+    /// 仅用于前端实时状态提示（如「正在写入：写入文件（N 字）」），不进正文/记忆。
+    ToolCallProgress { name: String, chars: usize },
     /// 流终止信号：归一化停止原因（"stop" / "max_tokens" / "tool_calls" / …）。
     /// 由 provider 在流末尾发射，消费方按需忽略（剧本导师用它检测截断）。
     StreamEnd { reason: Option<String> },

--- a/src-tauri/src/ai_service/llm/providers/kimi_code.rs
+++ b/src-tauri/src/ai_service/llm/providers/kimi_code.rs
@@ -595,6 +595,11 @@ impl KimiCodeProvider {
                                         let idx = parsed.index.unwrap_or(0);
                                         if let Some(block) = tool_blocks.get_mut(&idx) {
                                             block.2.push_str(&partial);
+                                            // 实时汇报参数生成进度（驱动前端「正在写入…N 字」提示）
+                                            yield LlmChunk::ToolCallProgress {
+                                                name: block.1.clone(),
+                                                chars: block.2.chars().count(),
+                                            };
                                         }
                                     }
                                 }
@@ -603,14 +608,17 @@ impl KimiCodeProvider {
                                 if let Some(block) = parsed.content_block {
                                     if block.type_ == "tool_use" {
                                         let idx = parsed.index.unwrap_or(0);
+                                        let name = block.name.unwrap_or_default();
                                         tool_blocks.insert(
                                             idx,
                                             (
                                                 block.id.unwrap_or_default(),
-                                                block.name.unwrap_or_default(),
+                                                name.clone(),
                                                 String::new(),
                                             ),
                                         );
+                                        // 工具块一开始就让前端亮出「正在生成」状态
+                                        yield LlmChunk::ToolCallProgress { name, chars: 0 };
                                     }
                                 }
                             }

--- a/src-tauri/src/ai_service/message_system/producer.rs
+++ b/src-tauri/src/ai_service/message_system/producer.rs
@@ -179,6 +179,9 @@ impl StreamProducer {
                 LlmChunk::ToolCalls(_) => {
                     return Err(anyhow::anyhow!("工具调用片段不应进入正式回复流"));
                 }
+                LlmChunk::ToolCallProgress { .. } => {
+                    // 参数生成进度：不进正文，由 tool_loop 直接转发为前端事件
+                }
                 LlmChunk::StreamEnd { .. } => {
                     // 终止信号：主对话流忽略（截断检测仅供剧本导师等工具闭环消费）。
                 }

--- a/src-tauri/src/ai_service/message_system/responses.rs
+++ b/src-tauri/src/ai_service/message_system/responses.rs
@@ -24,6 +24,8 @@ pub mod event_names {
     pub const AI_TOOL_CALL: &str = "ai:tool_call";
     /// 工具执行生命周期（started/finished），供顶栏显示实时调用状态。
     pub const AI_TOOL_ACTIVITY: &str = "ai:tool_activity";
+    /// 工具调用参数的流式生成进度（工具名 + 已生成字符数），供顶栏实时显示。
+    pub const AI_TOOL_CALL_PROGRESS: &str = "ai:tool_call_progress";
     /// 强制将前端状态重置为 `input`。
     pub const STATUS_RESET: &str = "status:reset";
 }

--- a/src-tauri/src/ai_service/message_system/responses.rs
+++ b/src-tauri/src/ai_service/message_system/responses.rs
@@ -26,6 +26,8 @@ pub mod event_names {
     pub const AI_TOOL_ACTIVITY: &str = "ai:tool_activity";
     /// 工具调用参数的流式生成进度（工具名 + 已生成字符数），供顶栏实时显示。
     pub const AI_TOOL_CALL_PROGRESS: &str = "ai:tool_call_progress";
+    /// 一轮 LLM 流结束、参数生成阶段收尾：前端据此清除「正在生成…」进度提示。
+    pub const AI_TOOL_CALL_PROGRESS_END: &str = "ai:tool_call_progress_end";
     /// 强制将前端状态重置为 `input`。
     pub const STATUS_RESET: &str = "status:reset";
 }

--- a/src-tauri/src/ai_service/skill_agent/core.rs
+++ b/src-tauri/src/ai_service/skill_agent/core.rs
@@ -432,6 +432,9 @@ async fn stream_completion(
                 LlmChunk::StreamEnd { reason } => {
                     finish_reason = reason;
                 }
+                LlmChunk::ToolCallProgress { .. } => {
+                    // 剧本编辑器的 agent 会话不需要参数生成进度提示
+                }
             }
         }
     } else {

--- a/src-tauri/src/ai_service/tools/tool_loop.rs
+++ b/src-tauri/src/ai_service/tools/tool_loop.rs
@@ -117,6 +117,10 @@ pub async fn stream_with_tool_loop(
             while let Some(chunk) = response_stream.next().await {
                 match chunk? {
                     LlmChunk::ToolCalls(calls) => tool_calls.extend(calls),
+                    LlmChunk::ToolCallProgress { name, chars } => {
+                        // 参数生成进度直接转为前端事件，不进正文流
+                        emit_tool_call_progress_event(&app, &name, chars);
+                    }
                     LlmChunk::Content(text) => {
                         round_text.push_str(&text);
                         // 实时透传，保持下游流式体验
@@ -314,6 +318,17 @@ pub(crate) fn emit_tool_activity_event(
     });
     if let Err(error) = app.emit(event_names::AI_TOOL_ACTIVITY, &payload) {
         tracing::warn!("emit ai:tool_activity 失败: {error}");
+    }
+}
+
+/// 工具调用参数的流式生成进度：驱动前端顶栏「正在写入… N 字」实时提示。
+pub(crate) fn emit_tool_call_progress_event(app: &AppHandle, tool: &str, chars: usize) {
+    let payload = serde_json::json!({
+        "tool": tool,
+        "chars": chars,
+    });
+    if let Err(error) = app.emit(event_names::AI_TOOL_CALL_PROGRESS, &payload) {
+        tracing::warn!("emit ai:tool_call_progress 失败: {error}");
     }
 }
 

--- a/src-tauri/src/ai_service/tools/tool_loop.rs
+++ b/src-tauri/src/ai_service/tools/tool_loop.rs
@@ -36,6 +36,26 @@ pub struct ToolLoopResult {
     pub tool_messages: ToolMessageSink,
 }
 
+/// 保证工具参数进度在正常结束、流错误和上游取消时都会被清理。
+///
+/// `async_stream` 在消费方提前丢弃流时不会继续执行循环后的语句，因此清理必须
+/// 绑定到 RAII guard，不能只依赖正常路径中的显式事件。
+struct ToolCallProgressEndGuard {
+    app: AppHandle,
+}
+
+impl ToolCallProgressEndGuard {
+    fn new(app: AppHandle) -> Self {
+        Self { app }
+    }
+}
+
+impl Drop for ToolCallProgressEndGuard {
+    fn drop(&mut self) {
+        emit_tool_call_progress_end_event(&self.app);
+    }
+}
+
 /// 以流式请求执行普通聊天的工具闭环。
 ///
 /// 仅支持原生流式 tools 的 provider 会携带工具定义请求。工具调用必须等到本轮
@@ -111,6 +131,7 @@ pub async fn stream_with_tool_loop(
                 llm.complete_stream_with_tools(&messages, &definitions, Some("auto"))
                     .await?
             };
+            let progress_end_guard = ToolCallProgressEndGuard::new(app.clone());
             let mut tool_calls = Vec::new();
             let mut round_text = String::new();
 
@@ -132,6 +153,9 @@ pub async fn stream_with_tool_loop(
                     }
                 }
             }
+
+            // 正常路径立即结束进度；流错误或消费方提前取消时由 Drop 自动兜底。
+            drop(progress_end_guard);
 
             if tool_calls.is_empty() {
                 // 本轮没有工具调用，工具闭环结束
@@ -329,6 +353,13 @@ pub(crate) fn emit_tool_call_progress_event(app: &AppHandle, tool: &str, chars: 
     });
     if let Err(error) = app.emit(event_names::AI_TOOL_CALL_PROGRESS, &payload) {
         tracing::warn!("emit ai:tool_call_progress 失败: {error}");
+    }
+}
+
+/// 一轮 LLM 流结束：通知前端清除参数生成进度提示（无载荷）。
+pub(crate) fn emit_tool_call_progress_end_event(app: &AppHandle) {
+    if let Err(error) = app.emit(event_names::AI_TOOL_CALL_PROGRESS_END, ()) {
+        tracing::warn!("emit ai:tool_call_progress_end 失败: {error}");
     }
 }
 

--- a/src/api/services/tool-settings.ts
+++ b/src/api/services/tool-settings.ts
@@ -93,6 +93,11 @@ export function handleToolCallProgress(payload: { tool: string; chars: number })
   toolCallPreparing.value = { tool: payload.tool, chars: payload.chars }
 }
 
+/** 清除「正在生成」进度提示（一轮 LLM 流结束 / 工具进入执行阶段 / 异常中断时调用）。 */
+export function clearToolCallPreparing() {
+  toolCallPreparing.value = null
+}
+
 // 后台命令最长运行 60 分钟，再留 5 分钟给事件投递与系统休眠恢复。
 const ACTIVE_WATCHDOG_MS = 65 * 60 * 1000
 const FINISHED_VISIBLE_MS = 2200
@@ -162,7 +167,7 @@ export function handleToolActivity(event: ToolActivityEvent) {
 
   if (event.phase === 'started') {
     // 参数已合并完整、进入执行阶段：清掉「正在生成」进度提示
-    toolCallPreparing.value = null
+    clearToolCallPreparing()
     clearFinishedTimer()
     clearWatchdog(event.call_id)
     const activity: ToolActivityState = {
@@ -201,7 +206,7 @@ export function handleToolActivity(event: ToolActivityEvent) {
 
 /** AI 请求异常结束时清理前台调用；已脱离当前生成的后台命令继续保留。 */
 export function interruptToolActivities() {
-  toolCallPreparing.value = null
+  clearToolCallPreparing()
   const visible = currentToolActivity.value
   for (const [callId, activity] of [...activeToolCalls.entries()]) {
     if (isBackgroundCommand(activity)) continue

--- a/src/api/services/tool-settings.ts
+++ b/src/api/services/tool-settings.ts
@@ -84,6 +84,15 @@ export interface ToolActivityState {
 /** 顶栏正在显示的工具活动；结束状态短暂停留后自动淡出。 */
 export const currentToolActivity = ref<ToolActivityState | null>(null)
 
+/** 工具调用参数的流式生成进度（顶栏「正在生成…N 字」实时提示）。 */
+export const toolCallPreparing = ref<{ tool: string; chars: number } | null>(null)
+
+/** 接收后端参数生成进度事件（工具块开始与每个参数增量都会触发）。 */
+export function handleToolCallProgress(payload: { tool: string; chars: number }) {
+  if (!payload.tool?.trim()) return
+  toolCallPreparing.value = { tool: payload.tool, chars: payload.chars }
+}
+
 // 后台命令最长运行 60 分钟，再留 5 分钟给事件投递与系统休眠恢复。
 const ACTIVE_WATCHDOG_MS = 65 * 60 * 1000
 const FINISHED_VISIBLE_MS = 2200
@@ -152,6 +161,8 @@ export function handleToolActivity(event: ToolActivityEvent) {
   if (!event.call_id?.trim() || !event.tool?.trim()) return
 
   if (event.phase === 'started') {
+    // 参数已合并完整、进入执行阶段：清掉「正在生成」进度提示
+    toolCallPreparing.value = null
     clearFinishedTimer()
     clearWatchdog(event.call_id)
     const activity: ToolActivityState = {
@@ -190,6 +201,7 @@ export function handleToolActivity(event: ToolActivityEvent) {
 
 /** AI 请求异常结束时清理前台调用；已脱离当前生成的后台命令继续保留。 */
 export function interruptToolActivities() {
+  toolCallPreparing.value = null
   const visible = currentToolActivity.value
   for (const [callId, activity] of [...activeToolCalls.entries()]) {
     if (isBackgroundCommand(activity)) continue

--- a/src/api/tauri-events.ts
+++ b/src/api/tauri-events.ts
@@ -10,6 +10,7 @@ import { i18n } from '@/locales'
 import { useScriptEditorStore } from '../stores/modules/script-editor'
 import {
   handleToolActivity,
+  handleToolCallProgress,
   interruptToolActivities,
   pushToolCallRecord,
   toolDisplayName,
@@ -93,6 +94,11 @@ export function initializeTauriEventListeners() {
   listen('ai:tool_activity', (event) => {
     const payload = event.payload as ToolActivityEvent
     handleToolActivity(payload)
+  })
+
+  // 工具调用参数流式生成进度：顶栏实时显示「正在生成…N 字」
+  listen('ai:tool_call_progress', (event) => {
+    handleToolCallProgress(event.payload as { tool: string; chars: number })
   })
 
   // 工具调用结果：记入「工具调用」页面历史 + 左上角弹通知

--- a/src/api/tauri-events.ts
+++ b/src/api/tauri-events.ts
@@ -9,6 +9,7 @@ import { useGameStore } from '../stores/modules/game'
 import { i18n } from '@/locales'
 import { useScriptEditorStore } from '../stores/modules/script-editor'
 import {
+  clearToolCallPreparing,
   handleToolActivity,
   handleToolCallProgress,
   interruptToolActivities,
@@ -99,6 +100,11 @@ export function initializeTauriEventListeners() {
   // 工具调用参数流式生成进度：顶栏实时显示「正在生成…N 字」
   listen('ai:tool_call_progress', (event) => {
     handleToolCallProgress(event.payload as { tool: string; chars: number })
+  })
+
+  // 一轮 LLM 流结束：清除「正在生成」进度提示（工具被忽略的收尾轮不会再有执行事件）
+  listen('ai:tool_call_progress_end', () => {
+    clearToolCallPreparing()
   })
 
   // 工具调用结果：记入「工具调用」页面历史 + 左上角弹通知

--- a/src/components/tools/ToolActivityStatus.vue
+++ b/src/components/tools/ToolActivityStatus.vue
@@ -7,8 +7,8 @@
     mode="out-in"
   >
     <div
-      v-if="activity && !uiStore.showSettings"
-      :key="`${activity.callId}-${activity.status}`"
+      v-if="(activity || preparing) && !uiStore.showSettings"
+      :key="viewKey"
       class="hidden
         pointer-events-none
         mr-2
@@ -33,13 +33,13 @@
         :class="statusClass"
       >
         <LoaderCircle
-          v-if="activity.status === 'running'"
+          v-if="preparing || activity?.status === 'running'"
           :size="14"
           class="shrink-0
             animate-spin"
         />
         <CheckCircle2
-          v-else-if="activity.status === 'success'"
+          v-else-if="activity?.status === 'success'"
           :size="14"
           class="shrink-0"
         />
@@ -58,12 +58,20 @@
 import { computed } from 'vue'
 import { CheckCircle2, CircleAlert, LoaderCircle } from 'lucide-vue-next'
 import { useI18n } from 'vue-i18n'
-import { currentToolActivity } from '@/api/services/tool-settings'
+import { currentToolActivity, toolCallPreparing } from '@/api/services/tool-settings'
 import { useUIStore } from '@/stores/modules/ui/ui'
 
 const uiStore = useUIStore()
 const { t, te } = useI18n()
 const activity = currentToolActivity
+// 工具调用参数的流式生成进度；存在时优先于执行状态展示
+const preparing = toolCallPreparing
+
+const viewKey = computed(() => {
+  if (preparing.value) return `preparing-${preparing.value.tool}`
+  const current = activity.value
+  return current ? `${current.callId}-${current.status}` : 'idle'
+})
 
 const readTools = new Set([
   'list_skills',
@@ -148,6 +156,12 @@ function runningKey(current: NonNullable<typeof activity.value>): string {
 }
 
 const statusText = computed(() => {
+  const pending = preparing.value
+  if (pending) {
+    const key = `ui.toolCalls.tools.${pending.tool}`
+    const label = te(key) ? t(key) : pending.tool
+    return t('ui.toolActivity.preparing', { tool: label, chars: pending.chars })
+  }
   const current = activity.value
   if (!current) return ''
   if (current.status === 'success') {
@@ -163,6 +177,7 @@ const statusText = computed(() => {
 })
 
 const statusClass = computed(() => {
+  if (preparing.value) return 'text-sky-200/90'
   switch (activity.value?.status) {
     case 'success':
       return 'text-emerald-300/90'

--- a/src/locales/en/ui.ts
+++ b/src/locales/en/ui.ts
@@ -87,6 +87,7 @@ export default {
     updating: "Updating: {tool}",
     switching: "Switching: {tool}",
     calling: "Calling: {tool}",
+    preparing: "Generating: {tool} ({chars} chars)",
     completed: "Completed: {tool}",
     failed: "Failed: {tool}",
   },

--- a/src/locales/ja/ui.ts
+++ b/src/locales/ja/ui.ts
@@ -86,6 +86,7 @@ export default {
     updating: '更新中：{tool}',
     switching: '切り替え中：{tool}',
     calling: 'ツール呼び出し中：{tool}',
+    preparing: '生成中：{tool}（{chars} 文字）',
     completed: '完了：{tool}',
     failed: '呼び出し失敗：{tool}',
   },

--- a/src/locales/zh-CN/ui.ts
+++ b/src/locales/zh-CN/ui.ts
@@ -86,6 +86,7 @@ export default {
     updating: '正在更新：{tool}',
     switching: '正在切换：{tool}',
     calling: '正在调用：{tool}',
+    preparing: '正在生成：{tool}（{chars} 字）',
     completed: '已完成：{tool}',
     failed: '调用失败：{tool}',
   },

--- a/src/locales/zh-HK/ui.ts
+++ b/src/locales/zh-HK/ui.ts
@@ -87,6 +87,7 @@ export default {
     "updating": "正在更新：{tool}",
     "switching": "正在切換：{tool}",
     "calling": "正在調用：{tool}",
+    "preparing": "正在生成：{tool}（{chars} 字）",
     "completed": "已完成：{tool}",
     "failed": "調用失敗：{tool}"
   },


### PR DESCRIPTION
## 问题

让 AI 写大文件（剧本章节等）时，模型要流式生成几千字的工具调用参数，这期间界面没有任何反馈，看起来像卡死了。

## 方案

新增 `LlmChunk::ToolCallProgress` 进度片段，把参数流式生成过程实时透传到前端顶栏（与「已深度思考 N 字」同款体验）：

- **kimi provider**：`content_block_start`(tool_use) 时立即产出进度 0（顶栏立刻亮出「正在生成」状态），每个 `input_json_delta` 增量汇报当前已累积字符数
- **tool_loop**：进度 chunk 直接转为 `ai:tool_call_progress` 事件，不进正文流、不进记忆
- **清理兜底**：每轮流结束时发送 `ai:tool_call_progress_end`；RAII guard 同时覆盖流错误和消费方提前取消，避免顶栏永久残留
- **producer / skill_agent**：新变体的忽略分支
- **前端**：`toolCallPreparing` 状态 + 顶栏状态丸实时显示「正在生成：写入文件（N 字）」；工具开始执行（started）自动切换为执行状态，异常中断自动清理
- 四语言文案（zh-CN/zh-HK/en/ja）

未接入的 provider（genai 等）不产出进度 chunk，行为与现状一致，无破坏性。

> 注：本分支叠在 #590 之上（其合并后本 PR 自动只剩本功能 1 个提交）。

## 验证

- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- 本地集成分支完整 Rust 库检查通过
- 本地完整构建实测：让角色写剧本章节时顶栏实时跳动「正在生成：写入文件（N 字）」，写完后无缝切换「正在写入 → 已完成」