### PR TITLE
fix: 全屏状态下切换桌宠模式导致窗口边框消失

### DIFF
--- a/src-tauri/src/api/pet.rs
+++ b/src-tauri/src/api/pet.rs
@@ -33,11 +33,37 @@ pub fn update_solid_regions(rects: Vec<Rect>, state: tauri::State<'_, HitTestSta
     }
 }
 
+/// 退出全屏，并等到它真正结束。
+///
+/// 窗口处于全屏时，平台会吞掉后续的 `set_decorations` / `set_size`：
+/// tao 在 macOS 上是 `if fullscreen { return; }` 直接跳过，只把 decorations
+/// 记进状态；等真正退出全屏时，`restore_state_from_fullscreen` 又用的是
+/// **进入全屏那一刻保存的** style mask，中途记下的状态就丢了。Windows 侧
+/// 机制不同（改 `MARKER_DECORATIONS` 标志位），但同样会和全屏标志打架。
+/// 结果就是全屏状态下进出桌宠模式，窗口边框会消失。
+#[cfg(desktop)]
+async fn leave_fullscreen(window: &tauri::WebviewWindow) {
+    if !window.is_fullscreen().unwrap_or(false) {
+        return;
+    }
+    let _ = window.set_fullscreen(false);
+
+    // macOS 退出全屏带动画，动画期间 is_fullscreen() 仍然是 true，
+    // 这时改窗口一样会被丢掉，所以要等到状态真的翻过来。
+    // 超时就继续往下走：降级成修复前的行为，总好过让桌宠模式进不去。
+    for _ in 0..40 {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        if !window.is_fullscreen().unwrap_or(false) {
+            return;
+        }
+    }
+}
+
 #[tauri::command]
 // scale/app_handle 只在桌面分支（cfg(desktop) 内调整窗口）使用，
 // 安卓/iOS 编译时视为未使用——用 cfg_attr 消除该平台上的警告
 #[cfg_attr(not(desktop), allow(unused_variables))]
-pub fn set_pet_mode(
+pub async fn set_pet_mode(
     enable: bool,
     scale: Option<f64>,
     app_handle: AppHandle,
@@ -49,6 +75,11 @@ pub fn set_pet_mode(
 
     #[cfg(desktop)]
     if let Some(window) = app_handle.get_webview_window("main") {
+        // 两个分支都要先退全屏：进入时防的是 issue #618 的复现路径
+        // （F11 全屏 → 进桌宠 → 退出，边框消失）；退出时防的是状态脱钩，
+        // 例如路由异常导致桌宠状态与全屏状态不一致时，恢复装饰同样会被吞。
+        leave_fullscreen(&window).await;
+
         if enable {
             let scale_val = scale.unwrap_or(1.0);
 


### PR DESCRIPTION
Fixes #618

## 问题

复现（issue 原文）：**F11 全屏 → 切桌宠模式 → 退出桌宠模式**，窗口边框和标题栏消失，再按一次 F11 才能恢复。

## 成因

窗口处于全屏时，平台会吞掉后续的 `set_decorations` / `set_size`，而 `set_pet_mode` 完全没有检查过全屏状态。

macOS 侧（tao 源码）的链条最完整：

1. `set_decorations` 开头就是 `if fullscreen { return; }` —— 只把新的 decorations 值记进状态，style mask 根本没改；
2. 等真正退出全屏时，`window_did_exit_fullscreen` → `restore_state_from_fullscreen` 恢复的是 `saved_style`，也就是**进入全屏那一刻保存的** style mask；
3. 于是第 1 步记下的状态被整个丢掉，窗口装饰停在一个和实际不符的状态上。

Windows 侧机制不同（`set_window_flags` 改 `MARKER_DECORATIONS` 标志位），但同样是在全屏标志下改装饰位，两者打架 —— 这与报告者描述的「显示异常一段时间后进入类似小窗模式但菜单栏丢失，再按一次 F11 可以恢复」吻合。

## 改动

`set_pet_mode` 改为 `async`，新增 `leave_fullscreen()` helper，在**进入和退出两个分支**开头都先退出全屏：

- **必须等待，不能设完就走**：macOS 退出全屏带动画，动画期间 `is_fullscreen()` 仍然返回 `true`，这时改窗口照样被丢掉。每 50ms 轮询一次直到状态翻转，上限 2s。
- **超时继续执行，不返回 Err**：降级成修复前的行为即可，不该因为等待失败让桌宠模式整个进不去。
- **退出分支也加**：防的是桌宠状态与全屏状态脱钩（例如路由异常时），那时恢复装饰的 `set_decorations(true)` 会被同样吞掉。

`set_pet_mode` 由同步改 async 对调用侧无影响 —— 前端本来就是 `await invoke('set_pet_mode', ...)`。

顺带覆盖了前端的一个竞态：`App.vue` 的 F11 守卫只挡 `route.path === '/pet'`，从点击桌宠按钮到路由切换完成之间仍然可以按 F11 进全屏；Rust 侧无条件检查全屏，这条路径也一并封掉。

## 一个取舍

**退出桌宠模式不会恢复全屏。** 回到 1500×800 居中窗口是现有设计，这里没有实现「记住并恢复全屏状态」的逻辑。如果 maintainer 认为应该恢复，我可以再补。

## 测试

macOS（M3 Pro / Tauri 2.11）实机验证：按 issue 的复现步骤走一遍——F11 全屏 → 进桌宠（先播退出全屏动画再缩窗）→ 退出桌宠（回到居中窗口，边框与标题栏完整）；另外确认了非全屏状态下的常规进出没有回归。

Windows 未实机验证——按报告者的复现路径和 tao 的 Windows 实现推断，修复对该平台同样成立（根因是「全屏下改窗口装饰」，与具体平台的吞掉方式无关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca8P3waqybmyYHvcHJJpha