### PR TITLE
fix: 修复 macOS 桌宠模式的背景透明、窗口拖曳与点击穿透

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,7 +24,11 @@ custom-protocol = ["tauri/custom-protocol"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset"] }
+# macos-private-api：macOS 上透明窗口（桌宠模式）的必要条件。缺少它时 tauri.conf.json
+# 的 transparent: true 会被静默忽略，webview 仍然绘制不透明白底。
+# 该 feature 内部由 cfg(target_os = "macos") 门控，Windows / Linux / Android 无影响。
+# 由 tauri.conf.json 的 app.macOSPrivateApi 驱动，tauri CLI 会自动同步这里的 features。
+tauri = { version = "2", features = ["macos-private-api", "protocol-asset"] }
 tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -483,7 +483,7 @@ pub fn run() {
             // 因此首次消息延迟是启动时加载的代价。
             ai_service::tts::local::setup::spawn_preload(&app.handle(), &local_tts);
 
-            // 启动 Windows 鼠标轮询点击穿透循环
+            // 启动鼠标轮询点击穿透循环
             let window = app
                 .get_webview_window("main")
                 .ok_or_else(|| tauri::Error::AssetNotFound("main window not found".to_string()))?;
@@ -503,13 +503,19 @@ pub fn run() {
                 .await;
             });
 
-            // Windows 点击穿透逻辑
-            let hit_test_state = app.state::<api::pet::HitTestState>();
-            let rects_arc = hit_test_state.solid_rects.clone();
-            let enabled_arc = hit_test_state.enabled.clone();
-
-            #[cfg(target_os = "windows")]
+            // 桌宠点击穿透：全局轮询鼠标位置，只有落在前端上报的 solid 区域内才接收鼠标事件，
+            // 其余透明区域把点击让给底下的窗口。
+            //
+            // 原本用 Win32 的 GetCursorPos，因此整段是 cfg(windows) 独占，macOS 上桌宠窗口
+            // 会整块挡住底下窗口的点击。cursor_position() 与 set_ignore_cursor_events() 都是
+            // Tauri 的跨平台 API，改用前者后三个桌面平台可以共用同一个循环。
+            // （Linux 未实测：X11 / Wayland 下最差情况是 API 返回 Err，本轮直接跳过。）
+            #[cfg(desktop)]
             {
+                let hit_test_state = app.state::<api::pet::HitTestState>();
+                let rects_arc = hit_test_state.solid_rects.clone();
+                let enabled_arc = hit_test_state.enabled.clone();
+
                 tauri::async_runtime::spawn(async move {
                     let mut was_ignored = false;
                     loop {
@@ -529,18 +535,15 @@ pub fn run() {
                             continue;
                         }
 
-                        use windows::Win32::Foundation::POINT;
-                        use windows::Win32::UI::WindowsAndMessaging::GetCursorPos;
-
-                        let mut pt = POINT { x: 0, y: 0 };
-                        unsafe {
-                            let _ = GetCursorPos(&mut pt);
-                        }
+                        // 桌面全局坐标（物理像素），与 outer_position() 同一坐标系
+                        let Ok(cursor) = window.cursor_position() else {
+                            continue;
+                        };
 
                         if let Ok(window_pos) = window.outer_position() {
                             if let Ok(scale_factor) = window.scale_factor() {
-                                let mouse_x = f64::from(pt.x) - f64::from(window_pos.x);
-                                let mouse_y = f64::from(pt.y) - f64::from(window_pos.y);
+                                let mouse_x = cursor.x - f64::from(window_pos.x);
+                                let mouse_y = cursor.y - f64::from(window_pos.y);
 
                                 let logical_x = mouse_x / scale_factor;
                                 let logical_y = mouse_y / scale_factor;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,6 +10,7 @@
     "frontendDist": "../dist"
   },
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
         "title": "LingChat",

--- a/src/components/pet/GameRoleAvatar.vue
+++ b/src/components/pet/GameRoleAvatar.vue
@@ -31,9 +31,18 @@
       ></div>
 
       <!-- 5. 核心头像框 -->
+      <!--
+        data-tauri-drag-region="false" 是刻意的：Tauri 注入的 drag.js 对「裸属性」要求
+        事件目标就是标注元素本身（el === composedPath[0]），而下面的头像图片容器铺满整个框，
+        事件目标永远是子元素，官方路径其实从未触发过；"false" 让 drag.js 显式跳过，避免它与
+        下面的 startWindowDrag 形成双路径。CSS 选择器 [data-tauri-drag-region] 匹配任意值，
+        Windows 的 -webkit-app-region: drag 保持原样。
+      -->
       <div
         class="relative w-full h-full rounded-full bg-white/10 dark:bg-black/10 backdrop-blur-md border-2 border-white/60 dark:border-white/20 shadow-[0_8px_32px_rgba(0,176,255,0.15)] overflow-hidden flex items-center justify-center transition-colors duration-300 z-10"
-        data-tauri-drag-region
+        data-tauri-drag-region="false"
+        @mousedown="startWindowDrag"
+        @dragstart.prevent
       >
         <!-- 下降效果的粒子系统 -->
         <BAParticles
@@ -83,6 +92,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, toRefs } from 'vue'
 import { invoke, convertFileSrc } from '@tauri-apps/api/core'
+import { getCurrentWindow } from '@tauri-apps/api/window'
 import BAParticles from './BAParticles.vue'
 import ImageCrossFade from '@/components/ui/ImageAcrossFade.vue'
 import StarField from '../game/standard/particles/StarField.vue'
@@ -100,6 +110,43 @@ const bubbleAudio = ref<HTMLAudioElement | null>(null)
 const imageFadeRef = ref<InstanceType<typeof ImageCrossFade> | null>(null)
 const uiStore = useUIStore()
 const gameStore = useGameStore()
+
+// ─── 窗口拖曳 ────────────────────────────────────────────────
+// macOS 的 WKWebView 不支持 -webkit-app-region: drag，桌宠窗口因此完全拖不动。
+// 这里手动接管：按下后位移超过阈值才进入原生窗口拖曳，未超过则保持为普通点击
+// （头像的 click 仍会派发，"点击头像推进对话"不受影响）。
+const DRAG_THRESHOLD_PX = 4
+
+const startWindowDrag = (e: MouseEvent) => {
+  if (e.button !== 0) return
+
+  // 抑制文本选中与 <img> 的原生拖曳：原生 image drag 一旦启动，mousemove 就断流，
+  // 阈值永远达不到，拖曳会在整个头像区域间歇性失效。preventDefault 不影响后续 click 派发。
+  e.preventDefault()
+
+  const startX = e.screenX
+  const startY = e.screenY
+
+  const cleanup = () => {
+    window.removeEventListener('mousemove', onMove)
+    window.removeEventListener('mouseup', cleanup)
+  }
+
+  const onMove = (moveEvent: MouseEvent) => {
+    if (
+      Math.abs(moveEvent.screenX - startX) < DRAG_THRESHOLD_PX &&
+      Math.abs(moveEvent.screenY - startY) < DRAG_THRESHOLD_PX
+    ) {
+      return
+    }
+    // 交给系统接管后 webview 收不到后续鼠标事件，先摘监听器再启动拖曳
+    cleanup()
+    void getCurrentWindow().startDragging()
+  }
+
+  window.addEventListener('mousemove', onMove)
+  window.addEventListener('mouseup', cleanup)
+}
 
 const activeAnimationClass = ref('normal')
 const isBubbleVisible = ref(false)


### PR DESCRIPTION
桌宠模式在 macOS 上有三个问题，成因各自独立，一并修掉。Windows 行为未改动。

## 1. 背景不透明

`tauri.conf.json` 里已经有 `transparent: true`，前端 `body` / `html` / `#pet-app` 也全是透明的，但 macOS 上桌宠窗口仍然是一整块白底。

原因是 Tauri 在 macOS 上的透明窗口依赖私有 API，必须启用 `macos-private-api` feature，否则 `transparent: true` 被静默忽略，WKWebView 照常绘制不透明白底（见 tauri 2.11 `src/lib.rs` 的 feature 说明）。

改为打开 `app.macOSPrivateApi`，tauri CLI 会据此同步 `Cargo.toml` 的 features。

> ⚠️ 代价：构建产物会用到 macOS 私有 API，**无法上架 Mac App Store**。本项目的 bundle targets 是 dmg / nsis / deb / appimage，不含 App Store，所以实际不受影响——但这是个需要知情的取舍。

## 2. 窗口拖不动

头像框上的 `data-tauri-drag-region` 其实从未生效过。Tauri 注入的 `drag.js` 对「裸属性」的判定是 `el === composedPath[0]`——必须直接点在标注元素本身，而头像图片容器是 `w-full h-full`，铺满整个框，事件目标永远是子元素。Windows 上靠 CSS `-webkit-app-region: drag` 兜住了，macOS 的 WKWebView 不认这个属性，于是完全拖不动。

改为手动监听 `mousedown`：位移超过 4px 才调 `startDragging()`，未超过则保持普通点击，让「拖动窗口」和「点击头像推进对话」共存。官方的 `deep` 模式做不到这点——它在 mousedown 就进入原生拖曳循环，mouseup 不回 webview，click 会被吞掉。

同时抑制 `<img>` 的原生拖曳：否则 image drag 一起来 mousemove 就断流，阈值判定会在大半个头像上失效。

属性改成 `data-tauri-drag-region="false"` 让 `drag.js` 显式跳过，避免圆环边缘那圈像素触发官方路径和新逻辑打架；CSS 选择器匹配任意值，Windows 那条 `-webkit-app-region` 保持原样。

## 3. 透明区域挡住底下窗口的点击

hit-test 轮询循环因为用了 Win32 的 `GetCursorPos`，整段是 `cfg(target_os = "windows")` 独占，macOS 上桌宠窗口会整块挡住底下窗口的点击——第 1 项修好之后这点尤其明显。

改用 Tauri 跨平台的 `cursor_position()`：同样返回桌面全局物理坐标，与 `outer_position()` 属同一坐标系，因此原本的相对坐标 / 缩放换算逻辑一行未动，只是把 `cfg` 从 `windows` 放宽到 `desktop`。顺带把 `rects_arc` / `enabled_arc` 的绑定挪进 `cfg` 块，消除移动端构建的未使用变量警告。

> ℹ️ Linux 未实测：`cursor_position()` 与 `set_ignore_cursor_events()` 都是 Tauri 跨平台 API，X11 / Wayland 下最差情况是返回 `Err` 后跳过本轮，不会崩。如果希望保守，可以把 `cfg(desktop)` 收窄成 `cfg(any(target_os = "windows", target_os = "macos"))`。

## 测试

macOS（M3 Pro / Tauri 2.11）实机验证：背景透明、从头像拖动窗口、单击头像推进对话、对话气泡与输入框可点、左侧四个按钮正常、退出桌宠模式后主窗口鼠标无残留状态。

Windows 未回归测试——但三项改动都刻意避开了 Windows 路径：feature 由 `cfg(target_os = "macos")` 门控，CSS `-webkit-app-region` 原样保留（Windows 上它会先吞掉 mousedown，新的 JS 逻辑不会触发），穿透循环的坐标换算逻辑未变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca8P3waqybmyYHvcHJJpha