### PR TITLE
 fix：安卓端音乐/环境音无法正常播放

### DIFF
--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
-    <!-- 音频设备名称授权（getUserMedia 解锁 enumerateDevices 的真实设备名） -->
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <!-- 音频设备名称授权（getUserMedia 解锁 enumerateDevices 的真实设备名）已移除：
+         音频输出设备切换仅桌面端可用，Android 上 audioOutputManager 直接跳过，无需麦克风权限 -->
 
     <!-- AndroidTV support -->
     <uses-feature android:name="android.software.leanback" android:required="false" />

--- a/src/components/game/standard/GameBackground.vue
+++ b/src/components/game/standard/GameBackground.vue
@@ -126,16 +126,22 @@ const backgroundSrc = computed(() => {
 // 统一转换入口：currentBackgroundMusic 存储原始路径，在此一次性转换
 // Android 上 asset 协议有 1MB 响应上限（见 toPlayableMediaUrl），需整文件 fetch 成 blob
 const backgroundMusicSrc = ref('None')
+let bgmLoadSeq = 0
 watch(
   () => uiStore.currentBackgroundMusic,
   async (src) => {
+    const seq = ++bgmLoadSeq
     if (!src || src === 'None') {
       backgroundMusicSrc.value = 'None'
       return
     }
     try {
-      backgroundMusicSrc.value = await toPlayableMediaUrl(src)
+      const url = await toPlayableMediaUrl(src)
+      // 竞态守卫：期间已切换过歌曲则丢弃过期结果
+      if (seq !== bgmLoadSeq) return
+      backgroundMusicSrc.value = url
     } catch (e) {
+      if (seq !== bgmLoadSeq) return
       console.warn('背景音乐加载失败:', src, e)
       backgroundMusicSrc.value = 'None'
     }
@@ -309,6 +315,8 @@ watch(
 const onStoppedDone = (id: string) => {
   const idx = displayTracks.value.findIndex((x) => x.id === id)
   if (idx >= 0) displayTracks.value.splice(idx, 1)
+  // 同步清理已解析的播放 URL，避免残留
+  playableSrcMap.value.delete(id)
 }
 </script>
 

--- a/src/components/game/standard/GameBackground.vue
+++ b/src/components/game/standard/GameBackground.vue
@@ -94,6 +94,7 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
 import { convertFileSrc } from '@tauri-apps/api/core'
+import { toPlayableMediaUrl } from '@/utils/mediaUrl'
 import { useUIStore } from '../../../stores/modules/ui/ui'
 import { useGameStore } from '../../../stores/modules/game'
 import ImageAcrossFade from '@/components/ui/ImageAcrossFade.vue'
@@ -123,11 +124,24 @@ const backgroundSrc = computed(() => {
 })
 
 // 统一转换入口：currentBackgroundMusic 存储原始路径，在此一次性转换
-const backgroundMusicSrc = computed(() => {
-  const src = uiStore.currentBackgroundMusic
-  if (!src || src === 'None') return 'None'
-  return convertFileSrc(src)
-})
+// Android 上 asset 协议有 1MB 响应上限（见 toPlayableMediaUrl），需整文件 fetch 成 blob
+const backgroundMusicSrc = ref('None')
+watch(
+  () => uiStore.currentBackgroundMusic,
+  async (src) => {
+    if (!src || src === 'None') {
+      backgroundMusicSrc.value = 'None'
+      return
+    }
+    try {
+      backgroundMusicSrc.value = await toPlayableMediaUrl(src)
+    } catch (e) {
+      console.warn('背景音乐加载失败:', src, e)
+      backgroundMusicSrc.value = 'None'
+    }
+  },
+  { immediate: true },
+)
 
 // 背景光照滤镜
 const bgLightingFilter = computed(() => {
@@ -189,17 +203,23 @@ const onStarfieldReady = (instance: any): void => {
 }
 
 // 只保留监听瞬时音效 (由于音效很短，不需要淡入淡出，保持原生调用)
+// currentSoundEffect 存原始路径（与 music/ambient 同一约定），在此统一转换
 watch(
   () => uiStore.currentSoundEffect,
-  (newAudioUrl: string | null | undefined) => {
-    if (soundEffectPlayer.value && newAudioUrl && newAudioUrl !== 'None') {
+  (rawPath: string | null | undefined) => {
+    if (soundEffectPlayer.value && rawPath && rawPath !== 'None') {
       // 重置 src 确保相同路径的重复事件也能触发播放
       soundEffectPlayer.value.pause()
       soundEffectPlayer.value.currentTime = 0
       soundEffectPlayer.value.src = ''
-      soundEffectPlayer.value.src = newAudioUrl
-      soundEffectPlayer.value.load()
-      soundEffectPlayer.value.play()
+      void toPlayableMediaUrl(rawPath)
+        .then((url) => {
+          if (!soundEffectPlayer.value) return
+          soundEffectPlayer.value.src = url
+          soundEffectPlayer.value.load()
+          soundEffectPlayer.value.play().catch(() => {})
+        })
+        .catch((e) => console.warn('音效加载失败:', rawPath, e))
     }
   },
 )
@@ -222,7 +242,18 @@ const displayTracks = ref<
 
 const effectiveVolume = (trackVolume: number) => (trackVolume / 100) * (uiStore.ambientVolume / 100)
 
-const srcOf = (d: { src: string }) => (d.src.startsWith('blob:') ? d.src : convertFileSrc(d.src))
+// Android 上 asset 协议有 1MB 响应上限，整文件 fetch 成 blob 后替换 src（见 toPlayableMediaUrl）
+const playableSrcMap = ref(new Map<string, string>())
+const resolvePlayableSrc = async (d: { id: string; src: string }) => {
+  try {
+    playableSrcMap.value.set(d.id, await toPlayableMediaUrl(d.src))
+  } catch (e) {
+    console.warn('环境音加载失败:', d.src, e)
+  }
+}
+
+const srcOf = (d: { src: string; id: string }) =>
+  playableSrcMap.value.get(d.id) ?? (d.src.startsWith('blob:') ? d.src : convertFileSrc(d.src))
 
 // 同步 store 轨道到 displayTracks：新增则挂载，移除则标记离场触发淡出
 watch(
@@ -233,7 +264,7 @@ watch(
     for (const t of newTracks) {
       const d = displayTracks.value.find((x) => x.id === t.id)
       if (!d) {
-        displayTracks.value.push({
+        const entry = {
           id: t.id,
           src: t.src,
           volume: effectiveVolume(t.volume),
@@ -241,7 +272,10 @@ watch(
           fade: t.fade ?? true,
           paused: t.paused ?? false,
           stopped: false,
-        })
+        }
+        displayTracks.value.push(entry)
+        // Android 上异步把 src 换成 blob URL（完成前组件先以 asset URL 挂载，失败会被 src 更新覆盖）
+        void resolvePlayableSrc(entry)
       } else if (!d.stopped) {
         d.src = t.src
         d.volume = effectiveVolume(t.volume)

--- a/src/components/game/standard/GameBackground.vue
+++ b/src/components/game/standard/GameBackground.vue
@@ -123,8 +123,7 @@ const backgroundSrc = computed(() => {
   return convertFileSrc(bg)
 })
 
-// 统一转换入口：currentBackgroundMusic 存储原始路径，在此一次性转换
-// Android 上 asset 协议有 1MB 响应上限（见 toPlayableMediaUrl），需整文件 fetch 成 blob
+// 统一转换入口：currentBackgroundMusic 存原始路径，此处转可播放 URL（Android 走 blob，见 toPlayableMediaUrl）
 const backgroundMusicSrc = ref('None')
 let bgmLoadSeq = 0
 watch(
@@ -248,7 +247,7 @@ const displayTracks = ref<
 
 const effectiveVolume = (trackVolume: number) => (trackVolume / 100) * (uiStore.ambientVolume / 100)
 
-// Android 上 asset 协议有 1MB 响应上限，整文件 fetch 成 blob 后替换 src（见 toPlayableMediaUrl）
+// 播放 URL 异步解析（Android 换 blob，见 toPlayableMediaUrl）
 const playableSrcMap = ref(new Map<string, string>())
 const resolvePlayableSrc = async (d: { id: string; src: string }) => {
   try {
@@ -280,7 +279,7 @@ watch(
           stopped: false,
         }
         displayTracks.value.push(entry)
-        // Android 上异步把 src 换成 blob URL（完成前组件先以 asset URL 挂载，失败会被 src 更新覆盖）
+        // 先以 asset URL 挂载，异步换 blob（Android 上 asset 协议有 1MB 响应上限）
         void resolvePlayableSrc(entry)
       } else if (!d.stopped) {
         d.src = t.src

--- a/src/core/events/processors/sound-processor.ts
+++ b/src/core/events/processors/sound-processor.ts
@@ -1,4 +1,3 @@
-import { convertFileSrc } from '@tauri-apps/api/core'
 import type { IEventProcessor } from '../event-processor'
 import type { ScriptSoundEvent } from '../../../types'
 import { useGameStore } from '../../../stores/modules/game'
@@ -15,16 +14,7 @@ export default class SoundProcessor implements IEventProcessor {
 
     gameStore.currentStatus = 'presenting'
 
-    let url = 'None'
-
-    if (event.soundPath) {
-      try {
-        url = convertFileSrc(event.soundPath)
-      } catch {
-        url = 'None'
-      }
-    }
-
-    uiStore.currentSoundEffect = url
+    // 存储原始文件路径，由 GameBackground.vue 统一转换（与 music/ambient 同一约定）
+    uiStore.currentSoundEffect = event.soundPath || 'None'
   }
 }

--- a/src/utils/audioOutputManager.ts
+++ b/src/utils/audioOutputManager.ts
@@ -1,5 +1,5 @@
 /**
- * 全局音频输出设备管理器
+ * 全局音频输出设备管理器（仅桌面端）
  *
  * 基于浏览器标准 API：
  * - 枚举：navigator.mediaDevices.enumerateDevices()（audiooutput）
@@ -9,9 +9,14 @@
  * 构造器，实现全局（背景音乐、角色语音、音效、环境音、打字音效等）音频输出设备切换。
  *
  * 设备选择持久化在设置 store 的 audio.outputDeviceId（'' = 跟随系统默认）。
+ *
+ * ⚠️ Android 上禁用：安卓的音频路由（蓝牙/外放）由系统管理，本管理器对
+ * WebView 媒体栈的 setSinkId 调用与 load() 重启会干扰播放（曾导致安卓端
+ * 音乐「部分可播、部分播一会即停、部分完全无法播放」的回归），故 init 时跳过。
  */
 import { ref } from 'vue'
 import { useSettingsStore } from '@/stores/modules/settings'
+import { isAndroid } from '@/utils/platform'
 
 export interface OutputDevice {
   deviceId: string
@@ -334,10 +339,13 @@ export async function setDevice(id: string) {
   )
 }
 
-/** 全局初始化（应用启动时调用一次，需在 pinia 就绪后） */
+/** 全局初始化（应用启动时调用一次，需在 pinia 就绪后；Android 上禁用） */
 export async function initAudioOutputManager() {
   if (initialized) return
   initialized = true
+
+  // Android 跳过：见文件头注释（setSinkId 对 WebView 媒体栈的干扰曾导致播放回归）
+  if (isAndroid()) return
 
   const hasApi =
     typeof navigator !== 'undefined' &&

--- a/src/utils/audioOutputManager.ts
+++ b/src/utils/audioOutputManager.ts
@@ -10,9 +10,8 @@
  *
  * 设备选择持久化在设置 store 的 audio.outputDeviceId（'' = 跟随系统默认）。
  *
- * ⚠️ Android 上禁用：安卓的音频路由（蓝牙/外放）由系统管理，本管理器对
- * WebView 媒体栈的 setSinkId 调用与 load() 重启会干扰播放（曾导致安卓端
- * 音乐「部分可播、部分播一会即停、部分完全无法播放」的回归），故 init 时跳过。
+ * ⚠️ Android 上禁用：设备切换是桌面功能，安卓的音频路由（蓝牙/外放）
+ * 由系统管理，无需在此干预 WebView 媒体栈。
  */
 import { ref } from 'vue'
 import { useSettingsStore } from '@/stores/modules/settings'
@@ -344,7 +343,7 @@ export async function initAudioOutputManager() {
   if (initialized) return
   initialized = true
 
-  // Android 跳过：见文件头注释（setSinkId 对 WebView 媒体栈的干扰曾导致播放回归）
+  // Android 跳过：桌面功能，见文件头注释
   if (isAndroid()) return
 
   const hasApi =

--- a/src/utils/mediaUrl.ts
+++ b/src/utils/mediaUrl.ts
@@ -1,0 +1,39 @@
+/**
+ * 媒体文件播放 URL 转换工具
+ *
+ * - 桌面端：直接返回 asset 协议 URL（WebView2 能正确处理 206 分块流）
+ * - Android：asset 协议每个响应最多 1MB（tauri 源码硬编码 MAX_LEN=1000*1024，
+ *   无法配置）。安卓媒体栈对 open-ended Range（bytes=N-）的截断响应不会
+ *   继续请求后续分块——大文件「播一会就停」（消耗完前两个 1MB 块后卡住），
+ *   OGG 探测（需要文件末尾页）直接失败。因此改为整文件 fetch
+ *   （fetch 不带 Range 头时 asset 协议返回完整 200）→ blob URL，缓存复用。
+ */
+import { convertFileSrc } from '@tauri-apps/api/core'
+import { isAndroid } from '@/utils/platform'
+
+// 原始路径 → blob URL 缓存（同会话内复用，避免每次播放都重新读取）
+const blobCache = new Map<string, string>()
+
+/** 把原始文件路径（或已转换的 asset/blob/data/http URL）转成可播放 URL */
+export async function toPlayableMediaUrl(path: string): Promise<string> {
+  if (
+    path.startsWith('blob:') ||
+    path.startsWith('data:') ||
+    path.startsWith('http://') ||
+    path.startsWith('https://') ||
+    path.startsWith('asset:')
+  ) {
+    return path
+  }
+  if (!isAndroid()) return convertFileSrc(path)
+
+  const cached = blobCache.get(path)
+  if (cached) return cached
+
+  const resp = await fetch(convertFileSrc(path))
+  if (!resp.ok) throw new Error(`媒体加载失败(${resp.status}): ${path}`)
+  const blob = await resp.blob()
+  const url = URL.createObjectURL(blob)
+  blobCache.set(path, url)
+  return url
+}

--- a/src/utils/mediaUrl.ts
+++ b/src/utils/mediaUrl.ts
@@ -7,12 +7,18 @@
  *   继续请求后续分块——大文件「播一会就停」（消耗完前两个 1MB 块后卡住），
  *   OGG 探测（需要文件末尾页）直接失败。因此改为整文件 fetch
  *   （fetch 不带 Range 头时 asset 协议返回完整 200）→ blob URL，缓存复用。
+ *
+ * 缓存语义：同会话内按路径复用 blob URL（文件被删除/替换后同路径仍播放
+ * 旧内容，重启会话即刷新）；达到上限时按最早插入的顺序淘汰并释放 blob。
  */
 import { convertFileSrc } from '@tauri-apps/api/core'
 import { isAndroid } from '@/utils/platform'
 
-// 原始路径 → blob URL 缓存（同会话内复用，避免每次播放都重新读取）
-const blobCache = new Map<string, string>()
+// 原始路径 → blob URL（Promise 形态，天然去重并发请求）
+const blobCache = new Map<string, Promise<string>>()
+
+/** 缓存上限：防会话内无限增长（几十首歌 × 数 MB 在合理范围内） */
+const MAX_CACHE_ENTRIES = 30
 
 /** 把原始文件路径（或已转换的 asset/blob/data/http URL）转成可播放 URL */
 export async function toPlayableMediaUrl(path: string): Promise<string> {
@@ -30,10 +36,24 @@ export async function toPlayableMediaUrl(path: string): Promise<string> {
   const cached = blobCache.get(path)
   if (cached) return cached
 
-  const resp = await fetch(convertFileSrc(path))
-  if (!resp.ok) throw new Error(`媒体加载失败(${resp.status}): ${path}`)
-  const blob = await resp.blob()
-  const url = URL.createObjectURL(blob)
-  blobCache.set(path, url)
-  return url
+  const pending = (async () => {
+    const resp = await fetch(convertFileSrc(path))
+    if (!resp.ok) throw new Error(`媒体加载失败(${resp.status}): ${path}`)
+    const blob = await resp.blob()
+    return URL.createObjectURL(blob)
+  })()
+  blobCache.set(path, pending)
+  // 加载失败时移出缓存，允许下次重试
+  pending.catch(() => blobCache.delete(path))
+
+  // LRU 上限：淘汰最早插入的条目，待其 resolve 后释放 blob
+  if (blobCache.size > MAX_CACHE_ENTRIES) {
+    const oldestPath = blobCache.keys().next().value
+    if (oldestPath) {
+      const oldest = blobCache.get(oldestPath)
+      blobCache.delete(oldestPath)
+      if (oldest) void oldest.then((url) => URL.revokeObjectURL(url))
+    }
+  }
+  return pending
 }

--- a/src/utils/mediaUrl.ts
+++ b/src/utils/mediaUrl.ts
@@ -1,15 +1,14 @@
 /**
  * 媒体文件播放 URL 转换工具
  *
- * - 桌面端：直接返回 asset 协议 URL（WebView2 能正确处理 206 分块流）
- * - Android：asset 协议每个响应最多 1MB（tauri 源码硬编码 MAX_LEN=1000*1024，
- *   无法配置）。安卓媒体栈对 open-ended Range（bytes=N-）的截断响应不会
- *   继续请求后续分块——大文件「播一会就停」（消耗完前两个 1MB 块后卡住），
- *   OGG 探测（需要文件末尾页）直接失败。因此改为整文件 fetch
- *   （fetch 不带 Range 头时 asset 协议返回完整 200）→ blob URL，缓存复用。
+ * - 桌面端：asset 协议直连（WebView2 能正确处理 206 分块流）
+ * - Android：asset 协议每个 206 响应上限 1MB（tauri 硬编码，不可配置），
+ *   安卓媒体栈对截断的 open-ended Range 响应不再请求后续分块——
+ *   大文件播一会即停、OGG 探测（需文件末尾页）直接失败。
+ *   故整文件 fetch（无 Range → 完整 200）→ blob URL，缓存复用。
  *
- * 缓存语义：同会话内按路径复用 blob URL（文件被删除/替换后同路径仍播放
- * 旧内容，重启会话即刷新）；达到上限时按最早插入的顺序淘汰并释放 blob。
+ * 缓存语义：同会话按路径复用（删后重导同名文件仍播放旧内容，重启会话刷新）；
+ * 超上限按插入顺序淘汰并释放 blob。
  */
 import { convertFileSrc } from '@tauri-apps/api/core'
 import { isAndroid } from '@/utils/platform'
@@ -17,7 +16,7 @@ import { isAndroid } from '@/utils/platform'
 // 原始路径 → blob URL（Promise 形态，天然去重并发请求）
 const blobCache = new Map<string, Promise<string>>()
 
-/** 缓存上限：防会话内无限增长（几十首歌 × 数 MB 在合理范围内） */
+/** 缓存上限：防会话内无限增长 */
 const MAX_CACHE_ENTRIES = 30
 
 /** 把原始文件路径（或已转换的 asset/blob/data/http URL）转成可播放 URL */
@@ -46,7 +45,7 @@ export async function toPlayableMediaUrl(path: string): Promise<string> {
   // 加载失败时移出缓存，允许下次重试
   pending.catch(() => blobCache.delete(path))
 
-  // LRU 上限：淘汰最早插入的条目，待其 resolve 后释放 blob
+  // 超限淘汰最早的条目，待其 resolve 后释放 blob
   if (blobCache.size > MAX_CACHE_ENTRIES) {
     const oldestPath = blobCache.keys().next().value
     if (oldestPath) {


### PR DESCRIPTION
## 背景

安卓端导入的音乐/环境音存在播放问题：
- 大文件（>2MB 左右）「播一会就停」——实测 5.4MB 的 mp3 卡在 ~85 秒
- OGG 文件完全无法播放（探测时长需要文件末尾页，直接失败）
- 小文件（<2MB）能正常播完（媒体栈启动时并发预读整段）

## 根因

Tauri asset 协议（`convertFileSrc` 生成的 URL）每个 206 分块响应硬编码上限 1MB（`MAX_LEN`，源码不可配置）。安卓媒体栈对 open-ended Range（`bytes=N-`）的截断响应不再请求后续分块；桌面 WebView2 会持续重发请求所以一直正常。

## 技术选型

- 不采用base64 data URL原因是大文件会卡前端

## 修复

- 媒体播放改走整文件 fetch + blob URL——新增 `utils/mediaUrl.ts`，安卓端 fetch（无 Range → 完整 200）转 blob 播放并缓存，桌面端保持 asset 协议不变；GameBackground 的 BGM/环境音/音效三处入口接入；blob 缓存去重 + LRU 上限 + 切歌竞态守卫

## 验证

- 手机实机验证：三首歌（含 5.4MB mp3、OGG 伪装 mp3）全部完整播放 ✅
- 手机浏览器模拟测试（复刻 asset 协议行为 + blob 模式对比）✅
- vue-tsc ✅ / prettier ✅
