### PR TITLE
fix: 素材引用带类型目录前缀时剥前缀兜底，剧本助手提示补素材写法（3/3）x2

### DIFF
--- a/src-tauri/src/ai_service/game_system/script_engine/utils/media.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/utils/media.rs
@@ -44,9 +44,26 @@ impl MediaType {
 /// Resolution order:
 /// 1. If `script_path` is `Some`, search `{script_path}/Assets/{candidate}/{file_path}`
 /// 2. Fallback: search `{data_dir}/game_data/{fallback_dir}/{file_path}`
+/// 3. 以上都失败时，剥掉引用里多余的类型目录前缀（如 `backgrounds/夜晚.webp`）重试
 ///
 /// Returns the canonical absolute path if found, `None` otherwise.
 pub fn resolve_script_media(
+    data_dir: &Path,
+    script_path: Option<&Path>,
+    file_path: &str,
+    media_type: MediaType,
+) -> Option<String> {
+    if let Some(found) = resolve_exact(data_dir, script_path, file_path, media_type) {
+        return Some(found);
+    }
+    // AI 生成/修改剧本时容易把类型目录写进引用（背景写成 backgrounds/夜晚.webp），
+    // 解析器本来就会按类型拼目录，这种写法会变成双重目录而找不到；剥掉前缀兜底一次。
+    let stripped = strip_type_dir_prefix(file_path, media_type)?;
+    resolve_exact(data_dir, script_path, stripped, media_type)
+}
+
+/// 按原始引用精确查找：先剧本 Assets 候选目录，再全局 game_data 类型目录。
+fn resolve_exact(
     data_dir: &Path,
     script_path: Option<&Path>,
     file_path: &str,
@@ -80,4 +97,30 @@ pub fn resolve_script_media(
     }
 
     None
+}
+
+/// 引用第一层是类型目录名（如 `backgrounds/`、`musics\\`）时返回剥掉前缀的部分，
+/// 否则返回 None。只剥已知类型词，自定义子目录（如 `海边/白天.webp`）不受影响；
+/// 同时拒绝绝对路径和 `..` 等不安全的剩余路径，避免兜底逻辑扩大原始查找范围。
+fn strip_type_dir_prefix<'a>(file_path: &'a str, media_type: MediaType) -> Option<&'a str> {
+    let separator = file_path.find(|c| c == '/' || c == '\\')?;
+    let (prefix, rest_with_separator) = file_path.split_at(separator);
+    let rest = rest_with_separator.get(1..)?;
+    let mut components = rest.split(|c| c == '/' || c == '\\');
+    let first = components.next()?;
+    if first.is_empty()
+        || first == "."
+        || first == ".."
+        || first.ends_with(':')
+        || components.any(|part| part.is_empty() || part == "." || part == "..")
+        || Path::new(rest).is_absolute()
+    {
+        return None;
+    }
+    let is_type_dir = prefix.eq_ignore_ascii_case(media_type.fallback_dir())
+        || media_type
+            .subdir_candidates()
+            .iter()
+            .any(|c| c.eq_ignore_ascii_case(prefix));
+    is_type_dir.then_some(rest)
 }

--- a/src-tauri/src/ai_service/skill_agent/core.rs
+++ b/src-tauri/src/ai_service/skill_agent/core.rs
@@ -67,7 +67,7 @@ fn build_script_block(sandbox_dir: &Path, script_key: Option<&str>) -> String {
         Ok(dir) => {
             let rel = dir.strip_prefix(sandbox_dir).unwrap_or(&dir);
             format!(
-                "\n\n【当前剧本上下文】\n剧本 key：{}\n剧本目录：{}（相对于文件沙箱根 {}）\n\n工作之前，请先用 list_files / read_file 查看剧本中已有的内容，再决定如何编写或修改。",
+                "\n\n【当前剧本上下文】\n剧本 key：{}\n剧本目录：{}（相对于文件沙箱根 {}）\n\n工作之前，请先用 list_files / read_file 查看剧本中已有的内容，再决定如何编写或修改。\n剧本中的素材引用（imagePath / musicPath / soundPath / ambientPath）只写素材文件名本身（如 夜晚.webp），不要带 backgrounds/、musics/ 等类型目录前缀；引擎会按事件类型自动到对应目录查找。",
                 key,
                 rel.display(),
                 sandbox_dir.display()


### PR DESCRIPTION
## 问题

实测发现：AI（主聊天工具闭环或剧本助手）修改剧本时，容易把素材引用写成带类型目录前缀的形式：

```yaml
imagePath: 'backgrounds/夜晚.webp'   # 正确写法是 夜晚.webp
musicPath: musics/夜晚音效.mp3       # 正确写法是 夜晚音效.mp3
```

`resolve_script_media` 本就会按事件类型拼目录（`game_data/backgrounds/` 等），带前缀就变成 `backgrounds/backgrounds/…` 双重目录找不到 → 校验报 asset.missing，**运行时静默清空画面/声音**。

## 修复（两层）

**硬容错** `script_engine/utils/media.rs`：精确查找失败后，若引用第一层前缀是已知类型目录词（`backgrounds`/`musics`/`ambient`/`Backgrounds`/`Pics`…，忽略大小写），剥掉前缀重试一次。

- 同时支持 `/` 与 Windows `\` 路径分隔符
- 自定义子目录（`海边/白天.webp`）不在类型词表，不剥——不掩盖真实错误
- 跨类型前缀（ambient 引用 `musics/…`）不剥——不静默错配
- 拒绝绝对路径、空路径段和 `.`/`..`，避免兜底逻辑扩大原始查找范围
- 校验器与运行时共用同一函数，行为一致

**软提示** `skill_agent/core.rs`：剧本 AI 助手的「当前剧本上下文」段补充素材引用规则——只写文件名，不带类型目录前缀，从源头减少出错。

## 验证

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- 已在本地集成构建中复现前缀问题并确认修复路径