### PR TITLE
fix: 剧本模式全面禁用工具并净化工具记忆（3/3）

### DIFF
--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -423,6 +423,16 @@ impl MessageGenerator {
         user_message: String,
         user_message_seq: Option<u32>,
     ) -> Result<String> {
+        // 剧本模式不携带工具记忆：丢弃工具结果消息，带 tool_calls 的 assistant
+        // 消息退化为纯文本台词，保持剧情上下文干净（与工具注册禁用配套）。
+        let context = if matches!(
+            self.deps.source,
+            GeneratorSource::ScriptAiDialogue | GeneratorSource::ScriptFreeDialogue
+        ) {
+            strip_tool_messages(context)
+        } else {
+            context
+        };
         let role_name = {
             let mut gs = self.deps.game_status.lock().await;
             let Some(role_id) = gs.current_role_id else {
@@ -597,6 +607,28 @@ impl MessageGenerator {
 // ============================================================
 // consumer 句子处理
 // ============================================================
+
+/// 剧本模式上下文净化：移除工具调用相关的消息。
+/// - `role == "tool"` 的工具结果消息直接丢弃；
+/// - 带 `tool_calls` 的 assistant 消息去掉 tool_calls 退化为纯文本台词，
+///   纯工具调用（无正文）的消息整体丢弃。
+fn strip_tool_messages(messages: Vec<LlmMessage>) -> Vec<LlmMessage> {
+    messages
+        .into_iter()
+        .filter_map(|mut message| match message.role.as_str() {
+            "tool" => None,
+            "assistant" if message.tool_calls.is_some() => {
+                message.tool_calls = None;
+                if message.content.trim().is_empty() {
+                    None
+                } else {
+                    Some(message)
+                }
+            }
+            _ => Some(message),
+        })
+        .collect()
+}
 
 /// 处理单个句子：解析 → 富化 → 构建响应 → 保存行。
 async fn consume_sentence(
@@ -827,4 +859,49 @@ async fn add_assistant_line(deps: &GeneratorDeps, response: &ReplyResponse) -> R
     let mut gs = deps.game_status.lock().await;
     gs.add_line(&deps.db, line).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai_service::types::{FunctionCall, ToolCall};
+
+    fn tool_call() -> ToolCall {
+        ToolCall {
+            id: "call-1".into(),
+            type_: "function".into(),
+            function: FunctionCall {
+                name: "write_file".into(),
+                arguments: "{}".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn strip_tool_messages_removes_tool_artifacts() {
+        let messages = vec![
+            LlmMessage::system("人设"),
+            LlmMessage::assistant("我来看看文件哦"),
+            LlmMessage {
+                role: "assistant".into(),
+                content: "先读取一下参考文件".into(),
+                tool_calls: Some(vec![tool_call()]),
+                tool_call_id: None,
+            },
+            LlmMessage::tool_result("call-1", "{\"ok\":true}"),
+            LlmMessage::tool(vec![tool_call()]), // 无正文纯工具调用
+            LlmMessage::user("继续"),
+        ];
+
+        let stripped = strip_tool_messages(messages);
+
+        let roles: Vec<&str> = stripped.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["system", "assistant", "assistant", "user"]);
+        // 带 tool_calls 的 assistant 退化为纯文本台词
+        assert_eq!(stripped[2].content, "先读取一下参考文件");
+        assert!(stripped[2].tool_calls.is_none());
+        // 不含任何 tool 角色消息与 tool_calls 残留
+        assert!(stripped.iter().all(|m| m.role != "tool"));
+        assert!(stripped.iter().all(|m| m.tool_calls.is_none()));
+    }
 }

--- a/src-tauri/src/ai_service/message_system/producer.rs
+++ b/src-tauri/src/ai_service/message_system/producer.rs
@@ -57,6 +57,9 @@ impl StreamProducer {
         let mut buffer = String::new();
         let mut sentence = String::new();
         let mut sentence_index: usize = 0;
+        // 本轮回复内已投递句子的归一化集合：模型在多轮工具调用间容易把
+        // 开场白复读一遍，逐字重复的句子直接丢弃（短句豁免，避免误伤语气词）。
+        let mut seen_sentences = std::collections::HashSet::new();
 
         while let Some(item) = self.llm_stream.next().await {
             let chunk = item?;
@@ -107,6 +110,7 @@ impl StreamProducer {
                                 &mut sentence,
                                 &mut sentence_index,
                                 false,
+                                &mut seen_sentences,
                             )
                             .await?;
                         } else {
@@ -145,6 +149,7 @@ impl StreamProducer {
                                     &mut sentence,
                                     &mut sentence_index,
                                     false,
+                                    &mut seen_sentences,
                                 )
                                 .await?;
                             } else {
@@ -210,13 +215,60 @@ impl StreamProducer {
         sentence: &mut String,
         sentence_index: &mut usize,
         is_final: bool,
+        seen: &mut std::collections::HashSet<String>,
     ) -> Result<()> {
         let s = std::mem::take(sentence);
+        // 复读去重：非最终句与本轮已投递句子逐字重复（忽略空白差异）时丢弃。
+        // 丢弃时不消耗索引，保证 publisher 收到的索引仍然连续；最终句始终放行，
+        // 确保前端一定能收到 is_final 完成信号。
+        if !is_final && Self::is_duplicate(seen, &s) {
+            tracing::info!("[dedupe] 丢弃复读句子: {:.40}", s);
+            return Ok(());
+        }
         let idx = *sentence_index;
         *sentence_index += 1;
         tx.send((s, idx, is_final))
             .await
             .map_err(|_| anyhow::anyhow!("sentence channel closed"))?;
         Ok(())
+    }
+
+    /// 判断句子是否是本轮回复内的逐字复读（忽略所有空白字符）。
+    /// 归一化后不足 8 个字符的短句不去重，避免误伤「嗯」「好哒」等合法重复。
+    fn is_duplicate(seen: &mut std::collections::HashSet<String>, sentence: &str) -> bool {
+        let normalized: String = sentence.chars().filter(|c| !c.is_whitespace()).collect();
+        if normalized.chars().count() < 8 {
+            return false;
+        }
+        !seen.insert(normalized)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_detection_ignores_whitespace() {
+        let mut seen = std::collections::HashSet::new();
+        let first = "【高兴】\n好哒用户酱，进入工程创建阶段～\n<わかりました>";
+        assert!(!StreamProducer::is_duplicate(&mut seen, first));
+        // 逐字复读（仅空白有差异）会被识别并丢弃
+        let repeated = "【高兴】 好哒用户酱，进入工程创建阶段～ \n<わかりました>\n";
+        assert!(StreamProducer::is_duplicate(&mut seen, repeated));
+    }
+
+    #[test]
+    fn short_sentences_are_exempt() {
+        let mut seen = std::collections::HashSet::new();
+        assert!(!StreamProducer::is_duplicate(&mut seen, "【高兴】嗯"));
+        assert!(!StreamProducer::is_duplicate(&mut seen, "【高兴】嗯"));
+    }
+
+    #[test]
+    fn distinct_sentences_pass() {
+        let mut seen = std::collections::HashSet::new();
+        assert!(!StreamProducer::is_duplicate(&mut seen, "【认真】先读取参考文件再动手写"));
+        assert!(!StreamProducer::is_duplicate(&mut seen, "【高兴】已经写好落盘啦"));
     }
 }

--- a/src-tauri/src/ai_service/tools/permissions.rs
+++ b/src-tauri/src/ai_service/tools/permissions.rs
@@ -147,12 +147,40 @@ impl ToolPermissionConfig {
     pub fn load_or_create(data_dir: &Path, tool_names: impl IntoIterator<Item = String>) -> Result<Self> {
         let path = data_dir.join(CONFIG_FILE_NAME);
         if path.exists() {
-            return Self::load(&path);
+            let mut config = Self::load(&path)?;
+            // 存量配置迁移：剧本模式来源统一归一到禁用的场景组（见下方常量说明）。
+            if config.enforce_script_sources_without_tools() {
+                config.save(&path)?;
+            }
+            return Ok(config);
         }
 
         let config = Self::with_default_tools(tool_names);
         config.save(&path)?;
         Ok(config)
+    }
+
+    /// 剧本模式（剧本 AI 对话 / 剧本自由对话）按产品策略不开放工具：
+    /// 两个来源的场景映射统一归一到默认禁用的 `scene_default` 组。
+    /// 旧版本配置可能把剧本自由对话映射到带全量工具的 `scene_normal`，
+    /// 导致角色在剧本演出中调用 skills/tools 破坏剧情，这里在加载时迁移修正。
+    /// 返回是否有改动。
+    fn enforce_script_sources_without_tools(&mut self) -> bool {
+        let mut changed = false;
+        for key in [
+            GeneratorSourceKey::ScriptAiDialogue,
+            GeneratorSourceKey::ScriptFreeDialogue,
+        ] {
+            let entry = self
+                .scene_mapping
+                .entry(key)
+                .or_insert_with(|| "scene_default".to_string());
+            if entry != "scene_default" {
+                *entry = "scene_default".to_string();
+                changed = true;
+            }
+        }
+        changed
     }
 
     /// 确保已知角色都归属于某个角色组，未归属的自动加入 default 组。
@@ -196,14 +224,6 @@ impl ToolPermissionConfig {
     ) -> HashSet<String> {
         // 1. 查映射找到场景组名（映射不存在时回退到 scene_default）
         let key: GeneratorSourceKey = source.into();
-        // 剧本模式（剧本 AI 对话 / 剧本自由对话）一律不注册工具：
-        // 避免角色在剧本演出中调用 skills/tools 破坏剧情（维护者要求）。
-        if matches!(
-            key,
-            GeneratorSourceKey::ScriptAiDialogue | GeneratorSourceKey::ScriptFreeDialogue
-        ) {
-            return HashSet::new();
-        }
         let scene_group_name = self.scene_mapping.get(&key).map(|s| s.as_str()).unwrap_or("scene_default");
         let Some(scene) = self.scene_groups.get(scene_group_name) else {
             return HashSet::new();
@@ -334,11 +354,12 @@ impl ToolPermissionConfig {
     fn with_default_tools(tool_names: impl IntoIterator<Item = String>) -> Self {
         let all_tools: HashSet<_> = tool_names.into_iter().collect();
 
-        // 默认映射
+        // 默认映射。剧本模式两个来源一律进 scene_default（默认禁用工具），
+        // 与 enforce_script_sources_without_tools 的存量迁移保持一致。
         let mut scene_mapping = HashMap::new();
         scene_mapping.insert(GeneratorSourceKey::UserChat, "scene_admin".into());
         scene_mapping.insert(GeneratorSourceKey::Proactive, "scene_normal".into());
-        scene_mapping.insert(GeneratorSourceKey::ScriptFreeDialogue, "scene_normal".into());
+        scene_mapping.insert(GeneratorSourceKey::ScriptFreeDialogue, "scene_default".into());
         scene_mapping.insert(GeneratorSourceKey::ScriptAiDialogue, "scene_default".into());
         scene_mapping.insert(GeneratorSourceKey::EntryGreeting, "scene_default".into());
 
@@ -452,30 +473,25 @@ user_chat = "scene_admin"
         assert_eq!(loaded.available_tools, vec!["get_current_time"]);
     }
 
-    /// 剧本模式（剧本 AI 对话 / 剧本自由对话）即使配置了 all_tools 也必须返回空集。
+    /// 默认配置下，剧本模式两个来源都映射到禁用的 scene_default，因此拿不到任何工具。
     #[test]
-    fn script_mode_sources_never_get_tools() {
-        let mut scene_groups = HashMap::new();
-        scene_groups.insert(
-            "scene_admin".to_string(),
-            ToolPermission {
-                enabled: true,
-                tools: HashSet::new(),
-                all_tools: true,
-            },
-        );
-        let mut scene_mapping = HashMap::new();
-        scene_mapping.insert(GeneratorSourceKey::ScriptAiDialogue, "scene_admin".to_string());
-        scene_mapping.insert(GeneratorSourceKey::ScriptFreeDialogue, "scene_admin".to_string());
-        let config = ToolPermissionConfig {
-            scene_mapping,
-            scene_groups,
-            ..Default::default()
-        };
+    fn script_sources_default_to_disabled_scene() {
         let all_names: HashSet<String> = ["web_search".to_string(), "execute_command".to_string()]
             .into_iter()
             .collect();
+        let config = ToolPermissionConfig::with_default_tools(all_names.iter().cloned());
 
+        for key in [
+            GeneratorSourceKey::ScriptAiDialogue,
+            GeneratorSourceKey::ScriptFreeDialogue,
+        ] {
+            assert_eq!(
+                config.scene_mapping.get(&key).map(|s| s.as_str()),
+                Some("scene_default"),
+                "{key:?} 应映射到 scene_default"
+            );
+        }
+        // scene_default 默认 enabled = false，剧本模式对话拿不到工具
         for source in [
             GeneratorSource::ScriptAiDialogue,
             GeneratorSource::ScriptFreeDialogue,
@@ -485,5 +501,44 @@ user_chat = "scene_admin"
                 "{source:?} 不应获得任何工具"
             );
         }
+    }
+
+    /// 旧配置把剧本自由对话映射到带工具的 scene_normal 时，
+    /// load_or_create 必须迁移修正为 scene_default 并落盘。
+    #[test]
+    fn load_migrates_legacy_script_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        let legacy = r#"
+[scene_mapping]
+user_chat = "scene_admin"
+script_free_dialogue = "scene_normal"
+script_ai_dialogue = "scene_normal"
+
+[scene_groups.scene_normal]
+enabled = true
+all_tools = true
+"#;
+        std::fs::write(dir.path().join(CONFIG_FILE_NAME), legacy).unwrap();
+
+        let config = ToolPermissionConfig::load_or_create(dir.path(), vec!["web_search".to_string()]).unwrap();
+        assert_eq!(
+            config.scene_mapping.get(&GeneratorSourceKey::ScriptFreeDialogue).map(|s| s.as_str()),
+            Some("scene_default")
+        );
+        assert_eq!(
+            config.scene_mapping.get(&GeneratorSourceKey::ScriptAiDialogue).map(|s| s.as_str()),
+            Some("scene_default")
+        );
+        // 用户聊天的映射不受影响
+        assert_eq!(
+            config.scene_mapping.get(&GeneratorSourceKey::UserChat).map(|s| s.as_str()),
+            Some("scene_admin")
+        );
+        // 迁移结果已保存回文件
+        let reloaded = ToolPermissionConfig::load(&dir.path().join(CONFIG_FILE_NAME)).unwrap();
+        assert_eq!(
+            reloaded.scene_mapping.get(&GeneratorSourceKey::ScriptFreeDialogue).map(|s| s.as_str()),
+            Some("scene_default")
+        );
     }
 }

--- a/src-tauri/src/ai_service/tools/permissions.rs
+++ b/src-tauri/src/ai_service/tools/permissions.rs
@@ -196,6 +196,14 @@ impl ToolPermissionConfig {
     ) -> HashSet<String> {
         // 1. 查映射找到场景组名（映射不存在时回退到 scene_default）
         let key: GeneratorSourceKey = source.into();
+        // 剧本模式（剧本 AI 对话 / 剧本自由对话）一律不注册工具：
+        // 避免角色在剧本演出中调用 skills/tools 破坏剧情（维护者要求）。
+        if matches!(
+            key,
+            GeneratorSourceKey::ScriptAiDialogue | GeneratorSourceKey::ScriptFreeDialogue
+        ) {
+            return HashSet::new();
+        }
         let scene_group_name = self.scene_mapping.get(&key).map(|s| s.as_str()).unwrap_or("scene_default");
         let Some(scene) = self.scene_groups.get(scene_group_name) else {
             return HashSet::new();
@@ -442,5 +450,40 @@ user_chat = "scene_admin"
 
         let loaded = ToolPermissionConfig::load(&path).unwrap();
         assert_eq!(loaded.available_tools, vec!["get_current_time"]);
+    }
+
+    /// 剧本模式（剧本 AI 对话 / 剧本自由对话）即使配置了 all_tools 也必须返回空集。
+    #[test]
+    fn script_mode_sources_never_get_tools() {
+        let mut scene_groups = HashMap::new();
+        scene_groups.insert(
+            "scene_admin".to_string(),
+            ToolPermission {
+                enabled: true,
+                tools: HashSet::new(),
+                all_tools: true,
+            },
+        );
+        let mut scene_mapping = HashMap::new();
+        scene_mapping.insert(GeneratorSourceKey::ScriptAiDialogue, "scene_admin".to_string());
+        scene_mapping.insert(GeneratorSourceKey::ScriptFreeDialogue, "scene_admin".to_string());
+        let config = ToolPermissionConfig {
+            scene_mapping,
+            scene_groups,
+            ..Default::default()
+        };
+        let all_names: HashSet<String> = ["web_search".to_string(), "execute_command".to_string()]
+            .into_iter()
+            .collect();
+
+        for source in [
+            GeneratorSource::ScriptAiDialogue,
+            GeneratorSource::ScriptFreeDialogue,
+        ] {
+            assert!(
+                config.allowed_tools(source, Some("钦灵"), &all_names).is_empty(),
+                "{source:?} 不应获得任何工具"
+            );
+        }
     }
 }

--- a/src-tauri/src/ai_service/tools/tool_loop.rs
+++ b/src-tauri/src/ai_service/tools/tool_loop.rs
@@ -23,6 +23,9 @@ const MAX_PERSISTED_TOOL_RESULT_CHARS: usize = 32_000;
 const MAX_PERSISTED_SINGLE_TOOL_RESULT_CHARS: usize = 12_000;
 const TOOL_RESULT_TRUNCATION_MARKER: &str = "\n...[工具结果过长，长期记忆已截断]";
 const FINAL_SYNTHESIS_PROMPT: &str = "工具调用已达到本轮上限。请停止调用工具，基于已有工具结果直接给出最终答复；如仍有未完成事项，请明确说明。";
+/// 工具结果返回后的续写引导。部分模型会把上一轮台词当作已结束回合而重新开场，
+/// 导致同一句话在多轮工具调用间被反复复读；显式要求接着上文继续、禁止重复。
+const CONTINUATION_PROMPT: &str = "工具结果已返回。请接着你上一条回复的内容继续，绝对不要重复之前已经发送过的台词、动作描写或翻译行；直接基于工具结果汇报结果或进行下一步。";
 const TOOL_USE_POLICY_PROMPT: &str = "你可以调用本请求随附的工具。用户要求执行文件读写/删除、命令运行、角色或场景切换等实际操作时，必须先真正调用相应工具，并在收到工具结果后再说明结果。绝不能只在思考中计划调用，或在没有成功工具结果时声称已经执行、删除、写入、切换或完成。需要用户确认的危险操作会由应用弹窗处理，请直接发起工具调用，不要用文字假装已经操作；如果工具失败、被拒绝或没有调用，必须明确说明操作尚未完成。";
 
 /// 工具消息收集槽：流消费过程中由闭环填充，消费完毕后调用方取走。
@@ -207,6 +210,7 @@ pub async fn stream_with_tool_loop(
                 active_role_name = refreshed_name;
             } else {
                 messages.extend(round_messages.clone());
+                messages.push(LlmMessage::system(CONTINUATION_PROMPT));
             }
 
             let persisted_messages = bounded_tool_history(


### PR DESCRIPTION
## 背景

维护者反馈：剧本模式下角色不应能调用 skills/tools，且不应携带任何工具相关记忆。

## 根因

工具注册链路（`ToolRegistry::allowed_tools` → `ToolPermissionConfig`）本身全部走权限文件 `tool_permissions.toml` 控制，没有绕过。真正的问题是默认配置：

- 剧本 AI 对话 `ScriptAiDialogue` → `scene_default`（禁用）→ 本就无工具 ✓
- 剧本自由对话 `ScriptFreeDialogue` → `scene_normal`（**带全量工具**）→ 漏网 ✗

## 修改内容（v2，按 review 意见重构）

不再在 `allowed_tools` 中硬编码返回空集，禁用策略完全由权限文件表达：

1. **`permissions.rs` 默认映射修正**：`with_default_tools` 中 `ScriptFreeDialogue` 由 `scene_normal` 改为 `scene_default`，新装用户剧本模式两个来源均无工具。
2. **存量配置迁移**：`load_or_create` 新增 `enforce_script_sources_without_tools`，加载旧配置时把两个剧本来源的映射归一到 `scene_default` 并落盘——旧配置里 `script_free_dialogue = scene_normal` 的用户升级后自动修正。
3. **`generator.rs` 记忆净化（保留）**：`run_pipeline` 入口对剧本模式来源执行 `strip_tool_messages`——丢弃 `role=tool` 消息、带 `tool_calls` 的 assistant 消息退化为纯文本台词（无正文整条丢弃），避免历史遗留的工具记忆污染剧情上下文，或与未注册工具的 provider 产生未配对 tool_calls 报错。

## 测试

- 新增：默认映射断言（两个剧本来源均 → scene_default 且拿不到工具）、旧配置迁移断言（映射修正 + 落盘 + 不影响 user_chat）
- `cargo test --lib` 全量 **181** 个测试通过