### PR TITLE
fix: 补全工具回复末尾去重与完成信号

### DIFF
--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -450,6 +450,7 @@ impl MessageGenerator {
             gs.line_list.len()
         };
         let tool_messages = tool_loop_result.tool_messages;
+        let tool_calls_seen = tool_loop_result.tool_calls_seen;
         let llm_stream = tool_loop_result.stream;
 
         let (sentence_tx, sentence_rx) =
@@ -529,7 +530,13 @@ impl MessageGenerator {
         drop(publish_tx);
 
         // producer：LLM 流 -> 句子
-        let producer = StreamProducer::new(llm_stream, sentence_tx, self.deps.app.clone(), thinking_buf);
+        let producer = StreamProducer::new(
+            llm_stream,
+            sentence_tx,
+            self.deps.app.clone(),
+            thinking_buf,
+            tool_calls_seen,
+        );
         let acc = producer.run().await.context("StreamProducer 失败")?;
 
         for t in consumer_tasks {

--- a/src-tauri/src/ai_service/message_system/producer.rs
+++ b/src-tauri/src/ai_service/message_system/producer.rs
@@ -10,6 +10,7 @@
 //! - Python 里还会调用一个 `num_end > 0 && buffer[num_end]=='】'` 的数字拆分分支，
 //!   用于拦截 `【1】` 之类非情绪 tag 的起始符；这里等价处理（仍按 `【...】` 捕获）。
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -31,6 +32,8 @@ pub struct StreamProducer {
     app: AppHandle,
     /// 与 consumer 共享的思考链缓冲：本轮生成的完整思考文本。
     thinking_buf: Arc<Mutex<String>>,
+    /// 工具闭环执行过工具后，暂存最后一条有效句子，直到能确定真正的收尾句。
+    tool_calls_seen: Arc<AtomicBool>,
 }
 
 impl StreamProducer {
@@ -39,12 +42,14 @@ impl StreamProducer {
         tx: mpsc::Sender<SentenceItem>,
         app: AppHandle,
         thinking_buf: Arc<Mutex<String>>,
+        tool_calls_seen: Arc<AtomicBool>,
     ) -> Self {
         Self {
             llm_stream,
             tx,
             app,
             thinking_buf,
+            tool_calls_seen,
         }
     }
 
@@ -60,6 +65,9 @@ impl StreamProducer {
         // 本轮回复内已投递句子的归一化集合：模型在多轮工具调用间容易把
         // 开场白复读一遍，逐字重复的句子直接丢弃（短句豁免，避免误伤语气词）。
         let mut seen_sentences = std::collections::HashSet::new();
+        // 工具闭环开始后保留最后一条有效句子，流结束时再决定它是否为最终句。
+        // 普通聊天没有工具调用，仍按原路径立即投递，不增加流式显示延迟。
+        let mut pending_sentence: Option<String> = None;
 
         while let Some(item) = self.llm_stream.next().await {
             let chunk = item?;
@@ -109,8 +117,9 @@ impl StreamProducer {
                                 &self.tx,
                                 &mut sentence,
                                 &mut sentence_index,
-                                false,
                                 &mut seen_sentences,
+                                &mut pending_sentence,
+                                &self.tool_calls_seen,
                             )
                             .await?;
                         } else {
@@ -148,8 +157,9 @@ impl StreamProducer {
                                     &self.tx,
                                     &mut sentence,
                                     &mut sentence_index,
-                                    false,
                                     &mut seen_sentences,
+                                    &mut pending_sentence,
+                                    &self.tool_calls_seen,
                                 )
                                 .await?;
                             } else {
@@ -201,10 +211,29 @@ impl StreamProducer {
             let final_content = fix_ai_generated_text(&final_content_raw);
             accumulated = fix_ai_generated_text(&accumulated);
 
-            self.tx
-                .send((final_content, sentence_index, true))
-                .await
-                .map_err(|_| anyhow::anyhow!("sentence channel closed"))?;
+            let final_is_duplicate = !final_content.is_empty()
+                && self.tool_calls_seen.load(Ordering::Acquire)
+                && Self::is_duplicate(&mut seen_sentences, &final_content);
+            if final_is_duplicate {
+                if let Some(pending) = pending_sentence.take() {
+                    tracing::info!("[dedupe] 丢弃末尾复读句子: {:.40}", final_content);
+                    Self::send_sentence(&self.tx, pending, &mut sentence_index, true).await?;
+                } else {
+                    // 理论上工具闭环启用暂存后不会走到这里；保留完成信号优先，
+                    // 避免异常格式导致前端永远停在等待状态。
+                    tracing::warn!("末尾句子重复但没有可提升为最终句的暂存内容");
+                    Self::send_sentence(&self.tx, final_content, &mut sentence_index, true).await?;
+                }
+            } else if !final_content.is_empty() {
+                if let Some(pending) = pending_sentence.take() {
+                    Self::send_sentence(&self.tx, pending, &mut sentence_index, false).await?;
+                }
+                Self::send_sentence(&self.tx, final_content, &mut sentence_index, true).await?;
+            } else if let Some(pending) = pending_sentence.take() {
+                Self::send_sentence(&self.tx, pending, &mut sentence_index, true).await?;
+            }
+        } else if let Some(pending) = pending_sentence.take() {
+            Self::send_sentence(&self.tx, pending, &mut sentence_index, true).await?;
         }
 
         Ok(accumulated)
@@ -214,20 +243,37 @@ impl StreamProducer {
         tx: &mpsc::Sender<SentenceItem>,
         sentence: &mut String,
         sentence_index: &mut usize,
-        is_final: bool,
         seen: &mut std::collections::HashSet<String>,
+        pending: &mut Option<String>,
+        tool_calls_seen: &AtomicBool,
     ) -> Result<()> {
         let s = std::mem::take(sentence);
-        // 复读去重：非最终句与本轮已投递句子逐字重复（忽略空白差异）时丢弃。
-        // 丢弃时不消耗索引，保证 publisher 收到的索引仍然连续；最终句始终放行，
-        // 确保前端一定能收到 is_final 完成信号。
-        if !is_final && Self::is_duplicate(seen, &s) {
+        // 复读去重：与本轮已接收句子逐字重复（忽略空白差异）时丢弃。
+        // 丢弃时不消耗索引，保证 publisher 收到的索引仍然连续。
+        if Self::is_duplicate(seen, &s) {
             tracing::info!("[dedupe] 丢弃复读句子: {:.40}", s);
             return Ok(());
         }
+
+        if tool_calls_seen.load(Ordering::Acquire) {
+            if let Some(previous) = pending.replace(s) {
+                Self::send_sentence(tx, previous, sentence_index, false).await?;
+            }
+            return Ok(());
+        }
+
+        Self::send_sentence(tx, s, sentence_index, false).await
+    }
+
+    async fn send_sentence(
+        tx: &mpsc::Sender<SentenceItem>,
+        sentence: String,
+        sentence_index: &mut usize,
+        is_final: bool,
+    ) -> Result<()> {
         let idx = *sentence_index;
         *sentence_index += 1;
-        tx.send((s, idx, is_final))
+        tx.send((sentence, idx, is_final))
             .await
             .map_err(|_| anyhow::anyhow!("sentence channel closed"))?;
         Ok(())
@@ -241,34 +287,5 @@ impl StreamProducer {
             return false;
         }
         !seen.insert(normalized)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn duplicate_detection_ignores_whitespace() {
-        let mut seen = std::collections::HashSet::new();
-        let first = "【高兴】\n好哒用户酱，进入工程创建阶段～\n<わかりました>";
-        assert!(!StreamProducer::is_duplicate(&mut seen, first));
-        // 逐字复读（仅空白有差异）会被识别并丢弃
-        let repeated = "【高兴】 好哒用户酱，进入工程创建阶段～ \n<わかりました>\n";
-        assert!(StreamProducer::is_duplicate(&mut seen, repeated));
-    }
-
-    #[test]
-    fn short_sentences_are_exempt() {
-        let mut seen = std::collections::HashSet::new();
-        assert!(!StreamProducer::is_duplicate(&mut seen, "【高兴】嗯"));
-        assert!(!StreamProducer::is_duplicate(&mut seen, "【高兴】嗯"));
-    }
-
-    #[test]
-    fn distinct_sentences_pass() {
-        let mut seen = std::collections::HashSet::new();
-        assert!(!StreamProducer::is_duplicate(&mut seen, "【认真】先读取参考文件再动手写"));
-        assert!(!StreamProducer::is_duplicate(&mut seen, "【高兴】已经写好落盘啦"));
     }
 }

--- a/src-tauri/src/ai_service/tools/tool_loop.rs
+++ b/src-tauri/src/ai_service/tools/tool_loop.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
@@ -34,6 +35,9 @@ pub type ToolMessageSink = Arc<Mutex<Vec<LlmMessage>>>;
 pub struct ToolLoopResult {
     pub stream: ChunkStream,
     pub tool_messages: ToolMessageSink,
+    /// 工具闭环是否真的执行过工具。生产者据此只在工具场景暂存最后一段，
+    /// 让重复的收尾段可以被丢弃，同时仍把最后一条有效回复标为完成。
+    pub tool_calls_seen: Arc<AtomicBool>,
 }
 
 /// 以流式请求执行普通聊天的工具闭环。
@@ -62,11 +66,14 @@ pub async fn stream_with_tool_loop(
         return Ok(ToolLoopResult {
             stream: presentation_stream(llm.complete_stream(&messages).await?),
             tool_messages: Arc::new(Mutex::new(Vec::new())),
+            tool_calls_seen: Arc::new(AtomicBool::new(false)),
         });
     }
 
     let tool_messages: ToolMessageSink = Arc::new(Mutex::new(Vec::new()));
     let sink = tool_messages.clone();
+    let tool_calls_seen = Arc::new(AtomicBool::new(false));
+    let tool_calls_seen_in_stream = tool_calls_seen.clone();
 
     // 流需要 'static：闭环状态全部改为持有所有权（Arc/克隆）
     let llm = llm.clone();
@@ -141,6 +148,7 @@ pub async fn stream_with_tool_loop(
                 return;
             }
 
+            tool_calls_seen_in_stream.store(true, Ordering::Release);
             let calls = tool_calls;
 
             let mut ids = HashSet::new();
@@ -224,6 +232,7 @@ pub async fn stream_with_tool_loop(
     Ok(ToolLoopResult {
         stream: Box::pin(stream),
         tool_messages,
+        tool_calls_seen,
     })
 }
 


### PR DESCRIPTION
## 问题

#590 在普通句子投递路径加入了本轮去重，但流结束时的最后一句直接发送，没有经过同一套去重判断。因此模型把旧台词复读在最终段时，重复内容仍会进入前端、历史和 TTS。

## 修复

- 工具闭环执行过工具后，共享一个轻量状态给流式生产者。
- 仅在工具场景暂存最后一条有效句子；普通聊天仍立即投递，不增加原有流式延迟。
- 最终段若为复读则丢弃，并把暂存的最后一条有效句子标记为 `is_final`，保证前端完成信号和索引连续。
- 移除 #590 合入的 3 个 `#[test]` / `#[cfg(test)]` 测试模块，继续保持相关 PR 不携带测试标签和测试代码。

## 影响

- 工具多轮回复的末尾复读不再进入显示、历史或语音合成。
- 去重后仍始终保留最终完成信号，不会让前端停在等待状态。
- 没有实际工具调用的普通聊天行为不变。

## 验证

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib --no-run`
- Windows 测试二进制全量运行：175 passed，0 failed
- 新增行扫描：无 `#[test]`、`#[cfg(test)]`、`mod tests` 或调试标记
