### PR TITLE
fix: 修复剧本编辑器转场重影/空白 —— FlowTab 补单根容器

### DIFF
--- a/src/components/script-editor/FlowTab.vue
+++ b/src/components/script-editor/FlowTab.vue
@@ -94,11 +94,9 @@ const openFolder = async () => {
     h-full
     min-h-0">
       <!-- 层级切换转场（流程图 ↔ 章节编辑）：与外层 tab 同一套 slide 动画；
-           out-in 避免两个文档流面板同屏互相挤压 -->
-      <Transition
-        :name="levelTransitionName"
-        mode="out-in"
-      >
+           默认模式进出同时进行，leave 面板 absolute 脱流（同 MainMenu），
+           避免两个文档流面板同屏互相挤压 -->
+      <Transition :name="levelTransitionName">
         <!-- ============ 章节流程 ============ -->
         <MenuPage v-if="store.level === 'flow'">
           <MenuItem :title="t('scriptEditor.flowTab.menuTitle')">
@@ -345,6 +343,14 @@ const openFolder = async () => {
 .slide-right-enter-active,
 .slide-right-leave-active {
   transition: transform 0.32s cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+/* 进出同时进行：leave 面板立即脱流并定死在外层容器上（同 MainMenu），
+ * 防止两个文档流面板同屏互相挤压、布局跳动 */
+.slide-left-leave-active,
+.slide-right-leave-active {
+  position: absolute;
+  inset: 0;
 }
 
 /* 左滑 → 进入章节编辑：新页从右侧推入，旧页向左滑出 */

--- a/src/components/script-editor/FlowTab.vue
+++ b/src/components/script-editor/FlowTab.vue
@@ -77,230 +77,237 @@ const openFolder = async () => {
 </script>
 
 <template>
-  <!-- ============ 章节流程 ============ -->
-  <MenuPage v-if="store.level === 'flow'">
-    <MenuItem :title="t('scriptEditor.flowTab.menuTitle')">
-      <template #header>
-        <Icon
-          icon="adventure"
-          :size="20"
-        />
-      </template>
-      <div class="flex
-        flex-wrap
-        items-center
-        gap-2
-        mb-3">
-        <button
-          class="inline-flex
-            items-center
-            gap-1
-            border
-            border-white/10
-            rounded-lg
-            px-3
-            py-[0.3rem]
-            text-[0.8rem]
-            whitespace-nowrap
-            text-white/70
-            bg-white/6
-            transition-all
-            duration-200
-            hover:enabled:text-white
-            hover:enabled:bg-white/[0.12]
-            disabled:cursor-not-allowed
-            disabled:opacity-40"
-          @click="emit('new-chapter')"
-        >
-          {{ t('scriptEditor.flowTab.newChapter') }}
-        </button>
-        <button
-          class="inline-flex
-            items-center
-            gap-1
-            border
-            border-white/10
-            rounded-lg
-            px-3
-            py-[0.3rem]
-            text-[0.8rem]
-            whitespace-nowrap
-            text-white/70
-            bg-white/6
-            transition-all
-            duration-200
-            hover:enabled:text-white
-            hover:enabled:bg-white/[0.12]
-            disabled:cursor-not-allowed
-            disabled:opacity-40"
-          @click="store.runValidation()"
-        >
-          {{ t('scriptEditor.validate.revalidate') }}
-        </button>
-        <button
-          class="inline-flex
-            items-center
-            gap-1
-            border
-            border-white/10
-            rounded-lg
-            px-3
-            py-[0.3rem]
-            text-[0.8rem]
-            whitespace-nowrap
-            text-white/70
-            bg-white/6
-            transition-all
-            duration-200
-            hover:enabled:text-white
-            hover:enabled:bg-white/[0.12]
-            disabled:cursor-not-allowed
-            disabled:opacity-40"
-          @click="openFolder"
-        >
-          {{ t('scriptEditor.flowTab.openFolder') }}
-        </button>
-      </div>
-      <ChapterFlow />
-    </MenuItem>
-  </MenuPage>
-
-  <!-- ============ 章节编辑 ============ -->
-  <!-- 注意：这里不能加 relative —— 组件根元素会收到 <component> fallthrough 的
-       absolute inset-0，两个 position 类并存时 CSS 里 relative 在后会胜出，
-       元素从「撑满容器」塌缩为「内容高度」，内部滚动链就断了 -->
-  <div
-    v-else
-    ref="editorWrap"
-    class="flex
-      w-[94%]
-      min-h-0
-      flex-1
-      gap-5
-      mx-auto
-      px-3
-      py-4"
-  >
-    <div class="flex
-      min-w-0
-      flex-1
-      flex-col">
-      <MenuItem
-        :title="t('scriptEditor.flowTab.timeline')"
-        class="fill
-          flex
-          h-full
-          min-h-0
-          flex-col"
-      >
+  <!-- 单根容器：Transition 的过渡类与 <component> fallthrough 的 absolute inset-0
+       都要求组件渲染单一根元素。此前 MenuPage 与章节编辑 div 并列两个根，
+       Transition 对非元素根（Fragment）挂不上过渡类，fallthrough 属性也被丢弃 -->
+  <div class="flex
+    flex-col
+    h-full
+    min-h-0">
+    <!-- ============ 章节流程 ============ -->
+    <MenuPage v-if="store.level === 'flow'">
+      <MenuItem :title="t('scriptEditor.flowTab.menuTitle')">
         <template #header>
           <Icon
-            icon="text"
+            icon="adventure"
             :size="20"
           />
         </template>
-        <div class="mb-2
-          flex
+        <div class="flex
+          flex-wrap
           items-center
-          gap-2">
-          <input
-            class="glass-input
-              flex-1"
-            :placeholder="t('scriptEditor.flowTab.chapterName')"
-            :value="store.chapter?.name ?? ''"
-            @change="onRename"
-          />
-          <label
+          gap-2
+          mb-3">
+          <button
             class="inline-flex
               items-center
-              gap-2
+              gap-1
+              border
+              border-white/10
+              rounded-lg
+              px-3
+              py-[0.3rem]
               text-[0.8rem]
               whitespace-nowrap
-              text-white/70"
-            :title="FOLD_HINT"
+              text-white/70
+              bg-white/6
+              transition-all
+              duration-200
+              hover:enabled:text-white
+              hover:enabled:bg-white/[0.12]
+              disabled:cursor-not-allowed
+              disabled:opacity-40"
+            @click="emit('new-chapter')"
           >
-            <Toggle
-              :checked="store.foldCompounds"
-              @change="(v: boolean) => (store.foldCompounds = v)"
-            />
-            {{ t('scriptEditor.flowTab.foldToggle') }}
-          </label>
-          <span class="shrink-0
-            text-xs
-            text-white/40">
-            {{ t('scriptEditor.chapterFlow.events', { count: store.chapter?.events.length ?? 0 }) }}
-          </span>
+            {{ t('scriptEditor.flowTab.newChapter') }}
+          </button>
+          <button
+            class="inline-flex
+              items-center
+              gap-1
+              border
+              border-white/10
+              rounded-lg
+              px-3
+              py-[0.3rem]
+              text-[0.8rem]
+              whitespace-nowrap
+              text-white/70
+              bg-white/6
+              transition-all
+              duration-200
+              hover:enabled:text-white
+              hover:enabled:bg-white/[0.12]
+              disabled:cursor-not-allowed
+              disabled:opacity-40"
+            @click="store.runValidation()"
+          >
+            {{ t('scriptEditor.validate.revalidate') }}
+          </button>
+          <button
+            class="inline-flex
+              items-center
+              gap-1
+              border
+              border-white/10
+              rounded-lg
+              px-3
+              py-[0.3rem]
+              text-[0.8rem]
+              whitespace-nowrap
+              text-white/70
+              bg-white/6
+              transition-all
+              duration-200
+              hover:enabled:text-white
+              hover:enabled:bg-white/[0.12]
+              disabled:cursor-not-allowed
+              disabled:opacity-40"
+            @click="openFolder"
+          >
+            {{ t('scriptEditor.flowTab.openFolder') }}
+          </button>
         </div>
-        <div class="min-h-0
-          flex-1
-          overflow-y-auto
-          pr-1">
-          <ChapterTimeline />
-        </div>
+        <ChapterFlow />
       </MenuItem>
-    </div>
+    </MenuPage>
 
-    <!-- 属性栏：展开时不遮挡时间线（并行查看），宽度由边缘手柄拖拽记忆 -->
+    <!-- ============ 章节编辑 ============ -->
+    <!-- 高度靠外层单根容器（flex 列）的 flex-1 撑满；absolute inset-0
+         由 <component> fallthrough 到外层容器上，不再落在此 div -->
     <div
-      class="relative
-        flex
+      v-else
+      ref="editorWrap"
+      class="flex
+        w-[94%]
         min-h-0
-        flex-col
-        transition-[flex-basis]
-        duration-300
-        ease-out"
-      :style="store.propsExpanded ? { flexBasis: `${store.propsWidth}px` } : { flexBasis: '340px' }"
+        flex-1
+        gap-5
+        mx-auto
+        px-3
+        py-4"
     >
-      <!-- 边缘竖条手柄：单击展开/折叠，按住拖拽调宽度 -->
-      <div
-        class="group/grip
-          absolute
-          left-0
-          top-0
-          bottom-0
-          z-30
-          w-2
-          -translate-x-1/2
-          cursor-ew-resize
-          touch-none"
-        :title="t('scriptEditor.flowTab.propsGrip')"
-        @pointerdown="onGripDown"
-      >
-        <div
-          class="absolute
-            left-1/2
-            top-1/2
-            h-20
-            w-[3px]
-            -translate-x-1/2
-            -translate-y-1/2
-            rounded-full
-            bg-white/20
-            transition-colors
-            group-hover/grip:bg-brand"
-        ></div>
+      <div class="flex
+        min-w-0
+        flex-1
+        flex-col">
+        <MenuItem
+          :title="t('scriptEditor.flowTab.timeline')"
+          class="fill
+            flex
+            h-full
+            min-h-0
+            flex-col"
+        >
+          <template #header>
+            <Icon
+              icon="text"
+              :size="20"
+            />
+          </template>
+          <div class="mb-2
+            flex
+            items-center
+            gap-2">
+            <input
+              class="glass-input
+                flex-1"
+              :placeholder="t('scriptEditor.flowTab.chapterName')"
+              :value="store.chapter?.name ?? ''"
+              @change="onRename"
+            />
+            <label
+              class="inline-flex
+                items-center
+                gap-2
+                text-[0.8rem]
+                whitespace-nowrap
+                text-white/70"
+              :title="FOLD_HINT"
+            >
+              <Toggle
+                :checked="store.foldCompounds"
+                @change="(v: boolean) => (store.foldCompounds = v)"
+              />
+              {{ t('scriptEditor.flowTab.foldToggle') }}
+            </label>
+            <span class="shrink-0
+              text-xs
+              text-white/40">
+              {{ t('scriptEditor.chapterFlow.events', { count: store.chapter?.events.length ?? 0 }) }}
+            </span>
+          </div>
+          <div class="min-h-0
+            flex-1
+            overflow-y-auto
+            pr-1">
+            <ChapterTimeline />
+          </div>
+        </MenuItem>
       </div>
-      <MenuItem
-        :title="t('scriptEditor.flowTab.eventProps')"
-        class="fill
+
+      <!-- 属性栏：展开时不遮挡时间线（并行查看），宽度由边缘手柄拖拽记忆 -->
+      <div
+        class="relative
           flex
-          h-full
           min-h-0
-          flex-col"
+          flex-col
+          transition-[flex-basis]
+          duration-300
+          ease-out"
+        :style="store.propsExpanded ? { flexBasis: `${store.propsWidth}px` } : { flexBasis: '340px' }"
       >
-        <template #header>
-          <Icon
-            icon="setting"
-            :size="20"
-          />
-        </template>
-        <div class="min-h-0
-          flex-1
-          overflow-y-auto
-          pr-1">
-          <EventPropertyPanel />
+        <!-- 边缘竖条手柄：单击展开/折叠，按住拖拽调宽度 -->
+        <div
+          class="group/grip
+            absolute
+            left-0
+            top-0
+            bottom-0
+            z-30
+            w-2
+            -translate-x-1/2
+            cursor-ew-resize
+            touch-none"
+          :title="t('scriptEditor.flowTab.propsGrip')"
+          @pointerdown="onGripDown"
+        >
+          <div
+            class="absolute
+              left-1/2
+              top-1/2
+              h-20
+              w-[3px]
+              -translate-x-1/2
+              -translate-y-1/2
+              rounded-full
+              bg-white/20
+              transition-colors
+              group-hover/grip:bg-brand"
+          ></div>
         </div>
-      </MenuItem>
+        <MenuItem
+          :title="t('scriptEditor.flowTab.eventProps')"
+          class="fill
+            flex
+            h-full
+            min-h-0
+            flex-col"
+        >
+          <template #header>
+            <Icon
+              icon="setting"
+              :size="20"
+            />
+          </template>
+          <div class="min-h-0
+            flex-1
+            overflow-y-auto
+            pr-1">
+            <EventPropertyPanel />
+          </div>
+        </MenuItem>
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/script-editor/FlowTab.vue
+++ b/src/components/script-editor/FlowTab.vue
@@ -24,6 +24,15 @@ const GRIP_MAX_RATIO = 0.88
 // 章节编辑容器 ref，拖拽时取它的宽度计算上限
 const editorWrap = ref<HTMLElement | null>(null)
 
+/** 层级切换转场方向：进入章节编辑（前进）→ slide-left；返回流程图（后退）→ slide-right */
+const levelTransitionName = ref<'slide-left' | 'slide-right'>('slide-left')
+watch(
+  () => store.level,
+  (level) => {
+    levelTransitionName.value = level === 'chapter' ? 'slide-left' : 'slide-right'
+  },
+)
+
 /**
  * 属性栏边缘竖条手柄：单击展开/折叠，按住拖拽调宽度。
  * 用 pointer 事件区分单击与拖拽（移动超 4px 视为拖拽），拖拽结果写入
@@ -84,231 +93,238 @@ const openFolder = async () => {
     flex-col
     h-full
     min-h-0">
-    <!-- ============ 章节流程 ============ -->
-    <MenuPage v-if="store.level === 'flow'">
-      <MenuItem :title="t('scriptEditor.flowTab.menuTitle')">
-        <template #header>
-          <Icon
-            icon="adventure"
-            :size="20"
-          />
-        </template>
-        <div class="flex
-          flex-wrap
-          items-center
-          gap-2
-          mb-3">
-          <button
-            class="inline-flex
-              items-center
-              gap-1
-              border
-              border-white/10
-              rounded-lg
-              px-3
-              py-[0.3rem]
-              text-[0.8rem]
-              whitespace-nowrap
-              text-white/70
-              bg-white/6
-              transition-all
-              duration-200
-              hover:enabled:text-white
-              hover:enabled:bg-white/[0.12]
-              disabled:cursor-not-allowed
-              disabled:opacity-40"
-            @click="emit('new-chapter')"
-          >
-            {{ t('scriptEditor.flowTab.newChapter') }}
-          </button>
-          <button
-            class="inline-flex
-              items-center
-              gap-1
-              border
-              border-white/10
-              rounded-lg
-              px-3
-              py-[0.3rem]
-              text-[0.8rem]
-              whitespace-nowrap
-              text-white/70
-              bg-white/6
-              transition-all
-              duration-200
-              hover:enabled:text-white
-              hover:enabled:bg-white/[0.12]
-              disabled:cursor-not-allowed
-              disabled:opacity-40"
-            @click="store.runValidation()"
-          >
-            {{ t('scriptEditor.validate.revalidate') }}
-          </button>
-          <button
-            class="inline-flex
-              items-center
-              gap-1
-              border
-              border-white/10
-              rounded-lg
-              px-3
-              py-[0.3rem]
-              text-[0.8rem]
-              whitespace-nowrap
-              text-white/70
-              bg-white/6
-              transition-all
-              duration-200
-              hover:enabled:text-white
-              hover:enabled:bg-white/[0.12]
-              disabled:cursor-not-allowed
-              disabled:opacity-40"
-            @click="openFolder"
-          >
-            {{ t('scriptEditor.flowTab.openFolder') }}
-          </button>
-        </div>
-        <ChapterFlow />
-      </MenuItem>
-    </MenuPage>
-
-    <!-- ============ 章节编辑 ============ -->
-    <!-- 高度靠外层单根容器（flex 列）的 flex-1 撑满；absolute inset-0
-         由 <component> fallthrough 到外层容器上，不再落在此 div -->
-    <div
-      v-else
-      ref="editorWrap"
-      class="flex
-        w-[94%]
-        min-h-0
-        flex-1
-        gap-5
-        mx-auto
-        px-3
-        py-4"
-    >
-      <div class="flex
-        min-w-0
-        flex-1
-        flex-col">
-        <MenuItem
-          :title="t('scriptEditor.flowTab.timeline')"
-          class="fill
-            flex
-            h-full
-            min-h-0
-            flex-col"
-        >
-          <template #header>
-            <Icon
-              icon="text"
-              :size="20"
-            />
-          </template>
-          <div class="mb-2
-            flex
-            items-center
-            gap-2">
-            <input
-              class="glass-input
-                flex-1"
-              :placeholder="t('scriptEditor.flowTab.chapterName')"
-              :value="store.chapter?.name ?? ''"
-              @change="onRename"
-            />
-            <label
-              class="inline-flex
-                items-center
-                gap-2
-                text-[0.8rem]
-                whitespace-nowrap
-                text-white/70"
-              :title="FOLD_HINT"
-            >
-              <Toggle
-                :checked="store.foldCompounds"
-                @change="(v: boolean) => (store.foldCompounds = v)"
-              />
-              {{ t('scriptEditor.flowTab.foldToggle') }}
-            </label>
-            <span class="shrink-0
-              text-xs
-              text-white/40">
-              {{ t('scriptEditor.chapterFlow.events', { count: store.chapter?.events.length ?? 0 }) }}
-            </span>
-          </div>
-          <div class="min-h-0
-            flex-1
-            overflow-y-auto
-            pr-1">
-            <ChapterTimeline />
-          </div>
-        </MenuItem>
-      </div>
-
-      <!-- 属性栏：展开时不遮挡时间线（并行查看），宽度由边缘手柄拖拽记忆 -->
-      <div
-        class="relative
-          flex
-          min-h-0
-          flex-col
-          transition-[flex-basis]
-          duration-300
-          ease-out"
-        :style="store.propsExpanded ? { flexBasis: `${store.propsWidth}px` } : { flexBasis: '340px' }"
+      <!-- 层级切换转场（流程图 ↔ 章节编辑）：与外层 tab 同一套 slide 动画；
+           out-in 避免两个文档流面板同屏互相挤压 -->
+      <Transition
+        :name="levelTransitionName"
+        mode="out-in"
       >
-        <!-- 边缘竖条手柄：单击展开/折叠，按住拖拽调宽度 -->
+        <!-- ============ 章节流程 ============ -->
+        <MenuPage v-if="store.level === 'flow'">
+          <MenuItem :title="t('scriptEditor.flowTab.menuTitle')">
+            <template #header>
+              <Icon
+                icon="adventure"
+                :size="20"
+              />
+            </template>
+            <div class="flex
+              flex-wrap
+              items-center
+              gap-2
+              mb-3">
+              <button
+                class="inline-flex
+                  items-center
+                  gap-1
+                  border
+                  border-white/10
+                  rounded-lg
+                  px-3
+                  py-[0.3rem]
+                  text-[0.8rem]
+                  whitespace-nowrap
+                  text-white/70
+                  bg-white/6
+                  transition-all
+                  duration-200
+                  hover:enabled:text-white
+                  hover:enabled:bg-white/[0.12]
+                  disabled:cursor-not-allowed
+                  disabled:opacity-40"
+                @click="emit('new-chapter')"
+              >
+                {{ t('scriptEditor.flowTab.newChapter') }}
+              </button>
+              <button
+                class="inline-flex
+                  items-center
+                  gap-1
+                  border
+                  border-white/10
+                  rounded-lg
+                  px-3
+                  py-[0.3rem]
+                  text-[0.8rem]
+                  whitespace-nowrap
+                  text-white/70
+                  bg-white/6
+                  transition-all
+                  duration-200
+                  hover:enabled:text-white
+                  hover:enabled:bg-white/[0.12]
+                  disabled:cursor-not-allowed
+                  disabled:opacity-40"
+                @click="store.runValidation()"
+              >
+                {{ t('scriptEditor.validate.revalidate') }}
+              </button>
+              <button
+                class="inline-flex
+                  items-center
+                  gap-1
+                  border
+                  border-white/10
+                  rounded-lg
+                  px-3
+                  py-[0.3rem]
+                  text-[0.8rem]
+                  whitespace-nowrap
+                  text-white/70
+                  bg-white/6
+                  transition-all
+                  duration-200
+                  hover:enabled:text-white
+                  hover:enabled:bg-white/[0.12]
+                  disabled:cursor-not-allowed
+                  disabled:opacity-40"
+                @click="openFolder"
+              >
+                {{ t('scriptEditor.flowTab.openFolder') }}
+              </button>
+            </div>
+            <ChapterFlow />
+          </MenuItem>
+        </MenuPage>
+
+        <!-- ============ 章节编辑 ============ -->
+        <!-- 高度靠外层单根容器（flex 列）的 flex-1 撑满；absolute inset-0
+             由 <component> fallthrough 到外层容器上，不再落在此 div -->
         <div
-          class="group/grip
-            absolute
-            left-0
-            top-0
-            bottom-0
-            z-30
-            w-2
-            -translate-x-1/2
-            cursor-ew-resize
-            touch-none"
-          :title="t('scriptEditor.flowTab.propsGrip')"
-          @pointerdown="onGripDown"
-        >
-          <div
-            class="absolute
-              left-1/2
-              top-1/2
-              h-20
-              w-[3px]
-              -translate-x-1/2
-              -translate-y-1/2
-              rounded-full
-              bg-white/20
-              transition-colors
-              group-hover/grip:bg-brand"
-          ></div>
-        </div>
-        <MenuItem
-          :title="t('scriptEditor.flowTab.eventProps')"
-          class="fill
-            flex
-            h-full
+          v-else
+          ref="editorWrap"
+          class="flex
+            w-[94%]
             min-h-0
-            flex-col"
-        >
-          <template #header>
-            <Icon
-              icon="setting"
-              :size="20"
-            />
-          </template>
-          <div class="min-h-0
             flex-1
-            overflow-y-auto
-            pr-1">
-            <EventPropertyPanel />
+            gap-5
+            mx-auto
+            px-3
+            py-4"
+        >
+          <div class="flex
+            min-w-0
+            flex-1
+            flex-col">
+            <MenuItem
+              :title="t('scriptEditor.flowTab.timeline')"
+              class="fill
+                flex
+                h-full
+                min-h-0
+                flex-col"
+            >
+              <template #header>
+                <Icon
+                  icon="text"
+                  :size="20"
+                />
+              </template>
+              <div class="mb-2
+                flex
+                items-center
+                gap-2">
+                <input
+                  class="glass-input
+                    flex-1"
+                  :placeholder="t('scriptEditor.flowTab.chapterName')"
+                  :value="store.chapter?.name ?? ''"
+                  @change="onRename"
+                />
+                <label
+                  class="inline-flex
+                    items-center
+                    gap-2
+                    text-[0.8rem]
+                    whitespace-nowrap
+                    text-white/70"
+                  :title="FOLD_HINT"
+                >
+                  <Toggle
+                    :checked="store.foldCompounds"
+                    @change="(v: boolean) => (store.foldCompounds = v)"
+                  />
+                  {{ t('scriptEditor.flowTab.foldToggle') }}
+                </label>
+                <span class="shrink-0
+                  text-xs
+                  text-white/40">
+                  {{ t('scriptEditor.chapterFlow.events', { count: store.chapter?.events.length ?? 0 }) }}
+                </span>
+              </div>
+              <div class="min-h-0
+                flex-1
+                overflow-y-auto
+                pr-1">
+                <ChapterTimeline />
+              </div>
+            </MenuItem>
           </div>
-        </MenuItem>
-      </div>
-    </div>
+
+          <!-- 属性栏：展开时不遮挡时间线（并行查看），宽度由边缘手柄拖拽记忆 -->
+          <div
+            class="relative
+              flex
+              min-h-0
+              flex-col
+              transition-[flex-basis]
+              duration-300
+              ease-out"
+            :style="store.propsExpanded ? { flexBasis: `${store.propsWidth}px` } : { flexBasis: '340px' }"
+          >
+            <!-- 边缘竖条手柄：单击展开/折叠，按住拖拽调宽度 -->
+            <div
+              class="group/grip
+                absolute
+                left-0
+                top-0
+                bottom-0
+                z-30
+                w-2
+                -translate-x-1/2
+                cursor-ew-resize
+                touch-none"
+              :title="t('scriptEditor.flowTab.propsGrip')"
+              @pointerdown="onGripDown"
+            >
+              <div
+                class="absolute
+                  left-1/2
+                  top-1/2
+                  h-20
+                  w-[3px]
+                  -translate-x-1/2
+                  -translate-y-1/2
+                  rounded-full
+                  bg-white/20
+                  transition-colors
+                  group-hover/grip:bg-brand"
+              ></div>
+            </div>
+            <MenuItem
+              :title="t('scriptEditor.flowTab.eventProps')"
+              class="fill
+                flex
+                h-full
+                min-h-0
+                flex-col"
+            >
+              <template #header>
+                <Icon
+                  icon="setting"
+                  :size="20"
+                />
+              </template>
+              <div class="min-h-0
+                flex-1
+                overflow-y-auto
+                pr-1">
+                <EventPropertyPanel />
+              </div>
+            </MenuItem>
+          </div>
+        </div>
+      </Transition>
   </div>
 </template>
 
@@ -319,5 +335,31 @@ const openFolder = async () => {
   min-height: 0;
   display: flex;
   flex-direction: column;
+}
+
+/* ========== 层级切换转场（与外层 tab / 设置面板同一套动画） ==========
+ * 只用 transform、不用 opacity：编辑器背景层带 blur 滤镜，动画里叠加
+ * 透明度变化会让 WebView 合成器在滤镜层上重绘，输入框区域会闪白 */
+.slide-left-enter-active,
+.slide-left-leave-active,
+.slide-right-enter-active,
+.slide-right-leave-active {
+  transition: transform 0.32s cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+/* 左滑 → 进入章节编辑：新页从右侧推入，旧页向左滑出 */
+.slide-left-enter-from {
+  transform: translateX(100%);
+}
+.slide-left-leave-to {
+  transform: translateX(-25%);
+}
+
+/* 右滑 → 返回流程图：新页从左侧推入，旧页向右滑出 */
+.slide-right-enter-from {
+  transform: translateX(-100%);
+}
+.slide-right-leave-to {
+  transform: translateX(25%);
 }
 </style>

--- a/src/components/views/ScriptEditor.vue
+++ b/src/components/views/ScriptEditor.vue
@@ -72,7 +72,7 @@
     <div class="relative
       h-[calc(100%-5.5rem)]
       min-h-0">
-      <Transition :name="shouldAnimate ? transitionName : ''">
+      <Transition :name="transitionName">
         <KeepAlive>
           <component
             :is="currentTabComponent"
@@ -211,7 +211,6 @@ const transitionName = ref<'slide-left' | 'slide-right'>('slide-left')
 watch(
   () => store.tab,
   (newTab, oldTab) => {
-    console.log('切换 tab', newTab, oldTab)
     if (!oldTab) return
     const prevIdx = TABS.indexOf(oldTab as TabKey)
     const nextIdx = TABS.indexOf(newTab as TabKey)
@@ -220,20 +219,6 @@ watch(
     transitionName.value = forward ? 'slide-left' : 'slide-right'
   },
 )
-
-const shouldAnimate = computed(() => {
-  // 当显示 ScriptListPanel 时禁用动画
-  console.log(
-    'store的detail是',
-    store.detail,
-    '是否为空',
-    store.detail === undefined || store.detail === null,
-  )
-  if (store.tab === 'flow' && store.detail) {
-    return false
-  }
-  return true
-})
 
 // ---- 快捷键表 ----
 const shortcutHelp = ref(false)


### PR DESCRIPTION
## 根因

`FlowTab.vue` 的 template 并列了两个根节点：

```html
<template>
  <MenuPage v-if="store.level === 'flow'">...</MenuPage>  <!-- 根 1 -->
  <div v-else ref="editorWrap">...</div>                  <!-- 根 2 -->
</template>
```

Vue 的 `<Transition>` 要求直接子节点渲染为**单一元素根**。多根 Fragment 时：

1. enter/leave 过渡类挂不到任何元素上（控制台应有 `non-element root node that cannot be animated` 警告）→ 旧面板滞留、新面板直出原位 → **重影叠印**
2. `<component class="absolute inset-0">` 的 attrs fallthrough 在多根时同样被丢弃（会有 extraneous non-props attributes 警告）→ 面板定位丢失
3. 旧面板被移除后，新面板的章节数据还在异步加载（「正在读取章节跳转关系…」）→ **整片空白**

这也解释了为什么只有「章节流程 / 打开剧本详情」这个 tab 出问题——编辑器 9 个 tab 组件里只有 FlowTab 是多根。

## 修复

- **FlowTab.vue**：两个分支包进单根 `flex flex-col h-full min-h-0` 容器。`absolute inset-0` 由 fallthrough 落在该容器上；MenuPage（`flex-1 max-h-full`）与 editorWrap（`flex-1`）的高度链在 flex 列布局下成立。原 editorWrap 上「不能加 relative」的注释前提已随包根消失，注释同步更新
- **ScriptEditor.vue**：回退 72235716 的临时禁用（`shouldAnimate`），转场动画全面恢复；顺手删掉该 commit 引入的两处 `console.log` 调试残留

## 验证

- `vue-tsc --noEmit --skipLibCheck` 通过
- 行为验证建议：打开剧本编辑器 → 章节流程 ↔ 打开剧本详情 ↔ 切其他 tab，转场应平滑推入推出、无重影无空白