### PR TITLE
feat(web-search): 新增 Tavily 搜索提供商（修复选 Tavily 报 422）

### DIFF
--- a/src-tauri/src/ai_service/tools/settings.rs
+++ b/src-tauri/src/ai_service/tools/settings.rs
@@ -71,6 +71,7 @@ pub struct WebSearchSettings {
     /// 独立端点模式的搜索服务提供商：
     /// "kimi"（Kimi Code 同款 /v1/search，body 为 text_query）
     /// "bocha"（BoCha 博查 https://api.bochaai.com/v1/web-search）
+    /// "tavily"（Tavily https://api.tavily.com/search，body 为 query）
     /// 仅在 use_builtin = false 时生效。
     pub provider: String,
     /// API Key（Bearer 认证，仅 use_builtin = false 时需要）。

--- a/src-tauri/src/ai_service/tools/web_search.rs
+++ b/src-tauri/src/ai_service/tools/web_search.rs
@@ -190,6 +190,7 @@ impl WebSearchTool {
         }
         match cfg.provider.as_str() {
             "bocha" => self.execute_bocha_search(query, cfg).await,
+            "tavily" => self.execute_tavily_search(query, cfg).await,
             "custom" => self.execute_kimi_endpoint(query, cfg).await,
             _ => self.execute_kimi_endpoint(query, cfg).await,
         }
@@ -302,6 +303,73 @@ impl WebSearchTool {
                     "site_name": get("siteName"),
                     "date": get("datePublished"),
                     "snippet": if get("summary").is_empty() { get("snippet") } else { get("summary") },
+                })
+            })
+            .collect();
+
+        let text = Self::format_results(
+            query,
+            &results,
+            cfg.max_results.max(1),
+            cfg.hide_search_results,
+        );
+        Ok(serde_json::json!({
+            "ok": true,
+            "query": query,
+            "result_count": results.len().min(cfg.max_results.max(1)),
+            "text": text,
+        }))
+    }
+
+    /// 独立端点模式 · Tavily（https://api.tavily.com/search）。
+    ///
+    /// Tavily 只认顶层的 `query` 字段。此前没有这个分支，选 Tavily 的配置会落进
+    /// 上面 match 的 Kimi 兜底、发出 `text_query`，Tavily 便返回 422（issue #630）。
+    /// 注意 `text_query` 是 Kimi 官方端点要求的格式，不能反过来去改那一侧。
+    async fn execute_tavily_search(
+        &self,
+        query: &str,
+        cfg: &WebSearchSettings,
+    ) -> Result<ToolResult, ToolError> {
+        let base_url = "https://api.tavily.com/search";
+        let client = Self::build_client(cfg)?;
+        let response = client
+            .post(base_url)
+            .bearer_auth(cfg.api_key.trim())
+            .json(&serde_json::json!({
+                "query": query,
+                "max_results": cfg.max_results.max(1),
+            }))
+            .send()
+            .await
+            .map_err(classify_request_error)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(ToolError::Execution(
+                http_error_message(status, response).await,
+            ));
+        }
+
+        let payload: Value = response
+            .json()
+            .await
+            .map_err(|e| ToolError::Execution(format!("搜索结果解析失败: {e}")))?;
+        let rows = payload
+            .get("results")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        // 统一成 format_results 认识的字段：Tavily 的正文在 content，
+        // 没有站点名和日期，留空即可（format_results 会跳过空字段）。
+        let results: Vec<Value> = rows
+            .iter()
+            .map(|item| {
+                let get = |key: &str| item.get(key).and_then(Value::as_str).unwrap_or("");
+                serde_json::json!({
+                    "title": get("title"),
+                    "url": get("url"),
+                    "snippet": get("content"),
                 })
             })
             .collect();

--- a/src/api/services/tool-settings.ts
+++ b/src/api/services/tool-settings.ts
@@ -7,7 +7,7 @@ export interface WebSearchSettings {
   enabled: boolean
   /** true = 模型 API 内置联网（免 Key）；false = 独立搜索端点 + api_key */
   use_builtin: boolean
-  /** 独立端点模式的搜索提供商："kimi" | "bocha" | "custom"（仅 custom 用 base_url） */
+  /** 独立端点模式的搜索提供商："kimi" | "bocha" | "tavily" | "custom"（仅 custom 用 base_url） */
   provider: string
   api_key: string
   base_url: string

--- a/src/components/settings/pages/SettingsTools.vue
+++ b/src/components/settings/pages/SettingsTools.vue
@@ -53,6 +53,7 @@
           >
             <option value="kimi" class="bg-slate-800 text-white">Kimi /search</option>
             <option value="bocha" class="bg-slate-800 text-white">BoCha 博查</option>
+            <option value="tavily" class="bg-slate-800 text-white">Tavily</option>
             <option value="custom" class="bg-slate-800 text-white">
               {{ $t('ui.toolCalls.providerCustom') }}
             </option>


### PR DESCRIPTION
Fixes #630

## 先说结论：issue 里的修复建议不能照做

issue 提议「将 Tavily API 调用处的请求体字段名从 `text_query` 改为 `query`」。**照做会搞坏 Kimi。**

`text_query` 不是写错，它是 Kimi 官方端点要求的格式 —— `web_search.rs` 里那条路径的文档注释写得很清楚：「独立端点模式 · Kimi 系 /search（body 为 `text_query`）」。

## 真正的根因

provider 的 match 从来就没有 tavily 分支：

```rust
match cfg.provider.as_str() {
    "bocha"  => self.execute_bocha_search(query, cfg).await,
    "custom" => self.execute_kimi_endpoint(query, cfg).await,
    _        => self.execute_kimi_endpoint(query, cfg).await,  // ← Tavily 落这里
}
```

于是 Tavily 的配置走进 Kimi 端点，发出 `{"text_query": ...}`，而 Tavily 只认顶层的 `query`，返回 422。issue 里贴的错误响应 `{"type":"missing","loc":["body","query"],"input":{"text_query":"LingChat"}}` 正是这条路径的产物。

## 改动

新增独立的 `execute_tavily_search`，照 `execute_bocha_search` 的形状写：

- `POST https://api.tavily.com/search`，Bearer 认证
- body：`{"query": ..., "max_results": cfg.max_results.max(1)}`
- 响应 `results[]` 的 `title` / `url` / `content` 归一成 `format_results` 认识的字段（Tavily 没有站点名和日期，留空 —— `format_results` 本来就会跳过空字段）

四个文件，缺一不可：

| 文件 | 改动 |
|---|---|
| `ai_service/tools/web_search.rs` | match 新增 `"tavily"` 分支 + `execute_tavily_search` |
| `ai_service/tools/settings.rs` | provider 文档注释补 `"tavily"` |
| `settings/pages/SettingsTools.vue` | 提供商下拉新增 Tavily 选项 |
| `api/services/tool-settings.ts` | 类型注释补 `"tavily"` |

## 一个取舍

**此前用「自定义端点」填 Tavily 地址的配置，需要改选新的 Tavily 选项。** 没有做「检测 base_url 含 tavily.com 就换 body 格式」的静默迁移 —— 那种隐藏行为不如让用户显式选择，而且这些配置现在本来就是 422（就是本 issue 报的现象），不存在被破坏的既有可用配置。

## 测试

macOS 实机，Tavily 真实 API Key：

1. 设置页「测试搜索」→ 搜索成功，返回 8 条结果
2. 端到端：对话中触发联网搜索，工具调用参数为 `{"query": "..."}`，返回 `{"ok":true, "result_count":8, "text":"Title: ...\nURL: ...\nSnippet: ..."}` —— 请求、解析、格式化整条链路都覆盖到了

**Kimi 路径未实测**（手边没有 kimi key）。不过本次改动只在 match 里插入了一个新分支，`"custom" =>`、`_ =>` 兜底以及 `execute_kimi_endpoint` 函数体均未改动 —— 这也正是不能按 issue 建议去改 `text_query` 的原因。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca8P3waqybmyYHvcHJJpha