### PR TITLE
fix：为剧本编辑器清除当前对话和删除对话添加二次确认

### DIFF
--- a/src/components/script-editor/agent/AgentChatPanel.vue
+++ b/src/components/script-editor/agent/AgentChatPanel.vue
@@ -108,7 +108,7 @@
           text-white/40
           transition-colors
           hover:text-white/70"
-        @click="store.clearConversation()"
+        @click="clearConversation"
       >
         {{ t('scriptEditor.agentChat.clearConversation') }}
       </button>
@@ -562,5 +562,11 @@ async function removeConversation(c: ConversationInfo) {
   )
     return
   await store.deleteConversation(c.id)
+}
+
+/** 清空当前对话为危险操作，先弹确认框（移动端容易误触）。 */
+async function clearConversation() {
+  if (!window.confirm(t('scriptEditor.agentChat.clearConfirm'))) return
+  await store.clearConversation()
 }
 </script>

--- a/src/components/script-editor/agent/AgentChatPanel.vue
+++ b/src/components/script-editor/agent/AgentChatPanel.vue
@@ -477,6 +477,7 @@
 import { nextTick, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Icon } from '@/components/base'
+import { useDialogStore } from '@/stores/modules/ui/dialog'
 import { useAgentStore } from '@/stores/modules/agent'
 import AgentThinkingBlock from './AgentThinkingBlock.vue'
 import AgentToolCard from './AgentToolCard.vue'
@@ -486,6 +487,7 @@ import type { ChatRound } from '@/stores/modules/agent/state'
 
 const { t } = useI18n()
 const store = useAgentStore()
+const dialogStore = useDialogStore()
 
 const draft = ref('')
 const composing = ref(false)
@@ -566,7 +568,7 @@ async function removeConversation(c: ConversationInfo) {
 
 /** 清空当前对话为危险操作，先弹确认框（移动端容易误触）。 */
 async function clearConversation() {
-  if (!window.confirm(t('scriptEditor.agentChat.clearConfirm'))) return
+  if (!(await dialogStore.confirm(t('scriptEditor.agentChat.clearConfirm')))) return
   await store.clearConversation()
 }
 </script>

--- a/src/components/script-editor/agent/AgentChatPanel.vue
+++ b/src/components/script-editor/agent/AgentChatPanel.vue
@@ -555,14 +555,12 @@ async function send() {
 }
 
 async function removeConversation(c: ConversationInfo) {
-  if (
-    !window.confirm(
-      t('scriptEditor.agentChat.deleteConfirm', {
-        title: c.title || t('scriptEditor.agentChat.conversationTitle', { id: c.id }),
-      }),
-    )
+  const ok = await dialogStore.confirm(
+    t('scriptEditor.agentChat.deleteConfirm', {
+      title: c.title || t('scriptEditor.agentChat.conversationTitle', { id: c.id }),
+    }),
   )
-    return
+  if (!ok) return
   await store.deleteConversation(c.id)
 }
 

--- a/src/locales/en/scriptEditor.ts
+++ b/src/locales/en/scriptEditor.ts
@@ -524,6 +524,7 @@ export default {
     deleteConversation: 'Delete this conversation',
     conversationTitle: 'Conversation {id}',
     clearConversation: 'Clear current conversation',
+    clearConfirm: 'Clear the current conversation and all its messages? This cannot be undone.',
     tokenUsage: 'Token usage',
     input: 'Input',
     output: 'Output',

--- a/src/locales/ja/scriptEditor.ts
+++ b/src/locales/ja/scriptEditor.ts
@@ -524,6 +524,7 @@ export default {
     deleteConversation: 'この会話を削除',
     conversationTitle: '会話 {id}',
     clearConversation: '現在の会話をクリア',
+    clearConfirm: '現在の会話とすべてのメッセージをクリアしますか？この操作は元に戻せません。',
     tokenUsage: 'トークン使用量',
     input: '入力',
     output: '出力',

--- a/src/locales/zh-CN/scriptEditor.ts
+++ b/src/locales/zh-CN/scriptEditor.ts
@@ -494,6 +494,7 @@ export default {
     deleteConversation: '删除此对话',
     conversationTitle: '对话 {id}',
     clearConversation: '清空当前对话',
+    clearConfirm: '确定清空当前对话及其全部消息吗？此操作不可撤销。',
     tokenUsage: 'Token 用量',
     input: '输入',
     output: '输出',

--- a/src/locales/zh-HK/scriptEditor.ts
+++ b/src/locales/zh-HK/scriptEditor.ts
@@ -492,6 +492,7 @@ export default {
     deleteConversation: '刪除此對話',
     conversationTitle: '對話 {id}',
     clearConversation: '清空當前對話',
+    clearConfirm: '確定清空當前對話及其全部消息嗎？此操作不可撤銷。',
     tokenUsage: 'Token 用量',
     input: '輸入',
     output: '輸出',


### PR DESCRIPTION
## 背景
安卓端使用剧本编辑器时容易误触清空对话和删除对话，为防止出现误删的情况添加了二次确认

改动
1. 清空当前对话增加二次确认弹窗
顶栏「清空当前对话」原先点击即清空且不可撤销，移动端易误触。现改为先弹确认框，确认后才执行清空。

2. 确认弹窗使用 dialogStore.confirm
项目自带的确认弹窗（与角色删除、存档删除同一模式），全平台可用。

3. 删除对话确使用 dialogStore.confirm
与清空对话保持一致。

涉及文件
src/components/script-editor/agent/AgentChatPanel.vue
src/locales/{zh-CN,zh-HK,en,ja}/scriptEditor.ts（新增 clearConfirm 词条）
已通过 vue-tsc 检查。