### PR TITLE
fix: 单句合成失败不再禁用整个 TTS 服务

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -34,15 +34,15 @@
   </tr>
   <tr>
     <!-- 右侧：第二行数据 -->
-    <td><b>代码报错求助</b></td>
-    <td><a href="https://github.com/SlimeBoyOwO/LingChat/blob/main/README-help.md">👉 帮助文档-代码报错</a></td>
-    <td>遇到终端或后台代码红字报错时查看。</td>
+    <td><b>项目文档地址</b></td>
+    <td><a href="https://slimeboyowo.github.io/LingBlog/blog/projects/ling-chat/develop/">👉 帮助文档-代码报错</a></td>
+    <td>对项目有任何疑问可以在这里查看文档。</td>
   </tr>
   <tr>
     <!-- 右侧：第三行数据 -->
-    <td><b>截图报错求助</b></td>
-    <td><a href="https://github.com/SlimeBoyOwO/LingChat/blob/develop/others/document/Q&A.md">👉 帮助文档-截图报错</a></td>
-    <td>遇到弹窗或画面显示异常时查看。</td>
+    <td><b>开发者群</b></td>
+    <td><a href="https://github.com/SlimeBoyOwO/LingChat/blob/develop/others/document/Q&A.md">QQ群：798012738</a></td>
+    <td>对 AI-GALGAME 有开发意向，需要有兴趣或能力的人。</td>
   </tr>
 </table>
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -41,7 +41,7 @@
   <tr>
     <!-- 右侧：第三行数据 -->
     <td><b>开发者群</b></td>
-    <td><a href="https://github.com/SlimeBoyOwO/LingChat/blob/develop/others/document/Q&A.md">QQ群：798012738</a></td>
+    <td><b>QQ群：798012738</b></td>
     <td>对 AI-GALGAME 有开发意向，需要有兴趣或能力的人。</td>
   </tr>
 </table>

--- a/src-tauri/src/ai_service/tts/provider.rs
+++ b/src-tauri/src/ai_service/tts/provider.rs
@@ -1,7 +1,7 @@
 //! TTS 适配器 trait + 统一 Provider。
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
@@ -35,6 +35,13 @@ pub trait TtsAdapter: Send + Sync {
     }
 }
 
+/// 连续合成失败多少次才禁用 TTS。
+///
+/// 单句失败不应该关掉整个语音服务：个别句子可能因为文本本身（纯标点、
+/// 推理后端不支持的张量形状等）失败，而后面的句子完全正常。只有连续
+/// 失败才说明后端真的不可用（服务没启动、URL 配错等）。
+const MAX_CONSECUTIVE_FAILURES: u32 = 3;
+
 /// TTS Provider：持有所有已初始化的适配器并按 `tts_type` 路由。
 /// 对应 Python `TTS` 类。
 #[derive(Clone)]
@@ -42,6 +49,8 @@ pub struct TtsProvider {
     pub audio_format: String,
     enable: Arc<AtomicBool>,
     recovery_in_flight: Arc<AtomicBool>,
+    /// 连续失败计数；任意一次成功即归零。达到 [`MAX_CONSECUTIVE_FAILURES`] 才禁用。
+    consecutive_failures: Arc<AtomicU32>,
 
     pub sva: Option<Arc<VitsAdapter>>,
     pub sbv2: Option<Arc<Sbv2Adapter>>,
@@ -61,6 +70,7 @@ impl Default for TtsProvider {
             audio_format: String::new(),
             enable: Arc::new(AtomicBool::new(true)),
             recovery_in_flight: Arc::new(AtomicBool::new(false)),
+            consecutive_failures: Arc::new(AtomicU32::new(0)),
             sva: None,
             sbv2: None,
             sbv2api: None,
@@ -81,6 +91,7 @@ impl std::fmt::Debug for TtsProvider {
             .field("audio_format", &self.audio_format)
             .field("enable", &self.enable)
             .field("recovery_in_flight", &self.recovery_in_flight)
+            .field("consecutive_failures", &self.consecutive_failures)
             .field("sva", &self.sva.is_some())
             .field("sbv2", &self.sbv2.is_some())
             .field("sbv2api", &self.sbv2api.is_some())
@@ -116,6 +127,7 @@ impl TtsProvider {
 
     pub fn reactivate(&self) {
         self.enable.store(true, Ordering::Relaxed);
+        self.consecutive_failures.store(0, Ordering::Relaxed);
         tracing::info!("TTS 服务已重新启用");
     }
 
@@ -206,7 +218,10 @@ impl TtsProvider {
         Ok(adapter)
     }
 
-    /// 合成并把字节写入 `file_path`。失败时自动禁用 TTS（匹配 Python 行为）。
+    /// 合成并把字节写入 `file_path`。
+    ///
+    /// 连续失败 [`MAX_CONSECUTIVE_FAILURES`] 次才禁用 TTS —— 单句失败只回报错误，
+    /// 后面的句子仍会正常尝试合成。
     pub async fn generate_voice(
         &self,
         text: &str,
@@ -224,12 +239,22 @@ impl TtsProvider {
         let adapter = self.select(tts_type)?;
         match adapter.generate_voice(text, emo).await {
             Ok(bytes) => {
+                self.consecutive_failures.store(0, Ordering::Relaxed);
                 tokio::fs::write(file_path, &bytes).await?;
                 tracing::debug!("TTS 生成成功: {}", file_path.display());
                 Ok(())
             }
             Err(e) => {
-                self.disable();
+                let failures = self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;
+                if failures >= MAX_CONSECUTIVE_FAILURES {
+                    self.disable();
+                } else {
+                    tracing::warn!(
+                        "TTS 合成失败({}/{}), 保持启用继续尝试下一句: {e}",
+                        failures,
+                        MAX_CONSECUTIVE_FAILURES
+                    );
+                }
                 Err(e)
             }
         }


### PR DESCRIPTION
## 问题

`TtsProvider::generate_voice` 只要一次合成失败就关掉整个语音服务：

```rust
Err(e) => {
    self.disable();   // ← 一句失败 = 所有角色都没语音了
    Err(e)
}
```

之后所有台词都不会有语音，直到 `recover_in_background` 恰好拿一段能通过的文本探测成功才恢复。用户看到的现象是「语音时有时无」，而不是一个明确的错误。

但单句失败的原因常常只跟这一句有关 —— 纯标点的片段、推理后端不支持的张量形状等，后面的句子完全正常。

## 触发这个问题的真实例子

macOS (aarch64) 上本地 TTS 走 CoreML EP，而 CoreML 不接受零元素张量，Style-Bert-VITS2 的随机时长预测器会合法产生这种张量：

```
Non-zero status code returned while running CoreML_..._137 node.
Input (/sdp/flows.3/GatherND_2_output_0) has a dynamic shape ({-1,-1})
but the runtime shape ({0,10}) has zero elements.
This is not supported by the CoreML EP.
```

根因在上游依赖 `sbv2_core`：`load_model_with_device` 的 DirectML / WebGPU 分支都会在调用方要求 `InferenceDevice::Cpu` 时跳过注册加速器，唯独 CoreML 分支无条件 `push`，所以 `utils/device.rs` 在 macOS 只给 `"cpu"` 选项也没用。已另外提 PR：**shadow01a/sbv2-api#1**。

不过就算没有那个 EP bug，「一句失败关掉整个服务」本身也放大了伤害，所以这里单独修。

## 改动

连续失败达到 3 次才禁用，任意一次成功即归零：

```rust
Ok(bytes) => {
    self.consecutive_failures.store(0, Ordering::Relaxed);
    // ...
}
Err(e) => {
    let failures = self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;
    if failures >= MAX_CONSECUTIVE_FAILURES {
        self.disable();
    } else {
        tracing::warn!("TTS 合成失败({}/{}), 保持启用继续尝试下一句: {e}", ...);
    }
    Err(e)
}
```

`reactivate()` 也一并重置计数。原有意图（后端真的不可用时别每句都卡住重试）保留 —— 服务没启动或 URL 配错时仍会在 3 句内禁用。

## 验证

macOS 15 / M3 Pro，本地 TTS（Ling-v2）在排除 CoreML EP 后合成正常，日志中 CoreML 报错为 0：

![macOS 本地 TTS 试听正常播放](https://raw.githubusercontent.com/Oliver0804/LingChat/assets/tts-working-macos.png)

`cargo build` 通过，无新增警告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca8P3waqybmyYHvcHJJpha
