### PR TITLE
feat: add Fish S2 TTS integration

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6269,6 +6269,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi", "chron
 serde_yaml = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
-reqwest = { version = "0.13", features = ["json", "query", "stream", "rustls", "system-proxy"], default-features = false }
+reqwest = { version = "0.13", features = ["json", "multipart", "query", "stream", "rustls", "system-proxy"], default-features = false }
 # 用 webpki-roots（内置 Mozilla CA）构造 rustls ClientConfig 注入 reqwest，
 # 绕开 reqwest 0.13 默认的 rustls-platform-verifier（Android 上需显式初始化，
 # 未初始化会 TLS panic）。版本与 reqwest 0.13.3 的 rustls 依赖保持一致（0.23）。

--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -653,7 +653,7 @@ fn parse_segments(deps: &GeneratorDeps, sentence: &str) -> Vec<EmotionSegment> {
 /// 返回当前 TTS 需要的目标翻译语言。
 fn tts_translation_language(tts_type: &str, voice_lang: &str) -> Option<&'static str> {
     match (tts_type, voice_lang) {
-        ("gsv" | "opentts" | "sbv2", "en") => Some("en"),
+        ("gsv" | "opentts" | "sbv2" | "fishs2", "en") => Some("en"),
         // IndexTTS2 官方支持中/英文：voice_lang=en 时先翻译成英文再合成
         ("indextts2", "en") => Some("en"),
         ("gsv" | "opentts", "ko") => Some("ko"),

--- a/src-tauri/src/ai_service/tts/adapters/fish_s2.rs
+++ b/src-tauri/src/ai_service/tts/adapters/fish_s2.rs
@@ -1,0 +1,148 @@
+//! Fish Audio S2 HTTP API adapter.
+//!
+//! Compatible with the s2.cpp server endpoint:
+//! `POST /generate` using `multipart/form-data` fields `voice`, `text`, and
+//! JSON-encoded `params`.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use reqwest::multipart::Form;
+use serde_json::{json, Value as JsonValue};
+use tokio::sync::Mutex;
+
+use crate::ai_service::tts::adapters::http_client;
+use crate::ai_service::tts::provider::TtsAdapter;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+
+// s2.cpp currently handles one generation at a time. LingChat synthesizes
+// emotion segments concurrently, so serialize all Fish S2 calls process-wide.
+static REQUEST_GATE: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[derive(Debug, Clone)]
+pub struct FishS2Adapter {
+    api_url: String,
+    voice: String,
+}
+
+impl FishS2Adapter {
+    pub fn new(api_url: String, voice: String) -> Result<Self> {
+        if api_url.trim().is_empty() {
+            return Err(anyhow!("Fish S2 API URL is not configured"));
+        }
+        if voice.trim().is_empty() {
+            return Err(anyhow!("Fish S2 voice is not configured"));
+        }
+
+        Ok(Self {
+            api_url: api_url.trim_end_matches('/').to_string(),
+            voice: voice.trim().to_string(),
+        })
+    }
+
+    fn endpoint(&self) -> String {
+        if self.api_url.ends_with("/generate") {
+            self.api_url.clone()
+        } else {
+            format!("{}/generate", self.api_url)
+        }
+    }
+}
+
+fn normalize_emotion(emo: &str) -> Option<&'static str> {
+    match emo.trim().to_ascii_lowercase().as_str() {
+        "happy" | "happiness" | "joy" | "joyful" | "\u{9ad8}\u{5174}" | "\u{5f00}\u{5fc3}" => {
+            Some("happy")
+        }
+        "excited" | "excitement" | "\u{5174}\u{594b}" => Some("excited"),
+        "sad" | "sadness" | "depressed" | "\u{60b2}\u{4f24}" | "\u{4f24}\u{5fc3}" => Some("sad"),
+        "angry" | "anger" | "\u{751f}\u{6c14}" => Some("angry"),
+        "fear" | "fearful" | "scared" | "\u{5bb3}\u{6015}" => Some("fearful"),
+        "surprise" | "surprised" | "\u{60ca}\u{8bb6}" => Some("surprised"),
+        "disgust" | "disgusted" | "\u{538c}\u{6076}" => Some("disgusted"),
+        "whisper" | "whispering" | "\u{8033}\u{8bed}" | "\u{4f4e}\u{8bed}" => Some("whisper"),
+        "cry" | "crying" | "sob" | "sobbing" | "\u{54ed}\u{6ce3}" | "\u{5927}\u{54ed}"
+        | "\u{54ed}\u{8154}" => Some("crying"),
+        "nervous" | "\u{614c}\u{5f20}" | "\u{7d27}\u{5f20}" => Some("nervous"),
+        "worried" | "\u{62c5}\u{5fc3}" => Some("worried"),
+        "embarrassed" | "\u{5c34}\u{5c2c}" | "\u{96be}\u{4e3a}\u{60c5}" | "\u{7f9e}\u{803b}" => {
+            Some("embarrassed")
+        }
+        "confident" | "\u{81ea}\u{4fe1}" => Some("confident"),
+        "shy" | "\u{5bb3}\u{7f9e}" => Some("shy"),
+        "serious" | "\u{8ba4}\u{771f}" | "\u{6b63}\u{7ecf}" => Some("serious"),
+        "confused" | "\u{7591}\u{60d1}" => Some("confused"),
+        "affectionate" | "\u{60c5}\u{52a8}" | "\u{5fc3}\u{52a8}" => Some("affectionate"),
+        "playful" | "\u{8c03}\u{76ae}" => Some("playful"),
+        "calm" | "\u{5e73}\u{9759}" => Some("calm"),
+        "gentle" | "\u{6e29}\u{67d4}" => Some("gentle"),
+        _ => None,
+    }
+}
+
+fn text_with_emotion(text: &str, emo: &str) -> String {
+    let text = text.trim();
+    match normalize_emotion(emo) {
+        Some(tag) if !text.starts_with('[') => format!("[{tag}]{text}"),
+        _ => text.to_string(),
+    }
+}
+
+#[async_trait]
+impl TtsAdapter for FishS2Adapter {
+    async fn generate_voice(&self, text: &str, emo: &str) -> Result<Vec<u8>> {
+        if text.trim().is_empty() {
+            return Err(anyhow!("Fish S2 input text is empty"));
+        }
+
+        let _request_guard = REQUEST_GATE.lock().await;
+
+        let params = json!({
+            "max_new_tokens": 512,
+            "temperature": 0.8,
+            "top_p": 0.9,
+            "top_k": 40
+        });
+        let synthesized_text = text_with_emotion(text, emo);
+        let form = Form::new()
+            .text("voice", self.voice.clone())
+            .text("text", synthesized_text)
+            .text("params", params.to_string());
+
+        let response = http_client()
+            .post(self.endpoint())
+            .timeout(REQUEST_TIMEOUT)
+            .multipart(form)
+            .send()
+            .await
+            .context(
+                "Failed to connect to Fish S2; ensure the local API is listening on port 3030",
+            )?;
+
+        let status = response.status();
+        let bytes = response
+            .bytes()
+            .await
+            .context("Failed to read Fish S2 response")?;
+        if !status.is_success() {
+            let body = String::from_utf8_lossy(&bytes);
+            return Err(anyhow!("Fish S2 request failed: HTTP {status}: {body}"));
+        }
+        if bytes.len() < 12 || &bytes[..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
+            return Err(anyhow!("Fish S2 response is not a valid WAV file"));
+        }
+
+        Ok(bytes.to_vec())
+    }
+
+    fn get_params(&self) -> HashMap<String, JsonValue> {
+        HashMap::from([
+            ("api_url".into(), json!(self.api_url)),
+            ("voice".into(), json!(self.voice)),
+        ])
+    }
+}

--- a/src-tauri/src/ai_service/tts/adapters/mod.rs
+++ b/src-tauri/src/ai_service/tts/adapters/mod.rs
@@ -7,11 +7,13 @@
 //! - [`vits`] — Simple-Vits-API VITS (`/voice/vits`)
 //! - [`gsv`] — GPT-SoVITS (`/tts`)
 //! - [`aivis`] — AIVIS Cloud API (`/v1/tts/synthesize`)
+//! - [`fish_s2`] — Fish Audio S2 / s2.cpp (`/generate`)
 //! - [`opentts`] — OpenAI TTS API (`/v1/audio/speech`)
 //! - [`indextts`] — IndexTTS2 presets (`/voice/indextts/presets`)
 
 pub mod aivis;
 pub mod bv2;
+pub mod fish_s2;
 pub mod gsv;
 pub mod indextts;
 pub mod opentts;

--- a/src-tauri/src/ai_service/tts/provider.rs
+++ b/src-tauri/src/ai_service/tts/provider.rs
@@ -10,6 +10,7 @@ use serde_json::Value as JsonValue;
 
 use super::adapters::aivis::AivisAdapter;
 use super::adapters::bv2::Bv2Adapter;
+use super::adapters::fish_s2::FishS2Adapter;
 use super::adapters::gsv::GsvAdapter;
 use super::adapters::indextts::IndexTtsAdapter;
 use super::adapters::opentts::OpenTtsAdapter;
@@ -20,7 +21,7 @@ use super::adapters::vits::VitsAdapter;
 /// TTS 一次合成返回原始音频字节。
 #[async_trait]
 pub trait TtsAdapter: Send + Sync {
-    /// `emo` 参数仅 IndexTTS2 使用，其它 adapter 忽略。
+    /// `emo` 参数由 IndexTTS2 和 Fish S2 使用，其它 adapter 忽略。
     async fn generate_voice(&self, text: &str, emo: &str) -> Result<Vec<u8>>;
 
     /// 返回当前适配器参数（对应 Python `get_params`）。
@@ -51,6 +52,7 @@ pub struct TtsProvider {
     pub aivis: Option<Arc<AivisAdapter>>,
     pub indextts: Option<Arc<IndexTtsAdapter>>,
     pub opentts: Option<Arc<OpenTtsAdapter>>,
+    pub fish_s2: Option<Arc<FishS2Adapter>>,
 }
 
 impl Default for TtsProvider {
@@ -68,6 +70,7 @@ impl Default for TtsProvider {
             aivis: None,
             indextts: None,
             opentts: None,
+            fish_s2: None,
         }
     }
 }
@@ -87,6 +90,7 @@ impl std::fmt::Debug for TtsProvider {
             .field("aivis", &self.aivis.is_some())
             .field("indextts", &self.indextts.is_some())
             .field("opentts", &self.opentts.is_some())
+            .field("fish_s2", &self.fish_s2.is_some())
             .finish()
     }
 }
@@ -184,6 +188,10 @@ impl TtsProvider {
                 .opentts
                 .clone()
                 .ok_or_else(|| anyhow!("OpenTTS 适配器未初始化"))?,
+            "fishs2" => self
+                .fish_s2
+                .clone()
+                .ok_or_else(|| anyhow!("Fish S2 适配器未初始化"))?,
             "" => {
                 // 旧版：未指定时优先 sbv2
                 if let Some(a) = self.sbv2.clone() {

--- a/src-tauri/src/ai_service/tts/voice_maker.rs
+++ b/src-tauri/src/ai_service/tts/voice_maker.rs
@@ -14,6 +14,7 @@ use futures_util::future::join_all;
 use crate::ai_service::message_system::processor::EmotionSegment;
 use crate::ai_service::tts::adapters::aivis::AivisAdapter;
 use crate::ai_service::tts::adapters::bv2::Bv2Adapter;
+use crate::ai_service::tts::adapters::fish_s2::FishS2Adapter;
 use crate::ai_service::tts::adapters::gsv::GsvAdapter;
 use crate::ai_service::tts::adapters::indextts::IndexTtsAdapter;
 use crate::ai_service::tts::adapters::opentts::OpenTtsAdapter;
@@ -36,6 +37,7 @@ pub struct TtsAvailability {
     pub gsv: bool,
     pub aivis: bool,
     pub opentts: bool,
+    pub fish_s2: bool,
     pub sbv2_local: bool,
 }
 
@@ -186,6 +188,9 @@ impl VoiceMaker {
         // OpenTTS 可用性：角色级 voice 优先，全局 TTS 配置兜底，任一非空即可用
         let opentts =
             non_empty(&cfg.opentts_voice) || !self.tts_config.opentts_voice.trim().is_empty();
+        // Fish S2 可使用角色级音色，也可回退到全局默认音色。
+        let fish_s2 =
+            non_empty(&cfg.fish_s2_voice) || !self.tts_config.fish_s2_voice.trim().is_empty();
         // Local SBV2 only needs a voice_id; engine readiness is checked later
         let sbv2_local = non_empty(&cfg.sbv2_local_voice_id);
 
@@ -197,6 +202,7 @@ impl VoiceMaker {
             gsv,
             aivis,
             opentts,
+            fish_s2,
             sbv2_local,
         };
     }
@@ -394,6 +400,23 @@ impl VoiceMaker {
                     }
                 }
             }
+            "fishs2" if self.availability.fish_s2 => {
+                // s2.cpp 固定返回 WAV；确保缓存文件扩展名与实际内容一致。
+                self.audio_format = "wav".to_string();
+                self.provider.audio_format = "wav".to_string();
+                let voice = if non_empty(&cfg.fish_s2_voice) {
+                    cfg.fish_s2_voice.clone().unwrap_or_default()
+                } else {
+                    self.tts_config.fish_s2_voice.clone()
+                };
+                match FishS2Adapter::new(self.tts_config.fish_s2_api_url.clone(), voice) {
+                    Ok(adapter) => self.provider.fish_s2 = Some(Arc::new(adapter)),
+                    Err(error) => {
+                        tracing::warn!("Fish S2 初始化失败: {error}");
+                        self.provider.disable();
+                    }
+                }
+            }
             "indextts2" => {
                 // IndexTTS2 仅支持中/英文：角色若残留日语配置（旧版本可选），
                 // 兜底为中文，避免日语文本被直接送去合成。
@@ -470,8 +493,8 @@ impl VoiceMaker {
             let Some(text) = segment_text_for_lang(&self.lang, seg).map(str::to_owned) else {
                 continue;
             };
-            // 将情绪分类器的预测标签传给 TTS 适配器（目前仅 IndexTTS2 消费 emo，
-            // 其余适配器忽略该参数，行为不变）
+            // 将情绪分类器的预测标签传给 TTS 适配器（IndexTTS2 与 Fish S2
+            // 会消费 emo，其余适配器忽略该参数）。
             let emo = seg.predicted.clone();
 
             let file_name = if seg.voice_file.is_empty() {

--- a/src-tauri/src/ai_service/types.rs
+++ b/src-tauri/src/ai_service/types.rs
@@ -284,6 +284,7 @@ pub struct VoiceModel {
     pub gsv_sovits_model_name: Option<String>,
     pub aivis_model_uuid: Option<String>,
     pub opentts_voice: Option<String>,
+    pub fish_s2_voice: Option<String>,
     pub sbv2_local_voice_id: Option<String>,
     pub sbv2_local_speaker_id: Option<i64>,
     pub sbv2_local_style_id: Option<i32>,

--- a/src-tauri/src/api/character.rs
+++ b/src-tauri/src/api/character.rs
@@ -29,6 +29,7 @@ const LEGACY_VOICE_MODEL_FIELDS: &[&str] = &[
     "gsv_sovits_model_name",
     "aivis_model_uuid",
     "opentts_voice",
+    "fish_s2_voice",
 ];
 
 fn remove_legacy_voice_model_fields(settings: &mut CharacterSettings) {

--- a/src-tauri/src/config/keys.rs
+++ b/src-tauri/src/config/keys.rs
@@ -55,6 +55,10 @@ pub const AIVIS_API_URL: &str = "tts.aivis_api_url";
 pub const AIVIS_API_KEY: &str = "tts.aivis_api_key";
 pub const INDEXTTS_API_URL: &str = "tts.indextts_api_url";
 
+// ========== TTS Fish Audio S2 ==========
+pub const FISH_S2_API_URL: &str = "tts.fish_s2_api_url";
+pub const FISH_S2_VOICE: &str = "tts.fish_s2_voice";
+
 // ========== TTS OpenTTS ==========
 pub const OPENTTS_API_URL: &str = "tts.opentts_api_url";
 pub const OPENTTS_API_KEY: &str = "tts.opentts_api_key";

--- a/src-tauri/src/config/tree.rs
+++ b/src-tauri/src/config/tree.rs
@@ -282,6 +282,18 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                         setting_type: "text".to_string(),
                     },
                     ConfigSetting {
+                        key: keys::FISH_S2_API_URL.to_string(),
+                        value: read_setting(app, keys::FISH_S2_API_URL, &tts_defaults.fish_s2_api_url),
+                        description: "Fish S2 API 地址".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
+                        key: keys::FISH_S2_VOICE.to_string(),
+                        value: read_setting(app, keys::FISH_S2_VOICE, &tts_defaults.fish_s2_voice),
+                        description: "Fish S2 默认音色标识".to_string(),
+                        setting_type: "text".to_string(),
+                    },
+                    ConfigSetting {
                         key: keys::OPENTTS_API_URL.to_string(),
                         value: read_setting(app, keys::OPENTTS_API_URL, &tts_defaults.opentts_api_url),
                         description: "OpenTTS API 地址（硅基流动）".to_string(),

--- a/src-tauri/src/config/tts.rs
+++ b/src-tauri/src/config/tts.rs
@@ -41,6 +41,13 @@ pub struct TtsConfig {
     #[serde(default = "default_indextts_url")]
     pub indextts_api_url: String,
 
+    /// Fish Audio S2 / s2.cpp 服务地址
+    #[serde(default = "default_fish_s2_url")]
+    pub fish_s2_api_url: String,
+    /// Fish Audio S2 默认音色标识
+    #[serde(default = "default_fish_s2_voice")]
+    pub fish_s2_voice: String,
+
     /// OpenTTS API 地址
     #[serde(default = "default_opentts_url")]
     pub opentts_api_url: String,
@@ -85,6 +92,12 @@ pub fn default_aivis_url() -> String {
 pub fn default_indextts_url() -> String {
     "http://127.0.0.1:23467/voice/indextts/presets".into()
 }
+pub fn default_fish_s2_url() -> String {
+    "http://127.0.0.1:3030".into()
+}
+pub fn default_fish_s2_voice() -> String {
+    "paimeng".into()
+}
 pub fn default_opentts_url() -> String {
     "https://api.siliconflow.cn/v1".into()
 }
@@ -114,6 +127,8 @@ impl Default for TtsConfig {
             aivis_api_url: default_aivis_url(),
             aivis_api_key: None,
             indextts_api_url: default_indextts_url(),
+            fish_s2_api_url: default_fish_s2_url(),
+            fish_s2_voice: default_fish_s2_voice(),
             opentts_api_url: default_opentts_url(),
             opentts_api_key: None,
             opentts_model: default_opentts_model(),
@@ -164,6 +179,8 @@ impl TtsConfig {
                 }
             },
             indextts_api_url: get_string(keys::INDEXTTS_API_URL, &default_indextts_url()),
+            fish_s2_api_url: get_string(keys::FISH_S2_API_URL, &default_fish_s2_url()),
+            fish_s2_voice: get_string(keys::FISH_S2_VOICE, &default_fish_s2_voice()),
             opentts_api_url: get_string(keys::OPENTTS_API_URL, &default_opentts_url()),
             opentts_api_key: {
                 let s = get_string(keys::OPENTTS_API_KEY, "");

--- a/src/components/settings/pages/SettingsCharacterInfo.vue
+++ b/src/components/settings/pages/SettingsCharacterInfo.vue
@@ -352,6 +352,7 @@ const voiceModelKeys = [
   'gsv_sovits_model_name',
   'aivis_model_uuid',
   'opentts_voice',
+  'fish_s2_voice',
 ] as const
 
 // --- Schema Definition ---
@@ -430,6 +431,7 @@ const schemas = computed<Record<string, FieldSchema[]>>(() => ({
         { label: 'gsv', value: 'gsv' },
         { label: 'aivis', value: 'aivis' },
         { label: 'opentts', value: 'opentts' },
+        { label: t('settings.characterInfo.fields.fishS2'), value: 'fishs2' },
         { label: t('settings.characterInfo.fields.localSbv2Api'), value: 'localsbv2api' },
         { label: 'indextts2', value: 'indextts2' },
       ],
@@ -450,7 +452,7 @@ const schemas = computed<Record<string, FieldSchema[]>>(() => ({
         {
           label: t('settings.characterInfo.voiceLangOptions.en'),
           value: 'en',
-          visibleIf: (s) => ['gsv', 'opentts', 'sbv2', 'sbv2api', 'indextts2'].includes(s.tts_type),
+          visibleIf: (s) => ['gsv', 'opentts', 'sbv2', 'sbv2api', 'indextts2', 'fishs2'].includes(s.tts_type),
         },
         {
           label: t('settings.characterInfo.voiceLangOptions.ko'),
@@ -559,6 +561,16 @@ const schemas = computed<Record<string, FieldSchema[]>>(() => ({
       type: 'text',
       isVoiceModel: true,
       visibleIf: (s) => s.tts_type === 'aivis',
+    },
+
+    {
+      key: 'fish_s2_voice',
+      label: t('settings.characterInfo.fields.fishS2Voice'),
+      type: 'text',
+      isVoiceModel: true,
+      realtime: true,
+      placeholder: t('settings.characterInfo.placeholders.fishS2Voice'),
+      visibleIf: (s) => s.tts_type === 'fishs2',
     },
 
     // --- Local SBV2 (localsbv2api) ---

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -229,6 +229,8 @@ export default {
         aivis_api_url: "AIVIS cloud API address",
         aivis_api_key: "AIVIS API key (formerly the AIVIS_API_KRY env var)",
         indextts_api_url: "IndexTTS2 API address",
+        fish_s2_api_url: "Fish S2 API address",
+        fish_s2_voice: "Fish S2 default voice ID",
         opentts_api_url: "OpenTTS API address (SiliconFlow)",
         opentts_api_key: "OpenTTS API key",
         opentts_model: "OpenTTS model name",
@@ -365,11 +367,14 @@ export default {
       openttsVoicePlaceholder: 'Leave blank to use the global voice ID in advanced settings',
       localSbv2Api: "Local SBV2 API",
       openttsVoiceLabel: "OpenTTS Voice ID",
+      fishS2: "Fish S2 (Local API)",
+      fishS2Voice: "Fish S2 Voice ID",
 
       openttsVoice: "OpenTTS Voice ID",
     },
     placeholders: {
       openttsVoice: "Leave empty to use the global voice ID from Advanced Settings",
+      fishS2Voice: "Leave empty to use the default voice from Advanced Settings (paimeng)",
     },
     voiceLangOptions: {
       ja: "Japanese",

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -228,6 +228,8 @@ export default {
         aivis_api_url: 'AIVIS クラウド API アドレス',
         aivis_api_key: 'AIVIS API キー（旧環境変数 AIVIS_API_KRY）',
         indextts_api_url: 'IndexTTS2 API アドレス',
+        fish_s2_api_url: 'Fish S2 API アドレス',
+        fish_s2_voice: 'Fish S2 デフォルト音色 ID',
         opentts_api_url: 'OpenTTS API アドレス（SiliconFlow）',
         opentts_api_key: 'OpenTTS API キー',
         opentts_model: 'OpenTTS モデル名',
@@ -364,11 +366,14 @@ export default {
       openttsVoicePlaceholder: '空欄の場合、詳細設定のグローバル音色 ID を使用',
       localSbv2Api: 'ローカル SBV2 API',
       openttsVoiceLabel: 'OpenTTS 音色 ID',
+      fishS2: 'Fish S2（ローカル API）',
+      fishS2Voice: 'Fish S2 音色 ID',
 
       openttsVoice: 'OpenTTS 音色識別子',
     },
     placeholders: {
       openttsVoice: '空欄の場合は詳細設定のグローバル音色識別子を使用します',
+      fishS2Voice: '空欄の場合は詳細設定のデフォルト音色（paimeng）を使用します',
     },
     voiceLangOptions: {
       ja: '日本語',

--- a/src/locales/zh-CN/settings.ts
+++ b/src/locales/zh-CN/settings.ts
@@ -229,6 +229,8 @@ export default {
         aivis_api_url: 'AIVIS 云 API 地址',
         aivis_api_key: 'AIVIS API 密钥（原环境变量 AIVIS_API_KRY）',
         indextts_api_url: 'IndexTTS2 API 地址',
+        fish_s2_api_url: 'Fish S2 API 地址',
+        fish_s2_voice: 'Fish S2 默认音色标识',
         opentts_api_url: 'OpenTTS API 地址（硅基流动）',
         opentts_api_key: 'OpenTTS API 密钥',
         opentts_model: 'OpenTTS 模型名称',
@@ -365,11 +367,14 @@ export default {
       openttsVoicePlaceholder: '留空则使用高级设置中的全局音色标识',
       localSbv2Api: '本地 SBV2 API',
       openttsVoiceLabel: 'OpenTTS 音色标识',
+      fishS2: 'Fish S2（本地 API）',
+      fishS2Voice: 'Fish S2 音色标识',
 
       openttsVoice: 'OpenTTS 音色标识',
     },
     placeholders: {
       openttsVoice: '留空则使用高级设置中的全局音色标识',
+      fishS2Voice: '留空则使用高级设置中的默认音色（paimeng）',
     },
     voiceLangOptions: {
       ja: '日语',

--- a/src/locales/zh-HK/settings.ts
+++ b/src/locales/zh-HK/settings.ts
@@ -229,6 +229,8 @@ export default {
         "aivis_api_url": "AIVIS 雲 API 地址",
         "aivis_api_key": "AIVIS API 密鑰（原環境變數 AIVIS_API_KRY）",
         "indextts_api_url": "IndexTTS2 API 地址",
+        "fish_s2_api_url": "Fish S2 API 地址",
+        "fish_s2_voice": "Fish S2 預設音色標識",
         "opentts_api_url": "OpenTTS API 地址（硅基流動）",
         "opentts_api_key": "OpenTTS API 密鑰",
         "opentts_model": "OpenTTS 模型名稱",
@@ -365,11 +367,14 @@ export default {
       "openttsVoicePlaceholder": "留空則使用進階設定中的全域音色標識",
       "localSbv2Api": "本地 SBV2 API",
       "openttsVoiceLabel": "OpenTTS 音色標識",
+      "fishS2": "Fish S2（本機 API）",
+      "fishS2Voice": "Fish S2 音色標識",
 
       "openttsVoice": "OpenTTS 音色標識"
     },
     "placeholders": {
-      "openttsVoice": "留空就用高級設定入面嘅全局音色標識"
+      "openttsVoice": "留空就用高級設定入面嘅全局音色標識",
+      "fishS2Voice": "留空就用高級設定入面嘅預設音色（paimeng）"
     },
     "voiceLangOptions": {
       "ja": "日語",


### PR DESCRIPTION
## Summary
- add a Fish Audio S2 / s2.cpp TTS adapter using the local multipart `POST /generate` API
- expose Fish S2 in role voice settings, with per-role voice IDs and global API/voice defaults
- map LingChat emotion labels (including Chinese aliases) to Fish S2 inline tags
- serialize requests because the local s2.cpp server handles one generation at a time
- force WAV output for Fish S2 responses

## Verification
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- release executable and NSIS bundle produced by `pnpm tauri build` (local updater signing key is unavailable)
- live smoke test against `http://127.0.0.1:3030/generate`