### PR TITLE
docs: 将 PR #583 引入的英文注释翻译为中文

### DIFF
--- a/src-tauri/src/ai_service/skill_agent/command_executor.rs
+++ b/src-tauri/src/ai_service/skill_agent/command_executor.rs
@@ -1,4 +1,4 @@
-//! Shell command execution, user approval, timeout and output bounds.
+//! Shell 命令执行、用户审批、超时与输出上限。
 
 use crate::ai_service::skill_agent::events::SkillAgentEvent;
 use serde::{Deserialize, Serialize};
@@ -21,7 +21,7 @@ const OUTPUT_DRAIN_GRACE: Duration = Duration::from_millis(400);
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
-/// A command waiting for the user's decision.
+/// 等待用户审批决定的命令。
 pub struct ApprovalRequest {
     pub tx: oneshot::Sender<bool>,
 }
@@ -37,7 +37,7 @@ pub struct CommandOutput {
     pub exit_code: i32,
 }
 
-/// Windows command output is often GBK/CP936 rather than UTF-8.
+/// Windows 命令输出通常是 GBK/CP936 而非 UTF-8。
 fn decode_console_output(bytes: &[u8]) -> String {
     if let Ok(s) = std::str::from_utf8(bytes) {
         return s.to_string();
@@ -70,7 +70,7 @@ pub fn new_request_id() -> String {
     format!("req-{ts}-{n}")
 }
 
-/// Run a command with the default timeout.
+/// 以默认超时运行命令。
 pub async fn run_shell_command(
     sandbox_dir: &Path,
     command: &str,
@@ -79,11 +79,11 @@ pub async fn run_shell_command(
     run_shell_command_with_timeout(sandbox_dir, command, cwd, DEFAULT_COMMAND_TIMEOUT).await
 }
 
-/// Run a shell command with bounded time and output.
+/// 以受限的时间和输出运行 shell 命令。
 ///
-/// The shell process is the lifecycle boundary. A successfully detached descendant may continue
-/// running, but cannot keep this future alive merely by inheriting stdout/stderr handles. On
-/// timeout or runaway output, the process tree is terminated best-effort.
+/// shell 进程是生命周期边界。成功分离的后代进程可以继续运行，
+/// 但仅凭继承 stdout/stderr 句柄无法让这个 future 保持存活。
+/// 超时或输出失控时，进程树会被尽力终止。
 pub async fn run_shell_command_with_timeout(
     sandbox_dir: &Path,
     command: &str,
@@ -100,10 +100,10 @@ pub async fn run_shell_command_with_timeout(
     .await
 }
 
-/// Run a detached chat command with the larger, explicitly bounded background timeout.
+/// 以更大且明确受限的后台超时，运行分离的对话命令。
 ///
-/// This is intentionally separate from [`run_shell_command_with_timeout`] so foreground
-/// callers keep the existing five-minute ceiling.
+/// 特意与 [`run_shell_command_with_timeout`] 分开，
+/// 让前台调用方保留原有的五分钟上限。
 pub async fn run_shell_command_in_background_with_timeout(
     sandbox_dir: &Path,
     command: &str,
@@ -135,7 +135,7 @@ async fn run_shell_command_with_limits(
     #[cfg(windows)]
     let mut process = {
         let mut process = tokio::process::Command::new("cmd");
-        // raw_arg keeps cmd.exe's nested quoting intact.
+        // raw_arg 能保持 cmd.exe 的嵌套引号原样不被破坏。
         process
             .arg("/D")
             .arg("/C")
@@ -342,10 +342,10 @@ async fn terminate_process_tree(child: &mut tokio::process::Child) {
     let _ = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
 }
 
-/// Async cancellation drops the command future, so there is no opportunity to await cleanup.
-/// Run the OS tree-kill command before `Child::kill_on_drop` removes the shell process. This
-/// intentionally blocks only during cancellation: detaching taskkill races with child drop and can
-/// lose the parent/descendant relationship before taskkill inspects it.
+/// 异步取消会直接 drop 命令 future，没有机会再等待清理。
+/// 要在 `Child::kill_on_drop` 移除 shell 进程之前运行操作系统的进程树终止命令。
+/// 这里特意只在取消时阻塞：分离的 taskkill 会与子进程 drop 竞争，
+/// 可能在 taskkill 检查之前就丢失父子进程关系。
 struct ProcessTreeCancellationGuard {
     pid: Option<u32>,
 }
@@ -410,9 +410,9 @@ pub async fn run_shell_command_elevated_with_timeout(
     std::fs::write(&temp.script, bat_content)?;
     std::fs::write(&temp.guard, b"running")?;
 
-    // The elevated watchdog owns termination of the elevated cmd tree. A medium-integrity
-    // launcher cannot reliably taskkill a high-integrity child, so timeout/cancellation removes
-    // the guard file and lets this elevated process perform cleanup at the same integrity level.
+    // 提权后的 cmd 进程树由提权 watchdog 负责终止。中等完整性的启动器
+    // 无法可靠地 taskkill 高完整性子进程，因此超时/取消时只移除哨兵文件，
+    // 让这个提权进程在同等完整性级别下执行清理。
     let watchdog = format!(
         "$ErrorActionPreference = 'Stop'\r\n\
          $guard = '{}'\r\n\
@@ -434,8 +434,8 @@ pub async fn run_shell_command_elevated_with_timeout(
     );
     std::fs::write(&temp.watchdog, watchdog)?;
 
-    // Process::WaitForExit waits for the elevated watchdog itself. Start-Process -Wait also waits
-    // for descendants and would reproduce the inherited-handle hang.
+    // Process::WaitForExit 只等待提权 watchdog 本身。
+    // Start-Process -Wait 还会等待后代进程，会复现句柄继承导致的挂起。
     let ps = format!(
         "$p = Start-Process -FilePath powershell.exe -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','\"{}\"' -Verb RunAs -PassThru; $p.WaitForExit(); exit $p.ExitCode",
         temp.watchdog.display()
@@ -546,7 +546,7 @@ async fn cancel_elevated_process(guard_path: &Path, pid_path: &Path) {
     }
     let Some(pid) = pid else { return };
 
-    // Give the elevated watchdog one polling interval to perform privileged cleanup first.
+    // 先给提权 watchdog 一个轮询间隔，让它优先执行特权清理。
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     let mut taskkill = tokio::process::Command::new("taskkill");
@@ -559,8 +559,8 @@ async fn cancel_elevated_process(guard_path: &Path, pid_path: &Path) {
         .kill_on_drop(true);
     match tokio::time::timeout(Duration::from_secs(5), taskkill.status()).await {
         Ok(Ok(status)) if status.success() => {}
-        // The watchdog may already have removed the process; a non-zero fallback is therefore
-        // diagnostic only and not treated as a second user-visible failure.
+        // watchdog 可能已经终止了进程；因此非零的兜底结果仅作诊断，
+        // 不视为第二次面向用户的失败。
         Ok(Ok(status)) => tracing::debug!(pid, ?status, "提权 watchdog 已接管或兜底终止失败"),
         Ok(Err(error)) => tracing::warn!(pid, %error, "无法启动 taskkill 清理提权进程"),
         Err(_) => tracing::warn!(pid, "终止超时的提权进程失败：taskkill 超时"),
@@ -597,7 +597,7 @@ pub async fn run_shell_command_elevated_with_timeout(
     anyhow::bail!("UAC 提权仅支持 Windows 平台")
 }
 
-/// Script-agent command execution with its existing approval channel.
+/// 剧本代理的命令执行，沿用其现有的审批通道。
 #[allow(clippy::too_many_arguments)]
 pub async fn execute_command(
     channel: &tauri::ipc::Channel<SkillAgentEvent>,

--- a/src-tauri/src/ai_service/skill_agent/file_tools.rs
+++ b/src-tauri/src/ai_service/skill_agent/file_tools.rs
@@ -1,4 +1,4 @@
-//! File tools exposed to the LLM, bounded by a sandbox unless explicitly disabled.
+//! 暴露给 LLM 的文件工具，除非显式关闭，否则一律受沙箱约束。
 
 use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf};
@@ -10,8 +10,8 @@ const MAX_WALK_FILES: usize = 500;
 const MAX_GREP_FILE_BYTES: u64 = 1024 * 1024;
 pub const MAX_GREP_RESULTS: usize = 100;
 
-/// Write beside the destination, flush the complete content, then atomically replace it.
-/// This prevents a cancelled or interrupted LLM tool call from leaving a half-written file.
+/// 先写入目标旁的临时文件，完整刷盘后，再原子地替换目标文件。
+/// 这能避免被取消或中断的 LLM 工具调用留下写了一半的文件。
 fn atomic_write(path: &Path, content: &[u8]) -> anyhow::Result<()> {
     use std::io::Write;
 
@@ -36,8 +36,8 @@ pub struct FileTools {
 }
 
 impl FileTools {
-    /// Resolve a path while preserving missing suffixes and resolving the deepest existing
-    /// ancestor. This prevents `..`, symlinks and Windows junctions from escaping the sandbox.
+    /// 解析路径：保留不存在的后缀部分，并解析最深一层存在的祖先目录。
+    /// 这能防止 `..`、符号链接和 Windows junction 逃出沙箱。
     pub fn sanitize(&self, path: &str) -> anyhow::Result<PathBuf> {
         let requested = PathBuf::from(path.trim());
         let joined = if requested.is_absolute() {
@@ -124,7 +124,7 @@ impl FileTools {
         Ok(out)
     }
 
-    /// Write a complete file, or append only when explicitly requested.
+    /// 写入完整文件；仅在显式要求时才追加。
     pub fn write_file(&self, path: &str, content: &str, append: bool) -> anyhow::Result<String> {
         let file = self.sanitize(path)?;
         if let Some(parent) = file.parent() {
@@ -159,7 +159,7 @@ impl FileTools {
         Ok(format!("已删除 {}", file.display()))
     }
 
-    /// Replace text exactly; `old_string` must be unique unless `replace_all=true`.
+    /// 精确替换文本；除非 `replace_all=true`，否则 `old_string` 必须唯一。
     pub fn edit_file(
         &self,
         path: &str,
@@ -197,7 +197,7 @@ impl FileTools {
         ))
     }
 
-    /// Recursively search file names with a case-insensitive `*` / `?` wildcard.
+    /// 以大小写不敏感的 `*` / `?` 通配符递归搜索文件名。
     pub fn search_files(&self, path: &str, pattern: &str) -> anyhow::Result<String> {
         let dir = self.sanitize(path)?;
         if !dir.is_dir() {
@@ -230,7 +230,7 @@ impl FileTools {
         ))
     }
 
-    /// Search text files with a regular expression and return `file:line: content` entries.
+    /// 用正则表达式搜索文本文件，返回 `文件:行号: 内容` 条目。
     pub fn grep_files(
         &self,
         path: &str,
@@ -303,7 +303,7 @@ impl FileTools {
     }
 }
 
-/// Collect regular files deterministically. Symlinks/junctions are never followed.
+/// 确定性地收集普通文件。绝不跟随符号链接/junction。
 fn walk_files(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) -> bool {
     if depth > MAX_WALK_DEPTH || out.len() >= MAX_WALK_FILES {
         return true;
@@ -367,7 +367,7 @@ fn wildcard_match(pattern: &str, name: &str) -> bool {
     pattern_index == pattern.len()
 }
 
-/// Canonicalize the deepest existing ancestor, append the missing suffix, then normalize it.
+/// 规范化最深存在的祖先目录，拼接缺失的后缀，再做归一化。
 fn canonicalize_allow_missing(path: &Path) -> anyhow::Result<PathBuf> {
     let mut ancestor = path.to_path_buf();
     let mut suffix = Vec::<OsString>::new();
@@ -515,7 +515,7 @@ mod tests {
         let outside = TempDir::new("outside");
         std::fs::write(outside.0.join("secret.txt"), "secret").unwrap();
         if symlink_dir(&outside.0, root.0.join("outside-link")).is_err() {
-            // Creating symlinks can require Developer Mode or elevated test permissions.
+            // 创建符号链接可能需要开发者模式或提权的测试权限。
             return;
         }
         let file_tools = tools(&root.0);

--- a/src-tauri/src/ai_service/skill_agent/skills.rs
+++ b/src-tauri/src/ai_service/skill_agent/skills.rs
@@ -263,7 +263,7 @@ mod tests {
         let outside = temp.path().join("outside.md");
         fs::write(&outside, "---\ndescription: secret\n---\n").unwrap();
         if symlink_file(&outside, skill_dir.join("SKILL.md")).is_err() {
-            // Creating symlinks can require Developer Mode or elevated test permissions.
+            // 创建符号链接可能需要开发者模式或提权的测试权限。
             return;
         }
 

--- a/src-tauri/src/ai_service/tools/background_command.rs
+++ b/src-tauri/src/ai_service/tools/background_command.rs
@@ -1,8 +1,8 @@
-//! Background command tasks for the main chat tool loop.
+//! 主对话工具循环的后台命令任务。
 //!
-//! A background command returns a task ID immediately. When the process exits, the bounded
-//! result is broadcast to the UI and appended to a model-only notification turn. This mirrors
-//! Kimi Code's detached-task workflow without adding a forged player line to chat history.
+//! 后台命令会立即返回任务 ID。进程退出时，受限的结果会广播给 UI，
+//! 并追加到一个仅模型可见的通知回合。这复刻了 Kimi Code 的分离式任务工作流，
+//! 且不会向对话历史里伪造玩家发言。
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -29,7 +29,7 @@ pub use command_executor::{DEFAULT_BACKGROUND_COMMAND_TIMEOUT, MAX_BACKGROUND_CO
 const MAX_CONCURRENT_BACKGROUND_COMMANDS: usize = 4;
 const NOTIFICATION_OUTPUT_CHARS: usize = 12_000;
 
-/// Concurrency slots and task ID allocation shared by every main-chat command tool instance.
+/// 每个主对话命令工具实例共享的并发槽位与任务 ID 分配器。
 pub struct BackgroundCommandManager {
     slots: Arc<Semaphore>,
     next_id: AtomicU64,
@@ -64,7 +64,7 @@ impl BackgroundCommandManager {
     }
 }
 
-/// Start a detached command and return its task metadata without waiting for completion.
+/// 启动一个分离的命令，不等待完成，直接返回其任务元数据。
 pub async fn start_background_command(
     app: AppHandle,
     sandbox_dir: PathBuf,
@@ -133,7 +133,7 @@ pub async fn start_background_command(
             Some(succeeded),
         );
 
-        // Release the command slot before waiting for the current model generation to finish.
+        // 在等待当前模型生成结束之前，先释放命令槽位。
         drop(permit);
 
         let notification = model_notification(&command, &cwd, &completion);

--- a/src-tauri/src/ai_service/tools/tool_loop.rs
+++ b/src-tauri/src/ai_service/tools/tool_loop.rs
@@ -15,8 +15,8 @@ use crate::AppState;
 use super::executor::{ToolContext, ToolExecutor};
 use super::registry::ToolRegistry;
 
-// Code/file tasks often need read -> edit -> verify cycles. Three rounds prematurely stopped
-// providers that emit one tool call per turn; eight remains bounded while allowing a useful loop.
+// 代码/文件任务常需要 读取 -> 修改 -> 验证 的循环。三轮会过早打断
+// 每轮只发一个工具调用的 provider；八轮既有上限又能保证循环可用。
 const MAX_TOOL_ROUNDS: usize = 8;
 /// 工具结果会写入角色长期记忆；限制单轮会话累计量，避免大文件/命令输出永久撑大上下文。
 const MAX_PERSISTED_TOOL_RESULT_CHARS: usize = 32_000;

--- a/src/api/tauri-events.ts
+++ b/src/api/tauri-events.ts
@@ -363,7 +363,7 @@ export function initializeTauriEventListeners() {
     uiStore.showCharacterSubtitle = role.roleSubTitle
   })
 
-  // === LLM scene tool event ===
+  // === LLM 场景工具事件 ===
 
   listen('scene:switch', (event) => {
     const payload = event.payload as { type: string; scene: SceneInfo }


### PR DESCRIPTION
## 说明

PR #583（已合并）的工具系统代码由 AI 生成，残留了一批英文注释。本 PR 将其全部翻译为中文，**纯注释改动，不涉及任何逻辑**。

## 覆盖范围（6 个文件，48 处）

| 文件 | 处数 |
|---|---|
| `skill_agent/command_executor.rs` | 25 |
| `skill_agent/file_tools.rs` | 12 |
| `tools/background_command.rs` | 7 |
| `tools/tool_loop.rs` | 2 |
| `skill_agent/skills.rs` | 1 |
| `api/tauri-events.ts` | 1 |

翻译风格与项目既有中文注释一致；技术术语（taskkill、watchdog、symlink、UAC、provider 等）保留英文原词。rustdoc 的 intra-doc link（如 `[`run_shell_command_with_timeout`]`）原样保留。

## 验证

- `cargo check` 通过（仅存量警告）