### PR TITLE
Fix:移除安卓端死功能

### DIFF
--- a/src/components/script-editor/tabs/FlowTab.vue
+++ b/src/components/script-editor/tabs/FlowTab.vue
@@ -8,6 +8,7 @@ import ChapterFlow from '../flow/ChapterFlow.vue'
 import ChapterTimeline from '../flow/ChapterTimeline.vue'
 import EventPropertyPanel from '../flow/EventPropertyPanel.vue'
 import { openScriptFolder } from '@/api/services/script-editor'
+import { isAndroid } from '@/utils/platform'
 
 const emit = defineEmits<{ 'new-chapter': [] }>()
 
@@ -138,6 +139,7 @@ const openFolder = async () => {
           {{ t('scriptEditor.validate.revalidate') }}
         </button>
         <button
+          v-if="!isAndroid()"
           class="inline-flex
             items-center
             gap-1

--- a/src/components/settings/SettingsNav.vue
+++ b/src/components/settings/SettingsNav.vue
@@ -125,6 +125,7 @@
         <p class="hidden xl:block whitespace-nowrap">{{ $t('nav.workshop') }}</p>
       </Button>
       <Button
+        v-if="!isAndroid()"
         ref="pluginsBtn"
         type="nav"
         class="shrink-0"
@@ -149,6 +150,7 @@ import { ref, onMounted, watch } from 'vue'
 import { useUIStore } from '../../stores/modules/ui/ui'
 import { Button } from '../base'
 import Icon from '../base/widget/Icon.vue'
+import { isAndroid } from '@/utils/platform'
 
 const props = defineProps<{}>()
 

--- a/src/components/settings/SettingsPanel.vue
+++ b/src/components/settings/SettingsPanel.vue
@@ -45,6 +45,7 @@ import {
 import SettingsNav from './SettingsNav.vue'
 import { useUIStore } from '../../stores/modules/ui/ui'
 import { ref, watch, computed, type Component } from 'vue'
+import { isAndroid } from '@/utils/platform'
 
 const uiStore = useUIStore()
 
@@ -91,7 +92,8 @@ const TABS = [
   'advance',
   'log',
   'workshop',
-  'plugins',
+  // 插件系统由 RustPython 驱动，移动端不编译（cfg(desktop)），Android 上不显示该 tab
+  ...(isAndroid() ? [] : ['plugins']),
 ] as const
 
 // 标签 → 组件映射（推入推出转场用 v-if 动态组件）

--- a/src/components/settings/pages/SettingsBackground.vue
+++ b/src/components/settings/pages/SettingsBackground.vue
@@ -23,6 +23,7 @@
             {{ $t('settings.background.scene.upload') }}
           </button>
           <button
+            v-if="!isAndroid()"
             class="px-4 py-1.5 rounded-full text-sm font-bold transition-all border shadow-lg bg-white/10 border-white/20 text-white/80 hover:bg-white/20"
             @click="handleOpenFolder"
           >
@@ -336,6 +337,7 @@ import { useGameStore } from '../../../stores/modules/game'
 import { useUIStore } from '../../../stores/modules/ui/ui'
 import { useDialogStore } from '../../../stores/modules/ui/dialog'
 import { useSettingsStore } from '../../../stores/modules/settings'
+import { isAndroid } from '@/utils/platform'
 import {
   listScenes,
   createScene,

--- a/src/components/settings/pages/SettingsCharacter.vue
+++ b/src/components/settings/pages/SettingsCharacter.vue
@@ -48,7 +48,8 @@
         <FolderOpen :size="20" />
       </template>
       <div class="space-y-2">
-        <Button type="big" @click="openCharacterFolder">{{ $t('settings.character.openFolder.button') }}</Button>
+        <!-- 打开文件夹依赖桌面端文件管理器，移动端不可用（open_folder 无 Android 分支） -->
+        <Button v-if="!isAndroid()" type="big" @click="openCharacterFolder">{{ $t('settings.character.openFolder.button') }}</Button>
       </div>
     </MenuItem>
 
@@ -106,6 +107,7 @@ import { useGameStore } from '../../../stores/modules/game'
 import { useUIStore } from '../../../stores/modules/ui/ui'
 import { useDialogStore } from '../../../stores/modules/ui/dialog'
 import type { Character as ApiCharacter, Clothes } from '../../../types'
+import { isAndroid } from '@/utils/platform'
 import RoleArchiveProgress from '@/components/ui/RoleArchiveProgress.vue'
 
 interface CharacterCardData {

--- a/src/components/settings/pages/SettingsCharacter.vue
+++ b/src/components/settings/pages/SettingsCharacter.vue
@@ -43,13 +43,13 @@
     </MenuItem>
     <RoleArchiveProgress />
 
-    <MenuItem :title="$t('settings.character.openFolder.title')" size="small">
+    <!-- 打开文件夹依赖桌面端文件管理器，移动端不可用（open_folder 无 Android 分支），整卡隐藏 -->
+    <MenuItem v-if="!isAndroid()" :title="$t('settings.character.openFolder.title')" size="small">
       <template #header>
         <FolderOpen :size="20" />
       </template>
       <div class="space-y-2">
-        <!-- 打开文件夹依赖桌面端文件管理器，移动端不可用（open_folder 无 Android 分支） -->
-        <Button v-if="!isAndroid()" type="big" @click="openCharacterFolder">{{ $t('settings.character.openFolder.button') }}</Button>
+        <Button type="big" @click="openCharacterFolder">{{ $t('settings.character.openFolder.button') }}</Button>
       </div>
     </MenuItem>
 

--- a/src/components/settings/pages/SettingsPlugins.vue
+++ b/src/components/settings/pages/SettingsPlugins.vue
@@ -146,6 +146,7 @@ import Icon from '@/components/base/widget/Icon.vue'
 import { Toggle } from '@/components/base'
 import { i18n } from '@/locales'
 import { useDialogStore } from '@/stores/modules/ui/dialog'
+import { isAndroid } from '@/utils/platform'
 import {
   listPlugins,
   setPluginEnabled,
@@ -216,5 +217,10 @@ const removePlugin = async (plugin: PluginInfo) => {
   }
 }
 
-onMounted(load)
+// 插件系统由 RustPython 驱动，移动端不编译后端（cfg(desktop)），
+// 导航与 TABS 已隐藏入口；此处双保险：Android 上不发起 invoke 避免报错。
+onMounted(() => {
+  if (isAndroid()) return
+  load()
+})
 </script>

--- a/src/components/settings/pages/SettingsTools.vue
+++ b/src/components/settings/pages/SettingsTools.vue
@@ -164,6 +164,10 @@
           {{ navLabel(selected) }}
         </h2>
         <p class="text-sm text-gray-400 mb-4 px-1">{{ $t('ui.toolCalls.otherToolsHint') }}</p>
+        <!-- 命令执行依赖本机 shell（cmd/sh），非 Windows 平台（如 Android）不可用 -->
+        <p v-if="!isWindows()" class="text-sm text-amber-400 px-1 mb-2">
+          {{ $t('ui.toolCalls.commandWindowsOnly') }}
+        </p>
         <div class="flex items-center gap-3 py-2.5 px-1">
           <Toggle
             :checked="form.groups[selected] ?? false"
@@ -241,6 +245,7 @@ import {
   type ToolSettings,
 } from '@/api/services/tool-settings'
 import Toggle from '@/components/base/widget/Toggle.vue'
+import { isWindows } from '@/utils/platform'
 
 const { t, te } = useI18n()
 

--- a/src/components/views/MainChat.vue
+++ b/src/components/views/MainChat.vue
@@ -26,7 +26,9 @@
       >
         <h3 class="hidden xl:block">{{ $t('views.mainChat.auto') }}</h3>
       </Button>
+      <!-- 桌宠模式依赖 Windows 透明置顶窗口与 hit-test（lib.rs 为 cfg(windows)），Android 不可用 -->
       <Button
+        v-if="!isAndroid()"
         type="nav"
         icon="character"
         @click="goToPetMode"
@@ -63,6 +65,7 @@ import { eventQueue } from '@/core/events/event-queue'
 
 import GameExtraUI from '../game/standard/GameExtraUI.vue'
 import ImageSourcePicker from '@/components/ui/ImageSourcePicker.vue'
+import { isAndroid } from '@/utils/platform'
 
 const LOADING_STORAGE_KEY = 'lingchat_loading_shown'
 

--- a/src/locales/en/ui.ts
+++ b/src/locales/en/ui.ts
@@ -164,6 +164,7 @@ export default {
     commandDeleteApprovalTitle: "Confirm Deletion Command",
     commandDeleteApprovalMessage: "This command may delete files:\n\n{command}\n\nWorking directory: {cwd}\n\nDeletion usually cannot be undone. Allow it to run?",
     commandHint: "You will be asked to confirm each command in a popup; the uac parameter requests admin rights (Windows UAC prompt)",
+    commandWindowsOnly: "⚠ Command execution is available on Windows only; shell commands cannot run on this platform",
     commandAutoApprove: "Run without confirmation (no popup before commands run)",
     commandAutoApproveHint: "⚠ Dangerous! Commands can run without consent; detected delete commands remain controlled by the separate switch below",
     commandDeleteAutoApprove: "Run delete commands without confirmation",

--- a/src/locales/ja/ui.ts
+++ b/src/locales/ja/ui.ts
@@ -163,6 +163,7 @@ export default {
     commandDeleteApprovalTitle: '削除コマンドの確認',
     commandDeleteApprovalMessage: 'このコマンドはファイルを削除する可能性があります：\n\n{command}\n\n作業ディレクトリ：{cwd}\n\n削除は通常元に戻せません。実行を許可しますか？',
     commandHint: '実行のたびに確認ポップアップが出ます。uac パラメータで管理者権限（Windows の UAC）を要求できます',
+    commandWindowsOnly: '⚠ コマンド実行は Windows のみ利用可能です。現在のプラットフォームでは shell コマンドを実行できません',
     commandAutoApprove: '確認なしで自動実行（ポップアップを出さない）',
     commandAutoApproveHint: '⚠ 危険！コマンドを同意なしで実行します。検出した削除コマンドは下の独立スイッチに従います',
     commandDeleteAutoApprove: '削除コマンドを確認なしで実行',

--- a/src/locales/zh-CN/ui.ts
+++ b/src/locales/zh-CN/ui.ts
@@ -163,6 +163,7 @@ export default {
     commandDeleteApprovalTitle: '删除命令确认',
     commandDeleteApprovalMessage: '检测到这条命令可能删除文件：\n\n{command}\n\n工作目录：{cwd}\n\n删除通常无法撤销，是否允许执行？',
     commandHint: '每次执行前会弹窗请你确认命令内容；uac 参数可请求管理员权限（Windows 弹 UAC 框）',
+    commandWindowsOnly: '⚠ 命令执行仅 Windows 可用，当前平台无法运行 shell 命令',
     commandAutoApprove: '免确认自动执行（ta 跑命令前不再弹窗）',
     commandAutoApproveHint: '⚠ 危险！开启后 ta 可以不经你同意运行命令；识别到的删除命令仍由下方独立开关控制',
     commandDeleteAutoApprove: '删除命令免确认（检测到删除操作时不再弹窗）',

--- a/src/locales/zh-HK/ui.ts
+++ b/src/locales/zh-HK/ui.ts
@@ -164,6 +164,7 @@ export default {
     "commandDeleteApprovalTitle": "刪除命令確認",
     "commandDeleteApprovalMessage": "偵測到呢條命令可能會刪除檔案：\n\n{command}\n\n工作目錄：{cwd}\n\n刪除通常無法復原，允許執行嗎？",
     "commandHint": "每次執行前都會彈窗請你確認命令內容；uac 參數可要求管理員權限（Windows 彈 UAC 框）",
+    "commandWindowsOnly": "⚠ 命令執行僅 Windows 可用，當前平台無法運行 shell 命令",
     "commandAutoApprove": "免確認自動執行（ta 跑命令前唔再彈窗）",
     "commandAutoApproveHint": "⚠ 危險！開咗之後 ta 可以唔經你同意跑命令；識別到嘅刪除命令仍由下面獨立開關控制",
     "commandDeleteAutoApprove": "刪除命令免確認（偵測到刪除操作時唔再彈窗）",

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -10,3 +10,10 @@ export function isAndroid(): boolean {
   if (typeof navigator === 'undefined') return false
   return /android/i.test(navigator.userAgent)
 }
+
+/** 是否 Windows 桌面端（WebView2 UA 含 "Windows NT"，Linux 为 "X11; Linux"）。
+ *  用于「仅 Windows 可用」的工具/功能标注。 */
+export function isWindows(): boolean {
+  if (typeof navigator === 'undefined') return false
+  return /windows/i.test(navigator.userAgent)
+}


### PR DESCRIPTION
### 背景
Android 端存在多处依赖桌面端能力的入口（Windows 文件管理器、透明置顶窗口、RustPython 插件、shell 环境），移动端上要么静默失效、要么直接报错。本 PR 统一处理：不可用功能在 Android 上隐藏入口或明确标注，全部为前端改动，后端零变更。

## 改动清单

### 1. fix: 插件系统由 RustPython 驱动仅桌面端可用，Android 端隐藏插件入口插件系统后端由 RustPython 驱动，移动端不编译（cfg(desktop)），Android 上插件功能完全不可用。三层防御隐藏：
- SettingsNav.vue：导航「插件」按钮 v-if="!isAndroid()"
- SettingsPanel.vue：TABS 数组条件展开，Android 下移除 'plugins' 标签
- SettingsPlugins.vue：onMounted 条件加载，Android 下不发 invoke 避免报错

### 2. fix: Android 端隐藏打开文件夹按钮（open_folder 无移动端实现，静默失效）
open_folder 系列 command 无 Android 分支，调用后静默失败。三处按钮加 v-if="!isAndroid()"：
- script-editor/tabs/FlowTab.vue（"打开剧本文件夹"按钮）
- settings/pages/SettingsBackground.vue（"打开场景文件夹"按钮，保留「上传」按钮）
- settings/pages/SettingsCharacter.vue（"打开角色文件夹"按钮，按钮级）

### 3. feat: 工具配置-命令执行栏标注仅 Windows 可用（移动端无 shell 环境）
命令执行工具依赖本机 shell（cmd/sh），移动端无 shell 环境。非 Windows 平台显示琥珀色警告标注（保留配置项，仅提示不可用）：
- utils/platform.ts：新增 isWindows() 工具函数
- settings/pages/SettingsTools.vue：非 Windows 时显示 commandWindowsOnly 警告
- 4 个语言包（zh-CN / zh-HK / en / ja）新增对应词条

### 4. feat: Android 隐藏聊天页桌宠按钮（桌宠模式依赖 Windows 透明置顶窗口）
桌宠模式依赖 Windows 透明置顶窗口 + hit-test 轮询（后端 cfg(windows)），移动端无此能力：
- views/MainChat.vue：「桌宠」导航按钮 v-if="!isAndroid()"安卓端不在显示桌宠入口

### 5. fix: 角色设置「打开文件夹」整卡在移动端隐藏（原来只隐藏按钮，卡片残留）
修复第 2 项的遗留问题——按钮隐藏后卡片外壳仍显示，Android 上出现空卡片：
- settings/pages/SettingsCharacter.vue：v-if 上移至整个 MenuItem 卡片

### 验证
✅ vue-tsc --noEmit 类型检查通过
平台判断基于 UA（isAndroid / isWindows），无需 Tauri API，纯前端逻辑
桌面端（Windows）行为完全不变