### PR TITLE
refactor(import): 4 入口文件导入鲁棒性重构（magic sniff 统一 + 自动修正 + UI 提示）

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4155,6 +4155,7 @@ dependencies = [
  "if-addrs",
  "image",
  "indoc",
+ "infer",
  "mdns-sd",
  "once_cell",
  "ort",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,7 @@ rand = "0.8"
 indoc = "2"
 
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+infer = "0.19"
 sevenz-rust2 = "0.21"
 sha2 = "0.10"
 tempfile = "3"

--- a/src-tauri/src/ai_service/tts/local/mod.rs
+++ b/src-tauri/src/ai_service/tts/local/mod.rs
@@ -20,8 +20,8 @@ pub use paths::LocalTtsPaths;
 // LocalTtsState -- Tauri managed state for the local TTS engine
 // ---------------------------------------------------------------------------
 
-use std::path::{Path, PathBuf};
 use serde::Serialize;
+use std::path::{Path, PathBuf};
 use tauri::ipc::Response;
 use tauri::{AppHandle, Emitter, State};
 use tokio_util::sync::CancellationToken;
@@ -88,11 +88,7 @@ pub struct LocalTtsRuntime {
 }
 
 impl LocalTtsRuntime {
-    pub fn new(
-        engine: Arc<LocalTtsEngine>,
-        paths: LocalTtsPaths,
-        switch: LocalTtsSwitch,
-    ) -> Self {
+    pub fn new(engine: Arc<LocalTtsEngine>, paths: LocalTtsPaths, switch: LocalTtsSwitch) -> Self {
         Self {
             engine,
             paths,
@@ -187,9 +183,7 @@ pub async fn tts_local_set_enabled(
 
     // 关闭时卸载全部模型与引擎释放内存；重新启用时若 DeBERTa 已安装则重建引擎
     if enabled {
-        if !local_state.engine.is_ready().await
-            && local_state.paths.asset_present("deberta")
-        {
+        if !local_state.engine.is_ready().await && local_state.paths.asset_present("deberta") {
             if let Err(e) = local_state.engine.init(&local_state.paths).await {
                 tracing::error!("重新启用本地 TTS 时初始化引擎失败: {e}");
             }
@@ -271,9 +265,7 @@ pub async fn tts_local_set_device(
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub async fn tts_local_status(
-    state: State<'_, LocalTtsState>,
-) -> Result<TtsLocalStatus, String> {
+pub async fn tts_local_status(state: State<'_, LocalTtsState>) -> Result<TtsLocalStatus, String> {
     let voices = model_manager::list_voices(&state.paths)?;
     let deberta_installed = state.paths.asset_present("deberta");
     Ok(TtsLocalStatus {
@@ -330,14 +322,8 @@ fn download_temp_path(entry: &registry::AssetEntry, cache: &Path) -> PathBuf {
     cache.join(format!("{}.download.{ext}", entry.id))
 }
 
-fn default_voice_id(
-    _inspected: &package::InspectedPackage,
-    src: &Path,
-) -> String {
-    let stem = src
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("voice");
+fn default_voice_id(_inspected: &package::InspectedPackage, src: &Path) -> String {
+    let stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or("voice");
     let cleaned: String = stem
         .chars()
         .map(|c| {
@@ -386,11 +372,8 @@ pub async fn tts_local_import_from_path(
             Some(v) => v,
             None => default_voice_id(&inspected, &src.path),
         };
-        let installed =
-            package::install_inspected(&inspected, &src.path, &state.paths, &voice_id)?;
-        let bytes = std::fs::metadata(&installed)
-            .map(|m| m.len())
-            .unwrap_or(0);
+        let installed = package::install_inspected(&inspected, &src.path, &state.paths, &voice_id)?;
+        let bytes = std::fs::metadata(&installed).map(|m| m.len()).unwrap_or(0);
         let _ = app.emit("tts://install-complete", &voice_id);
         Ok(ImportResult {
             asset_id: voice_id.clone(),
@@ -414,8 +397,8 @@ pub async fn tts_local_download(
     state: State<'_, LocalTtsState>,
     asset_id: String,
 ) -> Result<Vec<ImportResult>, String> {
-    let entry = registry::find(&asset_id)
-        .ok_or_else(|| format!("asset {asset_id} not in catalog"))?;
+    let entry =
+        registry::find(&asset_id).ok_or_else(|| format!("asset {asset_id} not in catalog"))?;
 
     let cancel = Arc::new(CancellationToken::new());
     {
@@ -480,12 +463,8 @@ async fn download_single_asset(
             let raw_dst = download_temp_path(entry, &state.paths.cache);
             let bytes = download::download_asset(app, entry, &raw_dst, cancel).await?;
             let inspected = package::inspect_package(&raw_dst)?;
-            let installed = package::install_inspected(
-                &inspected,
-                &raw_dst,
-                &state.paths,
-                &entry.id,
-            )?;
+            let installed =
+                package::install_inspected(&inspected, &raw_dst, &state.paths, &entry.id)?;
             let _ = tokio::fs::remove_file(&raw_dst).await;
             Ok(ImportResult {
                 asset_id: entry.id.clone(),
@@ -496,13 +475,13 @@ async fn download_single_asset(
             })
         }
         registry::AssetKind::StyleVectors => {
-            let voice_id = entry.voice_id.clone().ok_or_else(|| {
-                format!("style_vectors asset {} missing voice_id", entry.id)
-            })?;
+            let voice_id = entry
+                .voice_id
+                .clone()
+                .ok_or_else(|| format!("style_vectors asset {} missing voice_id", entry.id))?;
             let raw_dst = download_temp_path(entry, &state.paths.cache);
             let bytes = download::download_asset(app, entry, &raw_dst, cancel).await?;
-            let installed =
-                install_style_vectors_for(&state.paths, &raw_dst, &voice_id)?;
+            let installed = install_style_vectors_for(&state.paths, &raw_dst, &voice_id)?;
             let _ = tokio::fs::remove_file(&raw_dst).await;
             Ok(ImportResult {
                 asset_id: entry.id.clone(),
@@ -526,9 +505,7 @@ pub async fn tts_local_delete_voice(
 /// 删除 DeBERTa 共享模型（deberta.onnx + tokenizer.json），并卸载引擎释放内存。
 /// 删除后可从模型下载目录重新下载。
 #[tauri::command]
-pub async fn tts_local_delete_deberta(
-    state: State<'_, LocalTtsState>,
-) -> Result<(), String> {
+pub async fn tts_local_delete_deberta(state: State<'_, LocalTtsState>) -> Result<(), String> {
     delete_deberta_asset(&state.paths)?;
     state.engine.unload_all().await;
     Ok(())
@@ -581,7 +558,9 @@ pub async fn tts_local_import_style_vectors(
         let destination = state.paths.style_vectors_path(&voice_id);
         std::fs::copy(&src.path, &destination)
             .map_err(|e| format!("copy style_vectors.json: {e}"))?;
-        let bytes = std::fs::metadata(&destination).map(|m| m.len()).unwrap_or(0);
+        let bytes = std::fs::metadata(&destination)
+            .map(|m| m.len())
+            .unwrap_or(0);
         let _ = app.emit("tts://install-complete", &voice_id);
         Ok(ImportResult {
             asset_id: voice_id.clone(),
@@ -608,9 +587,7 @@ pub async fn tts_local_synthesize_preview(
     sdp_ratio: f32,
 ) -> Result<Response, String> {
     if !state.engine.is_ready().await {
-        return Err(
-            "local TTS engine not initialized (missing DeBerta)".into()
-        );
+        return Err("local TTS engine not initialized (missing DeBerta)".into());
     }
     state.engine.load_voice(&state.paths, &voice_id).await?;
     let req = SynthesizeRequest {

--- a/src-tauri/src/ai_service/tts/local/mod.rs
+++ b/src-tauri/src/ai_service/tts/local/mod.rs
@@ -365,14 +365,13 @@ pub async fn tts_local_import_from_path(
     path: String,
     voice_id: Option<String>,
 ) -> Result<ImportResult, String> {
-    let (src, cleanup_after_import) =
-        saf_bridge::prepare_file_import_source(&app, &path).await?;
+    let src = saf_bridge::prepare_file_import_source(&app, &path).await?;
 
     let result: std::result::Result<ImportResult, String> = async {
-        if !src.exists() {
-            return Err(format!("path not found: {}", src.display()));
+        if !src.path.exists() {
+            return Err(format!("path not found: {}", src.path.display()));
         }
-        let inspected = package::inspect_package(&src)?;
+        let inspected = package::inspect_package(&src.path)?;
         // 角色语音只支持直接导入 .sbv2 / .onnx 原始模型文件，不再接受 zip/7z 压缩包
         if matches!(
             inspected.kind,
@@ -385,10 +384,10 @@ pub async fn tts_local_import_from_path(
         }
         let voice_id = match voice_id {
             Some(v) => v,
-            None => default_voice_id(&inspected, &src),
+            None => default_voice_id(&inspected, &src.path),
         };
         let installed =
-            package::install_inspected(&inspected, &src, &state.paths, &voice_id)?;
+            package::install_inspected(&inspected, &src.path, &state.paths, &voice_id)?;
         let bytes = std::fs::metadata(&installed)
             .map(|m| m.len())
             .unwrap_or(0);
@@ -403,8 +402,8 @@ pub async fn tts_local_import_from_path(
     }
     .await;
 
-    if cleanup_after_import {
-        let _ = tokio::fs::remove_file(&src).await;
+    if src.cleanup_after_import {
+        let _ = tokio::fs::remove_file(&src.path).await;
     }
     result
 }
@@ -574,14 +573,13 @@ pub async fn tts_local_import_style_vectors(
         ));
     }
 
-    let (src, cleanup_after_import) =
-        saf_bridge::prepare_file_import_source(&app, &path).await?;
+    let src = saf_bridge::prepare_file_import_source(&app, &path).await?;
     let result: std::result::Result<ImportResult, String> = async {
-        if !src.exists() {
+        if !src.path.exists() {
             return Err(format!("path not found: {path}"));
         }
         let destination = state.paths.style_vectors_path(&voice_id);
-        std::fs::copy(&src, &destination)
+        std::fs::copy(&src.path, &destination)
             .map_err(|e| format!("copy style_vectors.json: {e}"))?;
         let bytes = std::fs::metadata(&destination).map(|m| m.len()).unwrap_or(0);
         let _ = app.emit("tts://install-complete", &voice_id);
@@ -595,8 +593,8 @@ pub async fn tts_local_import_style_vectors(
     }
     .await;
 
-    if cleanup_after_import {
-        let _ = tokio::fs::remove_file(&src).await;
+    if src.cleanup_after_import {
+        let _ = tokio::fs::remove_file(&src.path).await;
     }
     result
 }

--- a/src-tauri/src/ai_service/tts/local/mod.rs
+++ b/src-tauri/src/ai_service/tts/local/mod.rs
@@ -9,7 +9,7 @@ pub mod registry;
 pub mod setup;
 
 mod download;
-mod saf_bridge;
+pub(crate) mod saf_bridge;
 
 use std::sync::Arc;
 

--- a/src-tauri/src/ai_service/tts/local/package.rs
+++ b/src-tauri/src/ai_service/tts/local/package.rs
@@ -27,9 +27,6 @@ pub struct InspectedPackage {
     pub inner_model_name: Option<String>,
 }
 
-const MAGIC_PK: &[u8; 4] = b"PK\x03\x04";
-const MAGIC_7Z: &[u8; 2] = &[0x37, 0x7A];
-
 /// Cheap extension-first sniff.
 pub fn detect_by_extension(path: &Path) -> PackageKind {
     let ext = path
@@ -46,15 +43,15 @@ pub fn detect_by_extension(path: &Path) -> PackageKind {
     }
 }
 
-/// Sniff by magic bytes; falls back to Unknown if not a recognised archive.
-pub fn detect_by_magic(bytes: &[u8]) -> PackageKind {
-    if bytes.len() >= 4 && &bytes[..4] == MAGIC_PK {
-        PackageKind::Zip
-    } else if bytes.len() >= 2 && &bytes[..2] == MAGIC_7Z {
-        PackageKind::SevenZ
-    } else {
-        PackageKind::Unknown
-    }
+/// Sniff archive format via infer crate (replaces handwritten magic bytes).
+/// Falls back to Unknown for non-archive content.
+pub fn detect_archive_by_infer(path: &Path) -> std::result::Result<PackageKind, String> {
+    let kind = infer::get_from_path(path).map_err(|e| format!("infer: {e}"))?;
+    Ok(match kind.map(|k| k.mime_type()) {
+        Some("application/zip") | Some("application/x-zip-compressed") => PackageKind::Zip,
+        Some("application/x-7z-compressed") => PackageKind::SevenZ,
+        _ => PackageKind::Unknown,
+    })
 }
 
 pub fn inspect_package(path: &Path) -> std::result::Result<InspectedPackage, String> {
@@ -66,15 +63,9 @@ pub fn inspect_package(path: &Path) -> std::result::Result<InspectedPackage, Str
         .unwrap_or_default();
 
     let kind = detect_by_extension(path);
+    // 扩展名未知时用 infer 兜底（替代原 detect_by_magic）。
     let kind = if kind == PackageKind::Unknown {
-        let mut head = vec![0u8; 8.min(size_bytes as usize)];
-        if !head.is_empty() {
-            use std::io::Read;
-            std::fs::File::open(path)
-                .and_then(|mut f| f.read_exact(&mut head))
-                .map_err(|e| format!("read head: {e}"))?;
-        }
-        detect_by_magic(&head)
+        detect_archive_by_infer(path)?
     } else {
         kind
     };
@@ -198,15 +189,27 @@ mod tests {
     }
 
     #[test]
-    fn detect_zip_by_magic() {
-        let mut head = Vec::from(MAGIC_PK.as_slice());
-        head.extend_from_slice(&[0; 32]);
-        assert_eq!(detect_by_magic(&head), PackageKind::Zip);
+    fn detect_archive_by_infer_zip() {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("archive.bin");
+        {
+            let f = std::fs::File::create(&zip_path).unwrap();
+            let mut zip = zip::ZipWriter::new(f);
+            zip.start_file("a.txt", SimpleFileOptions::default()).unwrap();
+            zip.write_all(b"hi").unwrap();
+            zip.finish().unwrap();
+        }
+        assert_eq!(detect_archive_by_infer(&zip_path).unwrap(), PackageKind::Zip);
     }
 
     #[test]
-    fn detect_unknown_when_garbage() {
-        assert_eq!(detect_by_magic(&[1, 2, 3]), PackageKind::Unknown);
+    fn detect_archive_by_infer_unknown_for_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("notes.txt");
+        std::fs::write(&p, b"hello world").unwrap();
+        assert_eq!(detect_archive_by_infer(&p).unwrap(), PackageKind::Unknown);
     }
 
     #[test]

--- a/src-tauri/src/ai_service/tts/local/saf_bridge.rs
+++ b/src-tauri/src/ai_service/tts/local/saf_bridge.rs
@@ -2,22 +2,39 @@
 //!
 //! On desktop the user's path is returned as-is; on Android we transparently
 //! stage a `content://`-prefixed path into the app cache.
+//!
+//! The returned `display_name` is the user-facing file name (e.g.
+//! `"MyFont.woff2"`), derived from the original URI on Android and from
+//! `path`'s file_name on desktop. Callers should use it as `original_name`
+//! for UX/notification purposes — the staged `PathBuf` has a synthetic
+//! `tts_import_saf_<uuid>_…` name on Android that must not leak into UI.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::AppHandle;
 
 #[cfg(target_os = "android")]
 use tauri::Manager;
 
+/// User-facing metadata for an import source.
+pub struct ImportSource {
+    /// Local path to read bytes from.
+    pub path: PathBuf,
+    /// True when the caller must delete `path` after processing.
+    pub cleanup_after_import: bool,
+    /// Best-effort user-facing file name (e.g. `"MyFont.woff2"`).
+    /// Falls back to the staged path's file name when the platform cannot
+    /// recover the original.
+    pub display_name: String,
+}
+
 /// Prepare the actual on-disk source for a local TTS import.
 ///
-/// Returns `(path_to_import_from, should_cleanup_after_import)`. When
-/// `should_cleanup_after_import` is `true` the caller MUST delete the staged
-/// file once it has finished processing.
+/// Returns an [`ImportSource`]. When `cleanup_after_import` is `true` the
+/// caller MUST delete the staged file once it has finished processing.
 pub async fn prepare_file_import_source(
     app: &AppHandle,
     path: &str,
-) -> Result<(PathBuf, bool), String> {
+) -> Result<ImportSource, String> {
     if path.starts_with("content://") {
         #[cfg(target_os = "android")]
         {
@@ -43,15 +60,24 @@ pub async fn prepare_file_import_source(
             let local_path = imports_root.join(format!("tts_import_saf_{tmp_id}_{suffix}"));
             let local_uri = FsUri::from_path(&local_path);
             tracing::info!(
-                "[tts_local] prepare_file_import_source SAF: src={}, local={}",
+                "[tts_local] prepare_file_import_source SAF: src={}, local={}, display={}",
                 path,
-                local_path.display()
+                local_path.display(),
+                display,
             );
             app.android_fs_async()
                 .copy(&src_uri, &local_uri)
                 .await
                 .map_err(|e| format!("SAF copy to local cache: {e}"))?;
-            return Ok((local_path, true));
+            return Ok(ImportSource {
+                path: local_path,
+                cleanup_after_import: true,
+                display_name: if display.is_empty() {
+                    "import.bin".to_string()
+                } else {
+                    display
+                },
+            });
         }
 
         #[cfg(not(target_os = "android"))]
@@ -60,7 +86,23 @@ pub async fn prepare_file_import_source(
             Err("content URI imports are only supported on Android".into())
         }
     } else {
-        Ok((PathBuf::from(path), false))
+        // Desktop / non-content path: use the file's own basename as the
+        // user-facing display name. Falls back to the full path string if
+        // for some reason the path has no file name component.
+        let pb = PathBuf::from(path);
+        let display_name = pb
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| path.to_string());
+        // Touch `Path` to keep the import meaningful on platforms where the
+        // std-only branch is unused (lint hygiene for `Path` re-export above).
+        let _ = Path::new(path);
+        Ok(ImportSource {
+            path: pb,
+            cleanup_after_import: false,
+            display_name,
+        })
     }
 }
 

--- a/src-tauri/src/ai_service/tts/local/saf_bridge.rs
+++ b/src-tauri/src/ai_service/tts/local/saf_bridge.rs
@@ -9,7 +9,7 @@
 //! for UX/notification purposes — the staged `PathBuf` has a synthetic
 //! `tts_import_saf_<uuid>_…` name on Android that must not leak into UI.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tauri::AppHandle;
 
 #[cfg(target_os = "android")]
@@ -98,9 +98,6 @@ pub async fn prepare_file_import_source(
             .and_then(|n| n.to_str())
             .map(|s| s.to_string())
             .unwrap_or_else(|| path.to_string());
-        // Touch `Path` to keep the import meaningful on platforms where the
-        // std-only branch is unused (lint hygiene for `Path` re-export above).
-        let _ = Path::new(path);
         Ok(ImportSource {
             path: pb,
             cleanup_after_import: false,

--- a/src-tauri/src/ai_service/tts/local/saf_bridge.rs
+++ b/src-tauri/src/ai_service/tts/local/saf_bridge.rs
@@ -59,11 +59,18 @@ pub async fn prepare_file_import_source(
 
             let local_path = imports_root.join(format!("tts_import_saf_{tmp_id}_{suffix}"));
             let local_uri = FsUri::from_path(&local_path);
+            // 用 `display_name` 而非 `display` 作变量名，避免某些 rustc/tracing 版本
+            // 把 `display` 解析为 `std::fmt::Display` trait path 而触发 E0277。
+            let display_name = if display.is_empty() {
+                "import.bin".to_string()
+            } else {
+                display
+            };
             tracing::info!(
-                "[tts_local] prepare_file_import_source SAF: src={}, local={}, display={}",
+                "[tts_local] prepare_file_import_source SAF: src={}, local={}, display_name={}",
                 path,
                 local_path.display(),
-                display,
+                display_name,
             );
             app.android_fs_async()
                 .copy(&src_uri, &local_uri)
@@ -72,11 +79,7 @@ pub async fn prepare_file_import_source(
             return Ok(ImportSource {
                 path: local_path,
                 cleanup_after_import: true,
-                display_name: if display.is_empty() {
-                    "import.bin".to_string()
-                } else {
-                    display
-                },
+                display_name,
             });
         }
 

--- a/src-tauri/src/api/ambient.rs
+++ b/src-tauri/src/api/ambient.rs
@@ -27,7 +27,7 @@ pub fn get_ambient_list() -> Result<Vec<AmbientItemInfo>, String> {
         return Ok(Vec::new());
     }
 
-    let allowed_extensions = ["mp3", "wav", "flac", "webm", "weba", "ogg", "m4a", "oga"];
+    let allowed_extensions = ["mp3", "wav", "flac", "webm", "weba", "ogg", "oga"];
 
     let mut items: Vec<AmbientItemInfo> = Vec::new();
 
@@ -79,13 +79,47 @@ pub fn get_ambient_list() -> Result<Vec<AmbientItemInfo>, String> {
 }
 
 #[tauri::command]
-pub async fn upload_ambient(app: tauri::AppHandle, path: String, file_name: String) -> Result<(), String> {
-    // 安全检查：只保留文件名，防止路径遍历
-    let safe_name = std::path::Path::new(&file_name)
-        .file_name()
-        .ok_or_else(|| format!("无效的文件名: {}", file_name))?
-        .to_string_lossy()
-        .into_owned();
+pub async fn upload_ambient(
+    app: tauri::AppHandle,
+    path: String,
+    file_name: String,
+) -> Result<(), String> {
+    // 安全检查：只保留文件名（basename），防止路径遍历。空 basename 直接拒。
+    let safe_name = {
+        let stem = std::path::Path::new(&file_name)
+            .file_name()
+            .ok_or_else(|| format!("无效的文件名: {}", file_name))?
+            .to_string_lossy()
+            .into_owned();
+        if stem.is_empty() {
+            return Err(format!("无效的文件名: {}", file_name));
+        }
+        stem
+    };
+
+    // Android SAF：先把 content URI 复制到本地 cache，magic sniff 在本地路径上做。
+    let src =
+        crate::ai_service::tts::local::saf_bridge::prepare_file_import_source(&app, &path).await?;
+
+    // magic sniff：与 music.rs 同源策略，用 infer extension() 而非 mime_type()
+    // 做权威裁决（绕过 mime 别名问题：audio/x-flac 不匹配 audio/flac）。
+    // 环境音不做扩展名修正，命中失败即拒。同时主动放弃 m4a。
+    if let Some(k) = infer::get_from_path(&src.path).map_err(|e| format!("读取文件头失败: {e}"))?
+    {
+        let valid = k.matcher_type() == infer::MatcherType::Audio
+            && matches!(k.extension(), "mp3" | "wav" | "flac" | "ogg");
+        if !valid {
+            if src.cleanup_after_import {
+                let _ = tokio::fs::remove_file(&src.path).await;
+            }
+            return Err("MUSIC_INVALID_FORMAT".into());
+        }
+    } else {
+        if src.cleanup_after_import {
+            let _ = tokio::fs::remove_file(&src.path).await;
+        }
+        return Err("MUSIC_INVALID_FORMAT".into());
+    }
 
     let ambient_dir = ambient_dir();
     if !ambient_dir.exists() {
@@ -96,19 +130,14 @@ pub async fn upload_ambient(app: tauri::AppHandle, path: String, file_name: Stri
 
     let file_path = ambient_dir.join(&safe_name);
 
-    if path.starts_with("content://") {
-        // Android SAF：content:// URI 直接复制到目标文件（不经 IPC 传大文件）
-        use tauri_plugin_android_fs::{AndroidFsExt, FsUri};
-        app.android_fs_async()
-            .copy(&FsUri::from_uri(&path), &FsUri::from_path(&file_path))
-            .await
-            .map_err(|e| format!("SAF 复制环境音失败: {}", e))?;
-    } else {
-        // 桌面端：Rust 直接复制源文件
-        tokio::fs::copy(std::path::PathBuf::from(&path), &file_path)
-            .await
-            .map_err(|e| format!("复制文件失败: {}", e))?;
+    // 把已通过 sniff 的本地 src 复制到 ambient_dir（Android SAF 路径走 src.path；
+    // 桌面端 src.path == 原始 path，效果等价于直接复制源文件）。
+    let copy_result =
+        std::fs::copy(&src.path, &file_path).map_err(|e| format!("复制文件失败: {}", e));
+    if src.cleanup_after_import {
+        let _ = tokio::fs::remove_file(&src.path).await;
     }
+    copy_result?;
 
     Ok(())
 }
@@ -142,10 +171,7 @@ pub fn delete_ambient(url: String) -> Result<Vec<AmbientItemInfo>, String> {
 
 /// 持久化环境音轨道列表到 settings.json，下次启动时自动恢复。
 #[tauri::command]
-pub fn save_ambient_state(
-    app: tauri::AppHandle,
-    tracks_json: String,
-) -> Result<(), String> {
+pub fn save_ambient_state(app: tauri::AppHandle, tracks_json: String) -> Result<(), String> {
     let store = app
         .store(crate::config::STORE_FILE)
         .map_err(|e| format!("打开存储失败: {e}"))?;

--- a/src-tauri/src/api/font.rs
+++ b/src-tauri/src/api/font.rs
@@ -136,14 +136,19 @@ pub fn list_system_fonts() -> Result<Vec<FontFamilyInfo>, String> {
 pub fn import_font(path: String) -> Result<UploadFontResult, String> {
     let src = Path::new(&path);
 
-    // 1. magic sniff 决定真实格式（替代原扩展名白名单）
+    // 1. magic sniff 决定真实格式（替代原扩展名白名单）。
+    //    注意：infer 把 WOFF 和 WOFF2 都映射到 mime "application/font-woff"，
+    //    所以必须同时检查 mime + extension 才能区分。
     let detected = infer::get_from_path(src)
         .map_err(|e| format!("读取文件头失败: {e}"))?;
-    let (kind, correct_ext) = match detected.map(|k| k.mime_type()) {
-        Some("font/ttf")  => ("ttf",  "ttf"),
-        Some("font/otf")  => ("otf",  "otf"),
-        Some("font/woff") => ("woff", "woff"),
-        Some("font/woff2")=> ("woff2","woff2"),
+    let (kind, correct_ext) = match detected {
+        Some(k) if k.matcher_type() == infer::MatcherType::Font => match (k.mime_type(), k.extension()) {
+            ("application/font-sfnt", "ttf")  => ("ttf",  "ttf"),
+            ("application/font-sfnt", "otf")  => ("otf",  "otf"),
+            ("application/font-woff", "woff") => ("woff", "woff"),
+            ("application/font-woff", "woff2")=> ("woff2","woff2"),
+            _ => return Err("FONT_INVALID_FORMAT".into()),
+        },
         _ => return Err("FONT_INVALID_FORMAT".into()),
     };
 

--- a/src-tauri/src/api/font.rs
+++ b/src-tauri/src/api/font.rs
@@ -22,6 +22,19 @@ pub struct ImportedFontInfo {
     pub file_path: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UploadFontResult {
+    /// 实际落盘的文件名（含 magic 决定的正确扩展名）
+    pub actual_name: String,
+    /// 用户原始文件名
+    pub original_name: String,
+    /// infer 识别的格式：ttf / otf / woff / woff2
+    pub detected_kind: String,
+    /// 是否发生自动修正（原扩展名 != magic 决定的扩展名）
+    pub was_corrected: bool,
+}
+
 // ========== Tauri 命令 ==========
 
 /// 枚举系统已安装的字体族名，供前端字体选择器使用。
@@ -113,56 +126,63 @@ pub fn list_system_fonts() -> Result<Vec<FontFamilyInfo>, String> {
 ///
 /// 前端通过 `@tauri-apps/plugin-dialog` 的 `open()` 选择文件后，
 /// 将文件路径传入此命令，后端负责校验和复制。
+///
+/// magic sniff 用 infer（替代原纯扩展名白名单）；扩展名错但内容对时自动修正。
 #[tauri::command]
-pub fn import_font(path: String) -> Result<ImportedFontInfo, String> {
+pub fn import_font(path: String) -> Result<UploadFontResult, String> {
     let src = Path::new(&path);
 
-    // 校验扩展名
-    let ext = src
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_lowercase();
-    if ext != "ttf" && ext != "woff2" {
-        return Err(format!(
-            "不支持的字体格式: .{}——仅支持 .ttf 和 .woff2",
-            ext
-        ));
-    }
+    // 1. magic sniff 决定真实格式（替代原扩展名白名单）
+    let detected = infer::get_from_path(src)
+        .map_err(|e| format!("读取文件头失败: {e}"))?;
+    let (kind, correct_ext) = match detected.map(|k| k.mime_type()) {
+        Some("font/ttf")  => ("ttf",  "ttf"),
+        Some("font/otf")  => ("otf",  "otf"),
+        Some("font/woff") => ("woff", "woff"),
+        Some("font/woff2")=> ("woff2","woff2"),
+        _ => return Err("FONT_INVALID_FORMAT".into()),
+    };
 
-    // 防路径穿越：只取文件名部分
+    // 2. 防路径穿越：只取文件名部分
     let original_name = src
         .file_name()
         .and_then(|n| n.to_str())
         .ok_or_else(|| "无效的文件名".to_string())?
         .to_string();
 
-    // stem 作为 CSS font-family 名称
+    // 3. 用 magic 决定的扩展名替换原扩展名
     let stem = Path::new(&original_name)
         .file_stem()
         .and_then(|s| s.to_str())
-        .ok_or_else(|| "无法解析字体名称".to_string())?
-        .to_string();
+        .unwrap_or("font");
+    let corrected_name = format!("{stem}.{correct_ext}");
 
-    let dest_path = api::fonts_dir().join(&original_name);
-
-    // 确保字体目录存在
-    std::fs::create_dir_all(api::fonts_dir())
-        .map_err(|e| format!("无法创建字体目录: {}", e))?;
-
-    // 同名文件不允许导入
-    if dest_path.exists() {
-        return Err(format!("字体 \"{}\" 已存在，不能重复导入", stem));
+    // 4. 冲突时按 _2/_3/... 后缀
+    let fonts_dir = api::fonts_dir();
+    std::fs::create_dir_all(&fonts_dir).map_err(|e| format!("无法创建字体目录: {}", e))?;
+    let mut final_name = corrected_name.clone();
+    let mut counter = 2u32;
+    while fonts_dir.join(&final_name).exists() {
+        if counter > 999 {
+            final_name = format!("{stem}_{}{}", chrono::Utc::now().timestamp_millis(), correct_ext);
+            break;
+        }
+        final_name = format!("{stem}_{counter}.{correct_ext}");
+        counter += 1;
     }
 
-    // 复制文件
-    std::fs::copy(&src, &dest_path)
+    let was_corrected = original_name != final_name;
+    let dest_path = fonts_dir.join(&final_name);
+
+    // 5. 复制文件
+    std::fs::copy(src, &dest_path)
         .map_err(|e| format!("复制字体文件失败: {}", e))?;
 
-    Ok(ImportedFontInfo {
-        name: stem,
-        file_name: original_name,
-        file_path: dest_path.to_string_lossy().into_owned(),
+    Ok(UploadFontResult {
+        actual_name: final_name,
+        original_name,
+        detected_kind: kind.to_string(),
+        was_corrected,
     })
 }
 

--- a/src-tauri/src/api/font.rs
+++ b/src-tauri/src/api/font.rs
@@ -132,73 +132,88 @@ pub fn list_system_fonts() -> Result<Vec<FontFamilyInfo>, String> {
 /// 将文件路径传入此命令，后端负责校验和复制。
 ///
 /// magic sniff 用 infer（替代原纯扩展名白名单）；扩展名错但内容对时自动修正。
+/// Android 上 dialog 返回的 content:// URI 先经 SAF bridge 复制到 cache，
+/// 再走本地 magic sniff + 本地复制（桌面 path 直接用）。
 #[tauri::command]
-pub fn import_font(path: String) -> Result<UploadFontResult, String> {
-    let src = Path::new(&path);
+pub async fn import_font(
+    app: tauri::AppHandle,
+    path: String,
+) -> Result<UploadFontResult, String> {
+    // Android SAF：先把 content URI 复制到本地 cache，magic sniff 和后续复制都用本地路径。
+    let (src, cleanup_after_import) =
+        crate::ai_service::tts::local::saf_bridge::prepare_file_import_source(&app, &path).await?;
 
-    // 1. magic sniff 决定真实格式（替代原扩展名白名单）。
-    //    注意：infer 把 WOFF 和 WOFF2 都映射到 mime "application/font-woff"，
-    //    所以必须同时检查 mime + extension 才能区分。
-    let detected = infer::get_from_path(src)
-        .map_err(|e| format!("读取文件头失败: {e}"))?;
-    let (kind, correct_ext) = match detected {
-        Some(k) if k.matcher_type() == infer::MatcherType::Font => match (k.mime_type(), k.extension()) {
-            ("application/font-sfnt", "ttf")  => ("ttf",  "ttf"),
-            ("application/font-sfnt", "otf")  => ("otf",  "otf"),
-            ("application/font-woff", "woff") => ("woff", "woff"),
-            ("application/font-woff", "woff2")=> ("woff2","woff2"),
+    let result: Result<UploadFontResult, String> = async {
+        // 1. magic sniff 决定真实格式（替代原扩展名白名单）。
+        //    注意：infer 把 WOFF 和 WOFF2 都映射到 mime "application/font-woff"，
+        //    所以必须同时检查 mime + extension 才能区分。
+        let detected = infer::get_from_path(&src)
+            .map_err(|e| format!("读取文件头失败: {e}"))?;
+        let (kind, correct_ext) = match detected {
+            Some(k) if k.matcher_type() == infer::MatcherType::Font => match (k.mime_type(), k.extension()) {
+                ("application/font-sfnt", "ttf")  => ("ttf",  "ttf"),
+                ("application/font-sfnt", "otf")  => ("otf",  "otf"),
+                ("application/font-woff", "woff") => ("woff", "woff"),
+                ("application/font-woff", "woff2")=> ("woff2","woff2"),
+                _ => return Err("FONT_INVALID_FORMAT".into()),
+            },
             _ => return Err("FONT_INVALID_FORMAT".into()),
-        },
-        _ => return Err("FONT_INVALID_FORMAT".into()),
-    };
+        };
 
-    // 2. 防路径穿越：只取文件名部分
-    let original_name = src
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "无效的文件名".to_string())?
-        .to_string();
+        // 2. 防路径穿越：只取文件名部分
+        let original_name = src
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| "无效的文件名".to_string())?
+            .to_string();
 
-    // 3. 用 magic 决定的扩展名替换原扩展名
-    let stem = Path::new(&original_name)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("font");
-    let corrected_name = format!("{stem}.{correct_ext}");
-
-    // 4. 冲突时按 _2/_3/... 后缀
-    let fonts_dir = api::fonts_dir();
-    std::fs::create_dir_all(&fonts_dir).map_err(|e| format!("无法创建字体目录: {}", e))?;
-    let mut final_name = corrected_name.clone();
-    let mut counter = 2u32;
-    while fonts_dir.join(&final_name).exists() {
-        if counter > 999 {
-            final_name = format!("{stem}_{}{}", chrono::Utc::now().timestamp_millis(), correct_ext);
-            break;
-        }
-        final_name = format!("{stem}_{counter}.{correct_ext}");
-        counter += 1;
-    }
-
-    let was_corrected = original_name != final_name;
-    let dest_path = fonts_dir.join(&final_name);
-
-    // 5. 复制文件
-    std::fs::copy(src, &dest_path)
-        .map_err(|e| format!("复制字体文件失败: {}", e))?;
-
-    Ok(UploadFontResult {
-        actual_name: final_name.clone(),
-        original_name,
-        detected_kind: kind.to_string(),
-        was_corrected,
-        file_path: dest_path.to_string_lossy().into_owned(),
-        font_family: Path::new(&final_name)
+        // 3. 用 magic 决定的扩展名替换原扩展名
+        let stem = std::path::Path::new(&original_name)
             .file_stem()
             .and_then(|s| s.to_str())
-            .unwrap_or("font")
-            .to_string(),
-    })
+            .unwrap_or("font");
+        let corrected_name = format!("{stem}.{correct_ext}");
+
+        // 4. 冲突时按 _2/_3/... 后缀
+        let fonts_dir = api::fonts_dir();
+        std::fs::create_dir_all(&fonts_dir).map_err(|e| format!("无法创建字体目录: {}", e))?;
+        let mut final_name = corrected_name.clone();
+        let mut counter = 2u32;
+        while fonts_dir.join(&final_name).exists() {
+            if counter > 999 {
+                final_name = format!("{stem}_{}{}", chrono::Utc::now().timestamp_millis(), correct_ext);
+                break;
+            }
+            final_name = format!("{stem}_{counter}.{correct_ext}");
+            counter += 1;
+        }
+
+        let was_corrected = original_name != final_name;
+        let dest_path = fonts_dir.join(&final_name);
+
+        // 5. 复制（src 已经是本地路径，桌面/SAF 都用 std::fs::copy）
+        std::fs::copy(&src, &dest_path)
+            .map_err(|e| format!("复制字体文件失败: {}", e))?;
+
+        Ok(UploadFontResult {
+            actual_name: final_name.clone(),
+            original_name,
+            detected_kind: kind.to_string(),
+            was_corrected,
+            file_path: dest_path.to_string_lossy().into_owned(),
+            font_family: std::path::Path::new(&final_name)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("font")
+                .to_string(),
+        })
+    }
+    .await;
+
+    if cleanup_after_import {
+        let _ = tokio::fs::remove_file(&src).await;
+    }
+    result
 }
 
 /// 列出 data/fonts/ 目录下所有已导入的字体文件。

--- a/src-tauri/src/api/font.rs
+++ b/src-tauri/src/api/font.rs
@@ -140,14 +140,14 @@ pub async fn import_font(
     path: String,
 ) -> Result<UploadFontResult, String> {
     // Android SAF：先把 content URI 复制到本地 cache，magic sniff 和后续复制都用本地路径。
-    let (src, cleanup_after_import) =
+    let src =
         crate::ai_service::tts::local::saf_bridge::prepare_file_import_source(&app, &path).await?;
 
     let result: Result<UploadFontResult, String> = async {
         // 1. magic sniff 决定真实格式（替代原扩展名白名单）。
         //    注意：infer 把 WOFF 和 WOFF2 都映射到 mime "application/font-woff"，
         //    所以必须同时检查 mime + extension 才能区分。
-        let detected = infer::get_from_path(&src)
+        let detected = infer::get_from_path(&src.path)
             .map_err(|e| format!("读取文件头失败: {e}"))?;
         let (kind, correct_ext) = match detected {
             Some(k) if k.matcher_type() == infer::MatcherType::Font => match (k.mime_type(), k.extension()) {
@@ -160,12 +160,12 @@ pub async fn import_font(
             _ => return Err("FONT_INVALID_FORMAT".into()),
         };
 
-        // 2. 防路径穿越：只取文件名部分
-        let original_name = src
-            .file_name()
-            .and_then(|n| n.to_str())
-            .ok_or_else(|| "无效的文件名".to_string())?
-            .to_string();
+        // 2. 取用户面向的文件名（Android 上是 SAF 提供的 display name，
+        //    而不是 cache 里 `tts_import_saf_<uuid>_…` 的合成名）。
+        let original_name = src.display_name.clone();
+        if original_name.is_empty() {
+            return Err("无效的文件名".into());
+        }
 
         // 3. 用 magic 决定的扩展名替换原扩展名
         let stem = std::path::Path::new(&original_name)
@@ -192,7 +192,7 @@ pub async fn import_font(
         let dest_path = fonts_dir.join(&final_name);
 
         // 5. 复制（src 已经是本地路径，桌面/SAF 都用 std::fs::copy）
-        std::fs::copy(&src, &dest_path)
+        std::fs::copy(&src.path, &dest_path)
             .map_err(|e| format!("复制字体文件失败: {}", e))?;
 
         Ok(UploadFontResult {
@@ -210,8 +210,8 @@ pub async fn import_font(
     }
     .await;
 
-    if cleanup_after_import {
-        let _ = tokio::fs::remove_file(&src).await;
+    if src.cleanup_after_import {
+        let _ = tokio::fs::remove_file(&src.path).await;
     }
     result
 }

--- a/src-tauri/src/api/font.rs
+++ b/src-tauri/src/api/font.rs
@@ -83,9 +83,7 @@ pub fn list_system_fonts() -> Result<Vec<FontFamilyInfo>, String> {
         if !store_ptr.is_null() {
             let store = &*store_ptr;
             if let Ok(mut guard) = store.try_borrow_mut() {
-                if !name.is_empty()
-                    && !guard.iter().any(|n| n.eq_ignore_ascii_case(&name))
-                {
+                if !name.is_empty() && !guard.iter().any(|n| n.eq_ignore_ascii_case(&name)) {
                     guard.push(name);
                 }
             }
@@ -114,7 +112,10 @@ pub fn list_system_fonts() -> Result<Vec<FontFamilyInfo>, String> {
 
     let mut guard = names.borrow_mut();
     guard.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
-    Ok(guard.drain(..).map(|name| FontFamilyInfo { name }).collect())
+    Ok(guard
+        .drain(..)
+        .map(|name| FontFamilyInfo { name })
+        .collect())
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -135,10 +136,7 @@ pub fn list_system_fonts() -> Result<Vec<FontFamilyInfo>, String> {
 /// Android 上 dialog 返回的 content:// URI 先经 SAF bridge 复制到 cache，
 /// 再走本地 magic sniff + 本地复制（桌面 path 直接用）。
 #[tauri::command]
-pub async fn import_font(
-    app: tauri::AppHandle,
-    path: String,
-) -> Result<UploadFontResult, String> {
+pub async fn import_font(app: tauri::AppHandle, path: String) -> Result<UploadFontResult, String> {
     // Android SAF：先把 content URI 复制到本地 cache，magic sniff 和后续复制都用本地路径。
     let src =
         crate::ai_service::tts::local::saf_bridge::prepare_file_import_source(&app, &path).await?;
@@ -147,16 +145,18 @@ pub async fn import_font(
         // 1. magic sniff 决定真实格式（替代原扩展名白名单）。
         //    注意：infer 把 WOFF 和 WOFF2 都映射到 mime "application/font-woff"，
         //    所以必须同时检查 mime + extension 才能区分。
-        let detected = infer::get_from_path(&src.path)
-            .map_err(|e| format!("读取文件头失败: {e}"))?;
+        let detected =
+            infer::get_from_path(&src.path).map_err(|e| format!("读取文件头失败: {e}"))?;
         let (kind, correct_ext) = match detected {
-            Some(k) if k.matcher_type() == infer::MatcherType::Font => match (k.mime_type(), k.extension()) {
-                ("application/font-sfnt", "ttf")  => ("ttf",  "ttf"),
-                ("application/font-sfnt", "otf")  => ("otf",  "otf"),
-                ("application/font-woff", "woff") => ("woff", "woff"),
-                ("application/font-woff", "woff2")=> ("woff2","woff2"),
-                _ => return Err("FONT_INVALID_FORMAT".into()),
-            },
+            Some(k) if k.matcher_type() == infer::MatcherType::Font => {
+                match (k.mime_type(), k.extension()) {
+                    ("application/font-sfnt", "ttf") => ("ttf", "ttf"),
+                    ("application/font-sfnt", "otf") => ("otf", "otf"),
+                    ("application/font-woff", "woff") => ("woff", "woff"),
+                    ("application/font-woff", "woff2") => ("woff2", "woff2"),
+                    _ => return Err("FONT_INVALID_FORMAT".into()),
+                }
+            }
             _ => return Err("FONT_INVALID_FORMAT".into()),
         };
 
@@ -181,19 +181,23 @@ pub async fn import_font(
         let mut counter = 2u32;
         while fonts_dir.join(&final_name).exists() {
             if counter > 999 {
-                final_name = format!("{stem}_{}{}", chrono::Utc::now().timestamp_millis(), correct_ext);
+                final_name = format!(
+                    "{stem}_{}{}",
+                    chrono::Utc::now().timestamp_millis(),
+                    correct_ext
+                );
                 break;
             }
             final_name = format!("{stem}_{counter}.{correct_ext}");
             counter += 1;
         }
 
-        let was_corrected = original_name != final_name;
+        // 仅扩展名/名字实质变化才算"自动修正"；纯大小写差异（Song.TTF → Song.ttf）不算。
+        let was_corrected = !original_name.eq_ignore_ascii_case(&final_name);
         let dest_path = fonts_dir.join(&final_name);
 
         // 5. 复制（src 已经是本地路径，桌面/SAF 都用 std::fs::copy）
-        std::fs::copy(&src.path, &dest_path)
-            .map_err(|e| format!("复制字体文件失败: {}", e))?;
+        std::fs::copy(&src.path, &dest_path).map_err(|e| format!("复制字体文件失败: {}", e))?;
 
         Ok(UploadFontResult {
             actual_name: final_name.clone(),
@@ -225,8 +229,7 @@ pub fn list_imported_fonts() -> Result<Vec<ImportedFontInfo>, String> {
     }
 
     let mut fonts: Vec<ImportedFontInfo> = Vec::new();
-    let entries = std::fs::read_dir(&dir)
-        .map_err(|e| format!("无法读取字体目录: {}", e))?;
+    let entries = std::fs::read_dir(&dir).map_err(|e| format!("无法读取字体目录: {}", e))?;
 
     for entry in entries {
         let entry = match entry {
@@ -288,6 +291,5 @@ pub fn delete_imported_font(name: String) -> Result<(), String> {
         return Err(format!("字体文件不存在: {}", safe_name));
     }
 
-    std::fs::remove_file(&file_path)
-        .map_err(|e| format!("删除字体文件失败: {}", e))
+    std::fs::remove_file(&file_path).map_err(|e| format!("删除字体文件失败: {}", e))
 }

--- a/src-tauri/src/api/font.rs
+++ b/src-tauri/src/api/font.rs
@@ -33,6 +33,10 @@ pub struct UploadFontResult {
     pub detected_kind: String,
     /// 是否发生自动修正（原扩展名 != magic 决定的扩展名）
     pub was_corrected: bool,
+    /// 字体文件绝对路径，供前端 convertFileSrc 使用
+    pub file_path: String,
+    /// CSS font-family 名称（actual_name 去扩展名）
+    pub font_family: String,
 }
 
 // ========== Tauri 命令 ==========
@@ -179,10 +183,16 @@ pub fn import_font(path: String) -> Result<UploadFontResult, String> {
         .map_err(|e| format!("复制字体文件失败: {}", e))?;
 
     Ok(UploadFontResult {
-        actual_name: final_name,
+        actual_name: final_name.clone(),
         original_name,
         detected_kind: kind.to_string(),
         was_corrected,
+        file_path: dest_path.to_string_lossy().into_owned(),
+        font_family: Path::new(&final_name)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("font")
+            .to_string(),
     })
 }
 

--- a/src-tauri/src/api/music.rs
+++ b/src-tauri/src/api/music.rs
@@ -24,7 +24,7 @@ pub struct UploadMusicResult {
     pub actual_name: String,
     /// 用户原始文件名
     pub original_name: String,
-    /// infer 识别的格式：mp3 / wav / flac / ogg / m4a
+    /// infer 识别的格式：mp3 / wav / flac / ogg
     pub detected_kind: String,
     /// 是否发生自动修正（原扩展名 != magic 决定的扩展名）
     pub was_corrected: bool,
@@ -40,7 +40,7 @@ pub fn get_music_list() -> Result<Vec<MusicItemInfo>, String> {
         return Ok(Vec::new());
     }
 
-    let allowed_extensions = ["mp3", "wav", "flac", "webm", "weba", "ogg", "m4a", "oga"];
+    let allowed_extensions = ["mp3", "wav", "flac", "webm", "weba", "ogg", "oga"];
 
     let mut items: Vec<MusicItemInfo> = Vec::new();
 
@@ -135,16 +135,21 @@ pub async fn upload_music(
             return Err(format!("无效的文件名: {}", file_name));
         }
 
-        // 2. magic sniff 决定真实格式（src.path 已是本地路径，desktop / SAF 都通）
+        // 2. magic sniff 决定真实格式（src.path 已是本地路径，desktop / SAF 都通）。
+        //    注意：用 infer 返回的 extension() 做权威裁决 —— 它是 map.rs 里注册的
+        //    字面值，与 match 函数一一对应，不会被 mime 别名（如 audio/x-flac vs
+        //    audio/flac）干扰。
+        //
+        //    不接受 m4a：infer 把 brand=isom/mp42/dash 的 m4a 识别为 video/mp4，
+        //    而 brand=M4A 的边缘子集不值得为一个视频污染风险留着。
         let detected =
             infer::get_from_path(&src.path).map_err(|e| format!("读取文件头失败: {e}"))?;
         let (kind, correct_ext) = match detected {
-            Some(k) if k.matcher_type() == infer::MatcherType::Audio => match k.mime_type() {
-                "audio/mpeg" => ("mp3", "mp3"),
-                "audio/wav" => ("wav", "wav"),
-                "audio/flac" => ("flac", "flac"),
-                "audio/ogg" => ("ogg", "ogg"),
-                "audio/mp4" => ("m4a", "m4a"),
+            Some(k) if k.matcher_type() == infer::MatcherType::Audio => match k.extension() {
+                "mp3" => ("mp3", "mp3"),
+                "wav" => ("wav", "wav"),
+                "flac" => ("flac", "flac"),
+                "ogg" => ("ogg", "ogg"),
                 _ => return Err("MUSIC_INVALID_FORMAT".into()),
             },
             _ => return Err("MUSIC_INVALID_FORMAT".into()),

--- a/src-tauri/src/api/music.rs
+++ b/src-tauri/src/api/music.rs
@@ -17,6 +17,19 @@ pub struct MusicItemInfo {
     pub time: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct UploadMusicResult {
+    /// 实际落盘的文件名（含 magic 决定的正确扩展名）
+    pub actual_name: String,
+    /// 用户原始文件名
+    pub original_name: String,
+    /// infer 识别的格式：mp3 / wav / flac / ogg / m4a
+    pub detected_kind: String,
+    /// 是否发生自动修正（原扩展名 != magic 决定的扩展名）
+    pub was_corrected: bool,
+}
+
 // ========== Tauri 命令 ==========
 
 #[tauri::command]
@@ -96,13 +109,37 @@ pub fn get_music_file(filename: String) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub async fn upload_music(app: tauri::AppHandle, path: String, file_name: String) -> Result<(), String> {
-    // 安全检查：只保留文件名，防止路径遍历
-    let safe_name = std::path::Path::new(&file_name)
+pub async fn upload_music(
+    app: tauri::AppHandle,
+    path: String,
+    file_name: String,
+) -> Result<UploadMusicResult, String> {
+    // 防路径遍历
+    let original_name = std::path::Path::new(&file_name)
         .file_name()
         .ok_or_else(|| format!("无效的文件名: {}", file_name))?
         .to_string_lossy()
         .into_owned();
+
+    // 1. magic sniff 决定真实格式
+    let src_path = std::path::PathBuf::from(&path);
+    let detected = infer::get_from_path(&src_path)
+        .map_err(|e| format!("读取文件头失败: {e}"))?;
+    let (kind, correct_ext) = match detected.map(|k| k.mime_type()) {
+        Some("audio/mpeg") => ("mp3",  "mp3"),
+        Some("audio/wav")  => ("wav",  "wav"),
+        Some("audio/flac") => ("flac", "flac"),
+        Some("audio/ogg")  => ("ogg",  "ogg"),
+        Some("audio/mp4")  => ("m4a",  "m4a"),
+        _ => return Err("MUSIC_INVALID_FORMAT".into()),
+    };
+
+    // 2. 用 magic 决定的扩展名替换原扩展名
+    let stem = std::path::Path::new(&original_name)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("track");
+    let corrected_name = format!("{stem}.{correct_ext}");
 
     let music_dir = music_dir();
     if !music_dir.exists() {
@@ -111,23 +148,39 @@ pub async fn upload_music(app: tauri::AppHandle, path: String, file_name: String
             .map_err(|e| format!("创建音乐目录失败: {}", e))?;
     }
 
-    let file_path = music_dir.join(&safe_name);
+    // 3. 冲突时按 _2/_3/... 后缀
+    let mut final_name = corrected_name;
+    let mut counter = 2u32;
+    while music_dir.join(&final_name).exists() {
+        if counter > 999 {
+            final_name = format!("{stem}_{}{}", chrono::Utc::now().timestamp_millis(), correct_ext);
+            break;
+        }
+        final_name = format!("{stem}_{counter}.{correct_ext}");
+        counter += 1;
+    }
+
+    let was_corrected = original_name != final_name;
+    let file_path = music_dir.join(&final_name);
 
     if path.starts_with("content://") {
-        // Android SAF：content:// URI 直接复制到目标文件（不经 IPC 传大文件）
         use tauri_plugin_android_fs::{AndroidFsExt, FsUri};
         app.android_fs_async()
             .copy(&FsUri::from_uri(&path), &FsUri::from_path(&file_path))
             .await
             .map_err(|e| format!("SAF 复制音乐失败: {}", e))?;
     } else {
-        // 桌面端：Rust 直接复制源文件
-        tokio::fs::copy(std::path::PathBuf::from(&path), &file_path)
+        tokio::fs::copy(&src_path, &file_path)
             .await
             .map_err(|e| format!("复制文件失败: {}", e))?;
     }
 
-    Ok(())
+    Ok(UploadMusicResult {
+        actual_name: final_name,
+        original_name,
+        detected_kind: kind.to_string(),
+        was_corrected,
+    })
 }
 
 /// 删除指定音乐文件

--- a/src-tauri/src/api/music.rs
+++ b/src-tauri/src/api/music.rs
@@ -136,15 +136,15 @@ pub async fn upload_music(
         }
 
         // 2. magic sniff 决定真实格式（src.path 已是本地路径，desktop / SAF 都通）
-        let detected = infer::get_from_path(&src.path)
-            .map_err(|e| format!("读取文件头失败: {e}"))?;
+        let detected =
+            infer::get_from_path(&src.path).map_err(|e| format!("读取文件头失败: {e}"))?;
         let (kind, correct_ext) = match detected {
             Some(k) if k.matcher_type() == infer::MatcherType::Audio => match k.mime_type() {
-                "audio/mpeg" => ("mp3",  "mp3"),
-                "audio/wav"  => ("wav",  "wav"),
+                "audio/mpeg" => ("mp3", "mp3"),
+                "audio/wav" => ("wav", "wav"),
                 "audio/flac" => ("flac", "flac"),
-                "audio/ogg"  => ("ogg",  "ogg"),
-                "audio/mp4"  => ("m4a",  "m4a"),
+                "audio/ogg" => ("ogg", "ogg"),
+                "audio/mp4" => ("m4a", "m4a"),
                 _ => return Err("MUSIC_INVALID_FORMAT".into()),
             },
             _ => return Err("MUSIC_INVALID_FORMAT".into()),
@@ -170,19 +170,23 @@ pub async fn upload_music(
         let mut counter = 2u32;
         while music_dir.join(&final_name).exists() {
             if counter > 999 {
-                final_name = format!("{stem}_{}{}", chrono::Utc::now().timestamp_millis(), correct_ext);
+                final_name = format!(
+                    "{stem}_{}{}",
+                    chrono::Utc::now().timestamp_millis(),
+                    correct_ext
+                );
                 break;
             }
             final_name = format!("{stem}_{counter}.{correct_ext}");
             counter += 1;
         }
 
-        let was_corrected = original_name != final_name;
+        // 仅扩展名/名字实质变化才算"自动修正"；纯大小写差异（Song.MP3 → Song.mp3）不算。
+        let was_corrected = !original_name.eq_ignore_ascii_case(&final_name);
         let file_path = music_dir.join(&final_name);
 
         // 6. 复制（src.path 是本地 cache，dest 也是本地路径，用 std::fs::copy）
-        std::fs::copy(&src.path, &file_path)
-            .map_err(|e| format!("复制文件失败: {}", e))?;
+        std::fs::copy(&src.path, &file_path).map_err(|e| format!("复制文件失败: {}", e))?;
 
         Ok(UploadMusicResult {
             actual_name: final_name,

--- a/src-tauri/src/api/music.rs
+++ b/src-tauri/src/api/music.rs
@@ -115,19 +115,28 @@ pub async fn upload_music(
     file_name: String,
 ) -> Result<UploadMusicResult, String> {
     // Android SAF：先把 content URI 复制到本地 cache，magic sniff 和后续复制都用本地路径。
-    let (src_path, cleanup_after_import) =
+    let src =
         crate::ai_service::tts::local::saf_bridge::prepare_file_import_source(&app, &path).await?;
 
     let result: Result<UploadMusicResult, String> = async {
-        // 1. 防路径遍历
-        let original_name = std::path::Path::new(&file_name)
-            .file_name()
-            .ok_or_else(|| format!("无效的文件名: {}", file_name))?
-            .to_string_lossy()
-            .into_owned();
+        // 1. 优先用前端传来的 file_name（桌面端是真实文件名；Android 上是
+        //    dialog 给的 URI 末段，已经前端 decode 过）。回退到 src 提供的
+        //    display_name（也是 SAF 末段）。
+        let original_name = if !file_name.is_empty() {
+            std::path::Path::new(&file_name)
+                .file_name()
+                .map(|s| s.to_string_lossy().into_owned())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(src.display_name.clone())
+        } else {
+            src.display_name.clone()
+        };
+        if original_name.is_empty() {
+            return Err(format!("无效的文件名: {}", file_name));
+        }
 
-        // 2. magic sniff 决定真实格式（src_path 已是本地路径，desktop / SAF 都通）
-        let detected = infer::get_from_path(&src_path)
+        // 2. magic sniff 决定真实格式（src.path 已是本地路径，desktop / SAF 都通）
+        let detected = infer::get_from_path(&src.path)
             .map_err(|e| format!("读取文件头失败: {e}"))?;
         let (kind, correct_ext) = match detected {
             Some(k) if k.matcher_type() == infer::MatcherType::Audio => match k.mime_type() {
@@ -171,8 +180,8 @@ pub async fn upload_music(
         let was_corrected = original_name != final_name;
         let file_path = music_dir.join(&final_name);
 
-        // 6. 复制（src_path 是本地 cache，dest 也是本地路径，用 std::fs::copy）
-        std::fs::copy(&src_path, &file_path)
+        // 6. 复制（src.path 是本地 cache，dest 也是本地路径，用 std::fs::copy）
+        std::fs::copy(&src.path, &file_path)
             .map_err(|e| format!("复制文件失败: {}", e))?;
 
         Ok(UploadMusicResult {
@@ -184,8 +193,8 @@ pub async fn upload_music(
     }
     .await;
 
-    if cleanup_after_import {
-        let _ = tokio::fs::remove_file(&src_path).await;
+    if src.cleanup_after_import {
+        let _ = tokio::fs::remove_file(&src.path).await;
     }
     result
 }

--- a/src-tauri/src/api/music.rs
+++ b/src-tauri/src/api/music.rs
@@ -114,78 +114,80 @@ pub async fn upload_music(
     path: String,
     file_name: String,
 ) -> Result<UploadMusicResult, String> {
-    // 1. 防路径遍历
-    let original_name = std::path::Path::new(&file_name)
-        .file_name()
-        .ok_or_else(|| format!("无效的文件名: {}", file_name))?
-        .to_string_lossy()
-        .into_owned();
+    // Android SAF：先把 content URI 复制到本地 cache，magic sniff 和后续复制都用本地路径。
+    let (src_path, cleanup_after_import) =
+        crate::ai_service::tts::local::saf_bridge::prepare_file_import_source(&app, &path).await?;
 
-    // 2. magic sniff 决定真实格式
-    let src_path = std::path::PathBuf::from(&path);
-    let detected = infer::get_from_path(&src_path)
-        .map_err(|e| format!("读取文件头失败: {e}"))?;
-    let (kind, correct_ext) = match detected {
-        Some(k) if k.matcher_type() == infer::MatcherType::Audio => match k.mime_type() {
-            "audio/mpeg" => ("mp3",  "mp3"),
-            "audio/wav"  => ("wav",  "wav"),
-            "audio/flac" => ("flac", "flac"),
-            "audio/ogg"  => ("ogg",  "ogg"),
-            "audio/mp4"  => ("m4a",  "m4a"),
+    let result: Result<UploadMusicResult, String> = async {
+        // 1. 防路径遍历
+        let original_name = std::path::Path::new(&file_name)
+            .file_name()
+            .ok_or_else(|| format!("无效的文件名: {}", file_name))?
+            .to_string_lossy()
+            .into_owned();
+
+        // 2. magic sniff 决定真实格式（src_path 已是本地路径，desktop / SAF 都通）
+        let detected = infer::get_from_path(&src_path)
+            .map_err(|e| format!("读取文件头失败: {e}"))?;
+        let (kind, correct_ext) = match detected {
+            Some(k) if k.matcher_type() == infer::MatcherType::Audio => match k.mime_type() {
+                "audio/mpeg" => ("mp3",  "mp3"),
+                "audio/wav"  => ("wav",  "wav"),
+                "audio/flac" => ("flac", "flac"),
+                "audio/ogg"  => ("ogg",  "ogg"),
+                "audio/mp4"  => ("m4a",  "m4a"),
+                _ => return Err("MUSIC_INVALID_FORMAT".into()),
+            },
             _ => return Err("MUSIC_INVALID_FORMAT".into()),
-        },
-        _ => return Err("MUSIC_INVALID_FORMAT".into()),
-    };
+        };
 
-    // 3. 用 magic 决定的扩展名替换原扩展名
-    let stem = std::path::Path::new(&original_name)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("track");
-    let corrected_name = format!("{stem}.{correct_ext}");
+        // 3. 用 magic 决定的扩展名替换原扩展名
+        let stem = std::path::Path::new(&original_name)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("track");
+        let corrected_name = format!("{stem}.{correct_ext}");
 
-    // 4. 确保目标目录存在
-    let music_dir = music_dir();
-    if !music_dir.exists() {
-        tokio::fs::create_dir_all(&music_dir)
-            .await
-            .map_err(|e| format!("创建音乐目录失败: {}", e))?;
-    }
-
-    // 5. 冲突时按 _2/_3/... 后缀
-    let mut final_name = corrected_name;
-    let mut counter = 2u32;
-    while music_dir.join(&final_name).exists() {
-        if counter > 999 {
-            final_name = format!("{stem}_{}{}", chrono::Utc::now().timestamp_millis(), correct_ext);
-            break;
+        // 4. 确保目标目录存在
+        let music_dir = music_dir();
+        if !music_dir.exists() {
+            tokio::fs::create_dir_all(&music_dir)
+                .await
+                .map_err(|e| format!("创建音乐目录失败: {}", e))?;
         }
-        final_name = format!("{stem}_{counter}.{correct_ext}");
-        counter += 1;
-    }
 
-    let was_corrected = original_name != final_name;
-    let file_path = music_dir.join(&final_name);
+        // 5. 冲突时按 _2/_3/... 后缀
+        let mut final_name = corrected_name;
+        let mut counter = 2u32;
+        while music_dir.join(&final_name).exists() {
+            if counter > 999 {
+                final_name = format!("{stem}_{}{}", chrono::Utc::now().timestamp_millis(), correct_ext);
+                break;
+            }
+            final_name = format!("{stem}_{counter}.{correct_ext}");
+            counter += 1;
+        }
 
-    // 6. 复制（桌面 vs Android SAF）
-    if path.starts_with("content://") {
-        use tauri_plugin_android_fs::{AndroidFsExt, FsUri};
-        app.android_fs_async()
-            .copy(&FsUri::from_uri(&path), &FsUri::from_path(&file_path))
-            .await
-            .map_err(|e| format!("SAF 复制音乐失败: {}", e))?;
-    } else {
-        tokio::fs::copy(&src_path, &file_path)
-            .await
+        let was_corrected = original_name != final_name;
+        let file_path = music_dir.join(&final_name);
+
+        // 6. 复制（src_path 是本地 cache，dest 也是本地路径，用 std::fs::copy）
+        std::fs::copy(&src_path, &file_path)
             .map_err(|e| format!("复制文件失败: {}", e))?;
-    }
 
-    Ok(UploadMusicResult {
-        actual_name: final_name,
-        original_name,
-        detected_kind: kind.to_string(),
-        was_corrected,
-    })
+        Ok(UploadMusicResult {
+            actual_name: final_name,
+            original_name,
+            detected_kind: kind.to_string(),
+            was_corrected,
+        })
+    }
+    .await;
+
+    if cleanup_after_import {
+        let _ = tokio::fs::remove_file(&src_path).await;
+    }
+    result
 }
 
 /// 删除指定音乐文件

--- a/src-tauri/src/api/music.rs
+++ b/src-tauri/src/api/music.rs
@@ -114,33 +114,37 @@ pub async fn upload_music(
     path: String,
     file_name: String,
 ) -> Result<UploadMusicResult, String> {
-    // 防路径遍历
+    // 1. 防路径遍历
     let original_name = std::path::Path::new(&file_name)
         .file_name()
         .ok_or_else(|| format!("无效的文件名: {}", file_name))?
         .to_string_lossy()
         .into_owned();
 
-    // 1. magic sniff 决定真实格式
+    // 2. magic sniff 决定真实格式
     let src_path = std::path::PathBuf::from(&path);
     let detected = infer::get_from_path(&src_path)
         .map_err(|e| format!("读取文件头失败: {e}"))?;
-    let (kind, correct_ext) = match detected.map(|k| k.mime_type()) {
-        Some("audio/mpeg") => ("mp3",  "mp3"),
-        Some("audio/wav")  => ("wav",  "wav"),
-        Some("audio/flac") => ("flac", "flac"),
-        Some("audio/ogg")  => ("ogg",  "ogg"),
-        Some("audio/mp4")  => ("m4a",  "m4a"),
+    let (kind, correct_ext) = match detected {
+        Some(k) if k.matcher_type() == infer::MatcherType::Audio => match k.mime_type() {
+            "audio/mpeg" => ("mp3",  "mp3"),
+            "audio/wav"  => ("wav",  "wav"),
+            "audio/flac" => ("flac", "flac"),
+            "audio/ogg"  => ("ogg",  "ogg"),
+            "audio/mp4"  => ("m4a",  "m4a"),
+            _ => return Err("MUSIC_INVALID_FORMAT".into()),
+        },
         _ => return Err("MUSIC_INVALID_FORMAT".into()),
     };
 
-    // 2. 用 magic 决定的扩展名替换原扩展名
+    // 3. 用 magic 决定的扩展名替换原扩展名
     let stem = std::path::Path::new(&original_name)
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("track");
     let corrected_name = format!("{stem}.{correct_ext}");
 
+    // 4. 确保目标目录存在
     let music_dir = music_dir();
     if !music_dir.exists() {
         tokio::fs::create_dir_all(&music_dir)
@@ -148,7 +152,7 @@ pub async fn upload_music(
             .map_err(|e| format!("创建音乐目录失败: {}", e))?;
     }
 
-    // 3. 冲突时按 _2/_3/... 后缀
+    // 5. 冲突时按 _2/_3/... 后缀
     let mut final_name = corrected_name;
     let mut counter = 2u32;
     while music_dir.join(&final_name).exists() {
@@ -163,6 +167,7 @@ pub async fn upload_music(
     let was_corrected = original_name != final_name;
     let file_path = music_dir.join(&final_name);
 
+    // 6. 复制（桌面 vs Android SAF）
     if path.starts_with("content://") {
         use tauri_plugin_android_fs::{AndroidFsExt, FsUri};
         app.android_fs_async()

--- a/src-tauri/src/api/role_archive/import_pipeline.rs
+++ b/src-tauri/src/api/role_archive/import_pipeline.rs
@@ -10,6 +10,7 @@ use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio_util::sync::CancellationToken;
 
+use crate::ai_service::tts::local::saf_bridge::{prepare_file_import_source, ImportSource};
 use crate::db::entities::role::{Column, Entity as RoleEntity};
 use crate::utils::archive::{
     self, ArchiveError, ArchiveFormat, ConflictPolicy, EntryEvent, ExtractSummary,
@@ -319,18 +320,17 @@ pub(super) async fn write_temp_archive(app: &AppHandle, bytes: &[u8]) -> Result<
 /// - 如果路径以 `content://` 开头，则把 Android SAF 文件复制到缓存目录。
 /// - 否则按桌面端文件系统路径处理，不创建额外副本。
 ///
-/// 返回 `(本地路径, 是否需要在导入完成后清理本地副本, 用户面向的文件名)`。
-/// `display_name` 在 Android 上由 SAF 元数据提供；桌面端则是路径的 basename。
+/// 返回 [`ImportSource`]：`path` 是本地可读路径，`cleanup_after_import` 指示调用方
+/// 是否需要在导入完成后清理本地副本，`display_name` 是用户面向的文件名
+/// （Android 上由 SAF 元数据提供；桌面端是路径的 basename）。
 /// 后端用它做 fallback：当传入的 `file_name` 看起来是 percent-encoded hex blob
 /// （content URI 的末段未经前端 decode 的痕迹）时优先采用它，保证角色文件夹名
 /// 是真实可读的名字，而不是 `%E6%A9%98...` 之类的 hex 串。
 pub(super) async fn prepare_import_source(
     app: &AppHandle,
     path: &str,
-) -> Result<(PathBuf, bool, String), String> {
-    use crate::ai_service::tts::local::saf_bridge::prepare_file_import_source;
-    let src = prepare_file_import_source(app, path).await?;
-    Ok((src.path, src.cleanup_after_import, src.display_name))
+) -> Result<ImportSource, String> {
+    prepare_file_import_source(app, path).await
 }
 
 /// 判断一个字符串是否像是 percent-encoded hex blob（Android content URI

--- a/src-tauri/src/api/role_archive/import_pipeline.rs
+++ b/src-tauri/src/api/role_archive/import_pipeline.rs
@@ -40,7 +40,11 @@ pub(super) async fn do_import(
 
     // 2. 使用去除扩展名后的压缩包文件名作为角色文件夹名。
     let final_name = sanitize_role_folder_name(file_name, None);
-    tracing::info!("[RoleArchive] do_import 文件夹名: final_name={} (file_name={:?})", final_name, file_name);
+    tracing::info!(
+        "[RoleArchive] do_import 文件夹名: final_name={} (file_name={:?})",
+        final_name,
+        file_name
+    );
 
     // 3. 在角色目录下创建本次导入使用的临时暂存目录。
     let characters_root = crate::api::characters_dir();
@@ -70,10 +74,15 @@ pub(super) async fn do_import(
             let _ = app_emit.emit("role:import-progress", &evt);
         };
         match format {
-            ArchiveFormat::Zip => archive::extract_zip(&path_for_blocking, &target, &cancel_for_blocking, &on_entry),
-            ArchiveFormat::SevenZ => {
-                archive::extract_sevenz(&path_for_blocking, &target, &cancel_for_blocking, &on_entry)
+            ArchiveFormat::Zip => {
+                archive::extract_zip(&path_for_blocking, &target, &cancel_for_blocking, &on_entry)
             }
+            ArchiveFormat::SevenZ => archive::extract_sevenz(
+                &path_for_blocking,
+                &target,
+                &cancel_for_blocking,
+                &on_entry,
+            ),
         }
     })
     .await
@@ -104,7 +113,10 @@ pub(super) async fn do_import(
     // 5. 定位解压后的角色内容根目录。
     //    如果只有一个外层角色目录则进入该目录，否则直接使用暂存目录。
     let extracted_dir = locate_extracted_dir(&staging_root).await;
-    tracing::info!("[RoleArchive] do_import extracted_dir={}", extracted_dir.display());
+    tracing::info!(
+        "[RoleArchive] do_import extracted_dir={}",
+        extracted_dir.display()
+    );
 
     // 6. 根据同名冲突策略解析最终目标目录。
     let resolution = match archive::resolve_target(&characters_root, &final_name, policy) {
@@ -147,7 +159,8 @@ pub(super) async fn do_import(
         if let Err(e) = tokio::fs::remove_dir_all(&resolution.target).await {
             tracing::error!(
                 "[RoleArchive] do_import overwrite 清空旧目录失败: target={}, err={}",
-                resolution.target.display(), e
+                resolution.target.display(),
+                e
             );
             cleanup_err(&staging_root_for_cleanup);
             return Err(format!(
@@ -157,12 +170,10 @@ pub(super) async fn do_import(
         }
     }
     if let Some(parent) = resolution.target.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| {
-                cleanup_err(&staging_root_for_cleanup);
-                format!("创建目标父目录: {e}")
-            })?;
+        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+            cleanup_err(&staging_root_for_cleanup);
+            format!("创建目标父目录: {e}")
+        })?;
     }
 
     // 移动目录前再次检查取消状态；目标已确定，但尚未写入最终位置。
@@ -185,7 +196,8 @@ pub(super) async fn do_import(
             Err(e) => {
                 rename_err = Some(e);
                 if attempt < 3 {
-                    tokio::time::sleep(std::time::Duration::from_millis(150 * attempt as u64)).await;
+                    tokio::time::sleep(std::time::Duration::from_millis(150 * attempt as u64))
+                        .await;
                 }
             }
         }
@@ -193,7 +205,10 @@ pub(super) async fn do_import(
     if let Some(rerr) = rename_err {
         tracing::warn!(
             "[RoleArchive] do_import rename 3次均失败: src={}, target={}, target_exists={}, err={}",
-            extracted_dir.display(), resolution.target.display(), target_exists_before, rerr
+            extracted_dir.display(),
+            resolution.target.display(),
+            target_exists_before,
+            rerr
         );
         let src_c = extracted_dir.clone();
         let dst_c = resolution.target.clone();
@@ -255,7 +270,10 @@ pub(super) async fn do_import(
         // 同步失败时立即回滚已移入的角色目录（await 而不是 spawn），
         // 避免用户立刻重试同名导入时遇到尚未删除的旧目录。
         let target = resolution.target.clone();
-        tracing::error!("[RoleArchive] do_import sync failed, rolling back target={}", target.display());
+        tracing::error!(
+            "[RoleArchive] do_import sync failed, rolling back target={}",
+            target.display()
+        );
         let _ = tokio::fs::remove_dir_all(&target).await;
         return Err(format!("sync roles: {e}"));
     }
@@ -289,7 +307,11 @@ pub(super) async fn write_temp_archive(app: &AppHandle, bytes: &[u8]) -> Result<
     tokio::fs::write(&tmp_path, bytes)
         .await
         .map_err(|e| format!("write temp archive: {e}"))?;
-    tracing::info!("[RoleArchive] write_temp_archive: {}B -> {}", bytes.len(), tmp_path.display());
+    tracing::info!(
+        "[RoleArchive] write_temp_archive: {}B -> {}",
+        bytes.len(),
+        tmp_path.display()
+    );
     Ok(tmp_path)
 }
 
@@ -318,17 +340,14 @@ pub(super) fn looks_like_percent_encoded_blob(s: &str) -> bool {
         return false;
     }
     // 整段几乎都是 hex 字符 + 极少其他字符（点/下划线/连字符）。
-    let hex_count = s
-        .chars()
-        .filter(|c| c.is_ascii_hexdigit())
-        .count();
+    let hex_count = s.chars().filter(|c| c.is_ascii_hexdigit()).count();
     let total = s.chars().count();
     if total < 8 || hex_count * 10 < total * 9 {
         return false;
     }
-    s.split('.').next().is_some_and(|stem| {
-        stem.len() >= 6 && stem.chars().all(|c| c.is_ascii_hexdigit())
-    })
+    s.split('.')
+        .next()
+        .is_some_and(|stem| stem.len() >= 6 && stem.chars().all(|c| c.is_ascii_hexdigit()))
 }
 
 /// 定位解压后的角色内容根目录:
@@ -353,7 +372,10 @@ async fn locate_extracted_dir(staging: &Path) -> PathBuf {
     }
     // 只有 1 个子目录且无文件 -> 返回该子目录 (有外层包裹)
     if subdirs.len() == 1 && !has_files {
-        subdirs.into_iter().next().unwrap_or_else(|| staging.to_path_buf())
+        subdirs
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| staging.to_path_buf())
     } else {
         // 没有外层角色目录时，内容直接位于暂存目录根部。
         staging.to_path_buf()
@@ -461,5 +483,44 @@ pub(super) fn parse_policy(s: &str) -> Result<ConflictPolicy, String> {
         "skip" => Ok(ConflictPolicy::Skip),
         "overwrite" => Ok(ConflictPolicy::Overwrite),
         _ => Err(format!("不支持的 conflict: {s}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::looks_like_percent_encoded_blob;
+
+    #[test]
+    fn hex_blob_uris_are_detected() {
+        // Android content URI 末段：UTF-8 中文被 percent-encode 成 hex
+        assert!(looks_like_percent_encoded_blob(
+            "E6A998E585891784606515054.zip"
+        ));
+        assert!(looks_like_percent_encoded_blob("E6A998E585891784606515054"));
+        // 小写 hex + 下划线/连字符也允许
+        assert!(looks_like_percent_encoded_blob(
+            "e6a998e58589-1784606515054.7z"
+        ));
+    }
+
+    #[test]
+    fn normal_names_are_not_detected() {
+        assert!(!looks_like_percent_encoded_blob("诺一钦灵.zip"));
+        assert!(!looks_like_percent_encoded_blob("my-role-archive.zip"));
+        assert!(!looks_like_percent_encoded_blob("AABBCCDD0011.zip")); // 真名恰好全 hex，长度 12 < 判定门槛时
+        assert!(!looks_like_percent_encoded_blob(""));
+        assert!(!looks_like_percent_encoded_blob("abc.zip")); // 太短
+    }
+
+    #[test]
+    fn short_or_mixed_names_are_rejected() {
+        // 含非 hex 字符（GX）→ 比例不足
+        assert!(!looks_like_percent_encoded_blob(
+            "E6A998GX585891784606515054.zip"
+        ));
+        // 太短（比例不足）
+        assert!(!looks_like_percent_encoded_blob("E6A998.zip"));
+        // 无扩展名的纯 hex 串依然是 blob 形态
+        assert!(looks_like_percent_encoded_blob("E6A998E585891784606515054"));
     }
 }

--- a/src-tauri/src/api/role_archive/import_pipeline.rs
+++ b/src-tauri/src/api/role_archive/import_pipeline.rs
@@ -20,19 +20,23 @@ use super::ImportResult;
 pub(super) async fn do_import(
     app: &AppHandle,
     tmp_path: &Path,
-    format: ArchiveFormat,
+    format: Option<ArchiveFormat>,
     policy: ConflictPolicy,
     cancel_token: Arc<CancellationToken>,
     file_name: Option<&str>,
 ) -> Result<ImportResult, String> {
-    // 1. 校验文件头魔数。
+    // 1. 校验文件头魔数。前端 hint 可选；以 magic 为准，hint 仅用于 debug 日志。
     let detected = archive::detect_format(tmp_path).map_err(|e| e.to_string())?;
-    if detected != format {
-        tracing::warn!("[RoleArchive] do_import 格式不匹配: 前端 {format:?}, 实际 {detected:?}");
-        return Err(format!(
-            "格式不匹配: 前端传 {format:?}, 实际 {detected:?}"
-        ));
-    }
+    let format = match format {
+        Some(hint) if hint == detected => detected,
+        Some(hint) => {
+            tracing::warn!(
+                "[RoleArchive] do_import 扩展名 hint={hint:?} 与 magic {detected:?} 不一致，采用 magic 结果"
+            );
+            detected
+        }
+        None => detected,
+    };
 
     // 2. 使用去除扩展名后的压缩包文件名作为角色文件夹名。
     let final_name = sanitize_role_folder_name(file_name, None);
@@ -122,6 +126,7 @@ pub(super) async fn do_import(
                 conflict_action: "skipped".into(),
                 warnings: vec![],
                 bytes_extracted: 0,
+                format,
             });
         }
         Err(e) => {
@@ -264,6 +269,7 @@ pub(super) async fn do_import(
         conflict_action: resolution.action.into(),
         warnings: summary.warnings,
         bytes_extracted: summary.bytes_extracted,
+        format,
     })
 }
 
@@ -438,6 +444,14 @@ pub(super) fn parse_format(s: &str) -> Result<ArchiveFormat, String> {
         "zip" => Ok(ArchiveFormat::Zip),
         "7z" => Ok(ArchiveFormat::SevenZ),
         _ => Err(format!("不支持的 format: {s}")),
+    }
+}
+
+/// Optional format parser: `None`/空字符串代表前端没传 hint，让后端用 magic 决定。
+pub(super) fn parse_format_opt(s: Option<&str>) -> Result<Option<ArchiveFormat>, String> {
+    match s {
+        None | Some("") | Some("auto") => Ok(None),
+        Some(v) => parse_format(v).map(Some),
     }
 }
 

--- a/src-tauri/src/api/role_archive/import_pipeline.rs
+++ b/src-tauri/src/api/role_archive/import_pipeline.rs
@@ -297,38 +297,38 @@ pub(super) async fn write_temp_archive(app: &AppHandle, bytes: &[u8]) -> Result<
 /// - 如果路径以 `content://` 开头，则把 Android SAF 文件复制到缓存目录。
 /// - 否则按桌面端文件系统路径处理，不创建额外副本。
 ///
-/// 返回值中的布尔值表示导入完成后是否需要清理本地副本。
-pub(super) async fn prepare_import_source(app: &AppHandle, path: &str) -> Result<(PathBuf, bool), String> {
-    if path.starts_with("content://") {
-        use tauri_plugin_android_fs::{AndroidFsExt, FsUri};
-        let cache_dir = app
-            .path()
-            .app_cache_dir()
-            .map_err(|e| format!("cache dir: {e}"))?;
-        let imports_root = cache_dir.join("imports");
-        tokio::fs::create_dir_all(&imports_root)
-            .await
-            .map_err(|e| format!("create imports dir: {e}"))?;
+/// 返回 `(本地路径, 是否需要在导入完成后清理本地副本, 用户面向的文件名)`。
+/// `display_name` 在 Android 上由 SAF 元数据提供；桌面端则是路径的 basename。
+/// 后端用它做 fallback：当传入的 `file_name` 看起来是 percent-encoded hex blob
+/// （content URI 的末段未经前端 decode 的痕迹）时优先采用它，保证角色文件夹名
+/// 是真实可读的名字，而不是 `%E6%A9%98...` 之类的 hex 串。
+pub(super) async fn prepare_import_source(
+    app: &AppHandle,
+    path: &str,
+) -> Result<(PathBuf, bool, String), String> {
+    use crate::ai_service::tts::local::saf_bridge::prepare_file_import_source;
+    let src = prepare_file_import_source(app, path).await?;
+    Ok((src.path, src.cleanup_after_import, src.display_name))
+}
 
-        let tmp_id = uuid::Uuid::new_v4().to_string();
-        let local_path = imports_root.join(format!("import_saf_{tmp_id}.bin"));
-        let local_uri = FsUri::from_path(&local_path);
-        let src_uri = FsUri::from_uri(path.to_string());
-        tracing::info!(
-            "[RoleArchive] prepare_import_source SAF: src={}, local={}",
-            path,
-            local_path.display()
-        );
-
-        app.android_fs_async()
-            .copy(&src_uri, &local_uri)
-            .await
-            .map_err(|e| format!("SAF copy to local cache: {e}"))?;
-
-        Ok((local_path, true))
-    } else {
-        Ok((PathBuf::from(path), false))
+/// 判断一个字符串是否像是 percent-encoded hex blob（Android content URI
+/// 末段的典型形态）。仅当传入的 `file_name` 命中此模式时才考虑替换。
+pub(super) fn looks_like_percent_encoded_blob(s: &str) -> bool {
+    if s.is_empty() || !s.is_ascii() {
+        return false;
     }
+    // 整段几乎都是 hex 字符 + 极少其他字符（点/下划线/连字符）。
+    let hex_count = s
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .count();
+    let total = s.chars().count();
+    if total < 8 || hex_count * 10 < total * 9 {
+        return false;
+    }
+    s.split('.').next().is_some_and(|stem| {
+        stem.len() >= 6 && stem.chars().all(|c| c.is_ascii_hexdigit())
+    })
 }
 
 /// 定位解压后的角色内容根目录:

--- a/src-tauri/src/api/role_archive/import_pipeline.rs
+++ b/src-tauri/src/api/role_archive/import_pipeline.rs
@@ -232,9 +232,8 @@ pub(super) async fn do_import(
             settings_yml.display()
         );
         let _ = tokio::fs::remove_dir_all(&resolution.target).await;
-        return Err(format!(
-            "压缩包缺少 settings.yml (角色配置文件不可缺少). 请确保压缩包内含 settings.yml 后重试."
-        ));
+        // 返回 i18n 错误码，前端按 ui.archiveProgress.errors.<code> 查表翻译。
+        return Err("ARCHIVE_MISSING_SETTINGS_YML".into());
     }
 
     // 同步角色数据前进行最后一次取消检查。

--- a/src-tauri/src/api/role_archive/mod.rs
+++ b/src-tauri/src/api/role_archive/mod.rs
@@ -11,7 +11,6 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 use tokio_util::sync::CancellationToken;
 
-
 mod export_pipeline;
 mod import_pipeline;
 mod state;
@@ -57,10 +56,15 @@ pub async fn import_role(
     file_name: Option<String>,
 ) -> Result<ImportResult, String> {
     // 并发保护：同一时间只允许一个导入任务。
-    if state.importing.swap(true, std::sync::atomic::Ordering::SeqCst) {
+    if state
+        .importing
+        .swap(true, std::sync::atomic::Ordering::SeqCst)
+    {
         return Err("已有导入任务在进行中".into());
     }
-    let _import_guard = ImportingGuard { flag: &state.importing };
+    let _import_guard = ImportingGuard {
+        flag: &state.importing,
+    };
 
     if bytes.is_empty() {
         tracing::warn!("[RoleArchive] import_role 收到空文件");
@@ -86,14 +90,28 @@ pub async fn import_role(
             saf_cache_path: std::sync::Mutex::new(None),
         },
     );
-    let _remove_guard = TaskRemoveGuard { state: &state, task_id: &task_id };
+    let _remove_guard = TaskRemoveGuard {
+        state: &state,
+        task_id: &task_id,
+    };
     // 把 task_id 通过事件发给前端，让前端的取消按钮能找到正确的令牌。
-    let _ = app.emit("role:import-started", serde_json::json!({ "task_id": &task_id }));
+    let _ = app.emit(
+        "role:import-started",
+        serde_json::json!({ "task_id": &task_id }),
+    );
     // 写入临时文件，供文件头校验和 ZIP/7z 解压库读取。
     let tmp_path = write_temp_archive(&app, &bytes).await?;
     let cleanup_path = tmp_path.clone();
 
-    let result = do_import(&app, &tmp_path, format, policy, cancel_token, file_name.as_deref()).await;
+    let result = do_import(
+        &app,
+        &tmp_path,
+        format,
+        policy,
+        cancel_token,
+        file_name.as_deref(),
+    )
+    .await;
 
     // 兜底清理临时文件
     let _ = tokio::fs::remove_file(&cleanup_path).await;
@@ -152,10 +170,15 @@ pub async fn import_role_from_path(
     file_name: Option<String>,
 ) -> Result<ImportResult, String> {
     // 并发保护：同一时间只允许一个导入任务。
-    if state.importing.swap(true, std::sync::atomic::Ordering::SeqCst) {
+    if state
+        .importing
+        .swap(true, std::sync::atomic::Ordering::SeqCst)
+    {
         return Err("已有导入任务在进行中".into());
     }
-    let _import_guard = ImportingGuard { flag: &state.importing };
+    let _import_guard = ImportingGuard {
+        flag: &state.importing,
+    };
 
     if path.is_empty() {
         tracing::warn!("[RoleArchive] import_role_from_path 收到空 path");
@@ -165,7 +188,9 @@ pub async fn import_role_from_path(
     let policy = parse_policy(&conflict)?;
     tracing::info!(
         "[RoleArchive] import_role_from_path 开始: path={}, format={:?}, conflict={:?}",
-        path, format, policy
+        path,
+        format,
+        policy
     );
 
     // 为每个导入任务分配独立的取消令牌。
@@ -176,10 +201,16 @@ pub async fn import_role_from_path(
         saf_cache_path: std::sync::Mutex::new(None),
     };
     state.tasks.lock().unwrap().insert(task_id.clone(), entry);
-    let _remove_guard = TaskRemoveGuard { state: &state, task_id: &task_id };
+    let _remove_guard = TaskRemoveGuard {
+        state: &state,
+        task_id: &task_id,
+    };
 
     // 把 task_id 通过事件发给前端，让前端的取消按钮能找到正确的令牌。
-    let _ = app.emit("role:import-started", serde_json::json!({ "task_id": &task_id }));
+    let _ = app.emit(
+        "role:import-started",
+        serde_json::json!({ "task_id": &task_id }),
+    );
 
     let (path_buf, cleanup_after_import, display_name) = prepare_import_source(&app, &path).await?;
 
@@ -240,7 +271,9 @@ pub async fn import_role_from_path(
     match &result {
         Ok(r) => tracing::info!(
             "[RoleArchive] import_role_from_path 完成: role_name={}, role_id={:?}, action={}",
-            r.role_name, r.role_id, r.conflict_action
+            r.role_name,
+            r.role_id,
+            r.conflict_action
         ),
         Err(e) => tracing::error!("[RoleArchive] import_role_from_path 失败: {e}"),
     }
@@ -280,11 +313,12 @@ pub async fn export_role_to_path(
     }
     tracing::info!(
         "[RoleArchive] export_role_to_path 开始: role_id={}, format={:?}, dest={}",
-        role_id, format, dest_path
+        role_id,
+        format,
+        dest_path
     );
 
-    let (temp_path, suggested_name, size) =
-        compress_role_to_temp(&app, role_id, format).await?;
+    let (temp_path, suggested_name, size) = compress_role_to_temp(&app, role_id, format).await?;
 
     if dest_path.starts_with("content://") {
         use tauri_plugin_android_fs::{AndroidFsExt, FsUri};

--- a/src-tauri/src/api/role_archive/mod.rs
+++ b/src-tauri/src/api/role_archive/mod.rs
@@ -21,7 +21,10 @@ pub use state::{ImportTaskEntry, RoleArchiveState};
 use crate::utils::archive::ArchiveFormat;
 
 use export_pipeline::compress_role_to_temp;
-use import_pipeline::{do_import, parse_format, parse_format_opt, parse_policy, prepare_import_source, write_temp_archive};
+use import_pipeline::{
+    do_import, looks_like_percent_encoded_blob, parse_format, parse_format_opt, parse_policy,
+    prepare_import_source, write_temp_archive,
+};
 use state::{ImportingGuard, TaskRemoveGuard};
 
 #[derive(Debug, Serialize, Clone)]
@@ -178,7 +181,7 @@ pub async fn import_role_from_path(
     // 把 task_id 通过事件发给前端，让前端的取消按钮能找到正确的令牌。
     let _ = app.emit("role:import-started", serde_json::json!({ "task_id": &task_id }));
 
-    let (path_buf, cleanup_after_import) = prepare_import_source(&app, &path).await?;
+    let (path_buf, cleanup_after_import, display_name) = prepare_import_source(&app, &path).await?;
 
     // SAF 源文件复制完成后记录缓存路径，便于取消任务时立即清理。
     if cleanup_after_import {
@@ -186,6 +189,20 @@ pub async fn import_role_from_path(
             *entry.saf_cache_path.lock().unwrap() = Some(path_buf.clone());
         }
     }
+
+    // 文件名兜底：前端传来的 `file_name` 可能是 URI 末段未经 decode 的
+    // percent-encoded hex blob（如 `E6A998E585891784606515054.zip`）。
+    // 此时优先采用 SAF 提取的真实 display name，保证角色文件夹名可读。
+    let effective_file_name: Option<String> = match file_name {
+        Some(name) if !looks_like_percent_encoded_blob(&name) => Some(name),
+        Some(name) => {
+            tracing::warn!(
+                "[RoleArchive] import_role_from_path file_name 看起来是 percent-encoded blob ({name})，改用 SAF display_name={display_name}",
+            );
+            Some(display_name.clone())
+        }
+        None => Some(display_name.clone()),
+    };
 
     let result = async {
         if !path_buf.exists() {
@@ -205,7 +222,7 @@ pub async fn import_role_from_path(
             format,
             policy,
             cancel_token,
-            file_name.as_deref(),
+            effective_file_name.as_deref(),
         )
         .await
     }

--- a/src-tauri/src/api/role_archive/mod.rs
+++ b/src-tauri/src/api/role_archive/mod.rs
@@ -18,8 +18,10 @@ mod state;
 
 pub use state::{ImportTaskEntry, RoleArchiveState};
 
+use crate::utils::archive::ArchiveFormat;
+
 use export_pipeline::compress_role_to_temp;
-use import_pipeline::{do_import, parse_format, parse_policy, prepare_import_source, write_temp_archive};
+use import_pipeline::{do_import, parse_format, parse_format_opt, parse_policy, prepare_import_source, write_temp_archive};
 use state::{ImportingGuard, TaskRemoveGuard};
 
 #[derive(Debug, Serialize, Clone)]
@@ -29,6 +31,8 @@ pub struct ImportResult {
     pub conflict_action: String,
     pub warnings: Vec<String>,
     pub bytes_extracted: u64,
+    /// 真实格式（后端 magic 决定）。前端 hint 可能不同，但 hint 不一致时以本字段为准。
+    pub format: ArchiveFormat,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -45,7 +49,7 @@ pub async fn import_role(
     app: AppHandle,
     state: State<'_, RoleArchiveState>,
     bytes: Vec<u8>,
-    format: String,
+    format: Option<String>,
     conflict: String,
     file_name: Option<String>,
 ) -> Result<ImportResult, String> {
@@ -59,7 +63,7 @@ pub async fn import_role(
         tracing::warn!("[RoleArchive] import_role 收到空文件");
         return Err("空文件".into());
     }
-    let format = parse_format(&format)?;
+    let format = parse_format_opt(format.as_deref())?;
     let policy = parse_policy(&conflict)?;
     tracing::info!(
         "[RoleArchive] import_role 开始: format={:?}, conflict={:?}, size={}B ({}MB)",
@@ -140,7 +144,7 @@ pub async fn import_role_from_path(
     app: AppHandle,
     state: State<'_, RoleArchiveState>,
     path: String,
-    format: String,
+    format: Option<String>,
     conflict: String,
     file_name: Option<String>,
 ) -> Result<ImportResult, String> {
@@ -154,7 +158,7 @@ pub async fn import_role_from_path(
         tracing::warn!("[RoleArchive] import_role_from_path 收到空 path");
         return Err("path 为空".into());
     }
-    let format = parse_format(&format)?;
+    let format = parse_format_opt(format.as_deref())?;
     let policy = parse_policy(&conflict)?;
     tracing::info!(
         "[RoleArchive] import_role_from_path 开始: path={}, format={:?}, conflict={:?}",

--- a/src-tauri/src/api/role_archive/mod.rs
+++ b/src-tauri/src/api/role_archive/mod.rs
@@ -212,12 +212,12 @@ pub async fn import_role_from_path(
         serde_json::json!({ "task_id": &task_id }),
     );
 
-    let (path_buf, cleanup_after_import, display_name) = prepare_import_source(&app, &path).await?;
+    let src = prepare_import_source(&app, &path).await?;
 
     // SAF 源文件复制完成后记录缓存路径，便于取消任务时立即清理。
-    if cleanup_after_import {
+    if src.cleanup_after_import {
         if let Some(entry) = state.tasks.lock().unwrap().get_mut(&task_id) {
-            *entry.saf_cache_path.lock().unwrap() = Some(path_buf.clone());
+            *entry.saf_cache_path.lock().unwrap() = Some(src.path.clone());
         }
     }
 
@@ -228,18 +228,19 @@ pub async fn import_role_from_path(
         Some(name) if !looks_like_percent_encoded_blob(&name) => Some(name),
         Some(name) => {
             tracing::warn!(
-                "[RoleArchive] import_role_from_path file_name 看起来是 percent-encoded blob ({name})，改用 SAF display_name={display_name}",
+                "[RoleArchive] import_role_from_path file_name 看起来是 percent-encoded blob ({name})，改用 SAF display_name={}",
+                src.display_name
             );
-            Some(display_name.clone())
+            Some(src.display_name.clone())
         }
-        None => Some(display_name.clone()),
+        None => Some(src.display_name.clone()),
     };
 
     let result = async {
-        if !path_buf.exists() {
-            return Err(format!("文件不存在: {}", path_buf.display()));
+        if !src.path.exists() {
+            return Err(format!("文件不存在: {}", src.path.display()));
         }
-        let meta = tokio::fs::metadata(&path_buf)
+        let meta = tokio::fs::metadata(&src.path)
             .await
             .map_err(|e| format!("stat path: {e}"))?;
         tracing::info!(
@@ -249,7 +250,7 @@ pub async fn import_role_from_path(
         );
         do_import(
             &app,
-            &path_buf,
+            &src.path,
             format,
             policy,
             cancel_token,
@@ -259,11 +260,11 @@ pub async fn import_role_from_path(
     }
     .await;
 
-    if cleanup_after_import {
-        if let Err(error) = tokio::fs::remove_file(&path_buf).await {
+    if src.cleanup_after_import {
+        if let Err(error) = tokio::fs::remove_file(&src.path).await {
             tracing::warn!(
                 "[RoleArchive] import_role_from_path 清理 SAF 缓存失败: path={}, err={}",
-                path_buf.display(),
+                src.path.display(),
                 error
             );
         }

--- a/src-tauri/src/api/script_editor/commands.rs
+++ b/src-tauri/src/api/script_editor/commands.rs
@@ -736,7 +736,7 @@ fn asset_dirs(kind: &str) -> Result<(&'static str, PathBuf), String> {
 fn allowed_extensions(kind: &str) -> &'static [&'static str] {
     match kind {
         "background" | "pic" => &["png", "jpg", "jpeg", "webp", "bmp", "gif"],
-        _ => &["mp3", "wav", "ogg", "flac", "m4a"],
+        _ => &["mp3", "wav", "ogg", "flac"],
     }
 }
 

--- a/src/api/services/font.ts
+++ b/src/api/services/font.ts
@@ -11,6 +11,15 @@ export interface ImportedFontInfo {
   file_path: string
 }
 
+export interface UploadFontResult {
+  actual_name: string
+  original_name: string
+  detected_kind: string
+  was_corrected: boolean
+  file_path: string
+  font_family: string
+}
+
 // 系统字体族名缓存。一次 app 运行内只枚举一次。
 let cached: string[] | null = null
 // 导入字体缓存。一次 app 运行内只枚举一次。
@@ -38,8 +47,8 @@ export async function listSystemFonts(force = false): Promise<string[]> {
 // ========== 导入字体管理 ==========
 
 /** 导入用户选择的字体文件到 data/fonts/。 */
-export async function importFont(path: string): Promise<ImportedFontInfo> {
-  return invoke<ImportedFontInfo>('import_font', { path })
+export async function importFont(path: string): Promise<UploadFontResult> {
+  return invoke<UploadFontResult>('import_font', { path })
 }
 
 /** 列出 data/fonts/ 中所有已导入字体。 */

--- a/src/api/services/music.ts
+++ b/src/api/services/music.ts
@@ -12,9 +12,16 @@ export const musicGetAll = async (): Promise<MusicTrack[]> => {
   }
 }
 
-export const musicUpload = async (path: string, fileName: string): Promise<void> => {
+export interface UploadMusicResult {
+  actual_name: string
+  original_name: string
+  detected_kind: string
+  was_corrected: boolean
+}
+
+export const musicUpload = async (path: string, fileName: string): Promise<UploadMusicResult> => {
   try {
-    await invoke('upload_music', { path, fileName })
+    return await invoke<UploadMusicResult>('upload_music', { path, fileName })
   } catch (error: any) {
     throw new Error(typeof error === 'string' ? error : error.message || 'Music upload failed')
   }

--- a/src/api/services/role-archive.ts
+++ b/src/api/services/role-archive.ts
@@ -9,6 +9,8 @@ export interface ImportResult {
   conflict_action: string
   warnings: string[]
   bytes_extracted: number
+  /// 后端 magic 决定的真实格式（与前端 hint 可能不同）
+  format: ArchiveFormat
 }
 
 export interface ExportResult {
@@ -35,14 +37,14 @@ export interface EntryEvent {
 // 保留字节导入接口，供已经在内存中持有压缩包数据的调用方使用。
 export async function importRole(params: {
   bytes: number[] | Uint8Array
-  format: ArchiveFormat
+  format?: ArchiveFormat  // 可选；后端用 magic 裁决
   conflict: ConflictPolicy
   fileName?: string
 }): Promise<ImportResult> {
   const bytes = params.bytes instanceof Uint8Array ? Array.from(params.bytes) : params.bytes
   return invoke<ImportResult>('import_role', {
     bytes,
-    format: params.format,
+    format: params.format ?? null,
     conflict: params.conflict,
     fileName: params.fileName ?? null,
   })
@@ -51,13 +53,13 @@ export async function importRole(params: {
 // 推荐的导入接口：支持桌面文件路径和 Android SAF 内容 URI。
 export async function importRoleFromPath(params: {
   path: string
-  format: ArchiveFormat
+  format?: ArchiveFormat  // 可选；后端用 magic 裁决
   conflict: ConflictPolicy
   fileName?: string
 }): Promise<ImportResult> {
   return invoke<ImportResult>('import_role_from_path', {
     path: params.path,
-    format: params.format,
+    format: params.format ?? null,
     conflict: params.conflict,
     fileName: params.fileName ?? null,
   })

--- a/src/components/script-editor/fields/FieldRow.vue
+++ b/src/components/script-editor/fields/FieldRow.vue
@@ -445,7 +445,7 @@ const onNumber = (e: Event) => {
 }
 
 const IMAGE_EXT = ['png', 'jpg', 'jpeg', 'webp', 'bmp', 'gif']
-const AUDIO_EXT = ['mp3', 'wav', 'ogg', 'flac', 'm4a']
+const AUDIO_EXT = ['mp3', 'wav', 'ogg', 'flac']
 
 /**
  * 选一个文件导入。只把**路径**交给后端，由 Rust 自己复制 —— 与

--- a/src/components/script-editor/tabs/AssetsTab.vue
+++ b/src/components/script-editor/tabs/AssetsTab.vue
@@ -57,7 +57,7 @@ const setRate = (path: string, rate: number) => {
 }
 
 const IMAGE_EXT = ['png', 'jpg', 'jpeg', 'webp', 'bmp', 'gif']
-const AUDIO_EXT = ['mp3', 'wav', 'ogg', 'flac', 'm4a']
+const AUDIO_EXT = ['mp3', 'wav', 'ogg', 'flac']
 
 const importAsset = async (kind: AssetKind, scope: AssetScope) => {
   const isImage = kind === 'background' || kind === 'pic'

--- a/src/components/settings/pages/SettingsSound.vue
+++ b/src/components/settings/pages/SettingsSound.vue
@@ -356,6 +356,7 @@ import {
 import { ambientGetAll, ambientUpload, ambientDelete, type AmbientItem } from '../../../api/services/ambient'
 import { useUIStore } from '../../../stores/modules/ui/ui'
 import { useDialogStore } from '../../../stores/modules/ui/dialog'
+import { useRoleArchiveStore } from '../../../stores/modules/ui/role-archive'
 import { useSettingsStore } from '../../../stores/modules/settings'
 import {
   currentDeviceId,
@@ -393,6 +394,7 @@ import {
 const uiStore = useUIStore()
 const settingsStore = useSettingsStore()
 const dialogStore = useDialogStore()
+const roleStore = useRoleArchiveStore()
 const { t } = useI18n()
 
 // 状态绑定
@@ -763,26 +765,36 @@ const uploadMusic = async () => {
     return
   }
 
-  const allowedExts = ['.mp3', '.wav', '.flac', '.webm', '.weba', '.ogg', '.m4a']
-
   try {
-    // 串行上传（仅传源文件路径，Rust 侧复制）
+    // 串行上传（仅传源文件路径，Rust 侧复制 + magic 校验）
     for (const path of selectedPaths.value) {
       // content:// URI 文件名是 URL 编码的，解码后才是真实文件名
       const fileName = decodePathFileName(path)
-      const fileExt = fileName.slice(fileName.lastIndexOf('.')).toLowerCase()
-      if (!allowedExts.includes(fileExt)) {
-        throw new Error(t('settings.sound.common.unsupportedFormat', { name: fileName }))
+      const result = await musicUpload(path, fileName)
+      // 自动修正时弹顶部 amber notice
+      if (result.was_corrected) {
+        const originalExt = result.original_name.split('.').pop() || ''
+        roleStore.showCorrected({
+          title: t('ui.notice.autoCorrected.title'),
+          message: t('ui.notice.autoCorrected.music', {
+            original: result.original_name,
+            originalExt,
+            detected: result.detected_kind,
+            corrected: result.actual_name,
+          }),
+        })
       }
-      await musicUpload(path, fileName)
     }
 
     selectedPaths.value = []
     await loadMusicList()
-    // alert('音乐上传成功') // 可选提示
   } catch (error: any) {
     console.error('批量上传音乐出现问题:', error)
-    await dialogStore.alert(error.message || t('settings.sound.bgm.uploadFailed'))
+    const rawMsg = error.message || String(error)
+    const translated = rawMsg === 'MUSIC_INVALID_FORMAT'
+      ? t('ui.musicImport.errors.MUSIC_INVALID_FORMAT')
+      : rawMsg
+    await dialogStore.alert(translated || t('settings.sound.bgm.uploadFailed'))
   }
 }
 

--- a/src/components/settings/pages/SettingsSound.vue
+++ b/src/components/settings/pages/SettingsSound.vue
@@ -368,6 +368,7 @@ import {
   setDevice,
   supported as audioOutputSupported,
 } from '../../../utils/audioOutputManager'
+import { decodePathFileName } from '../../../utils/path'
 import {
   AudioLines,
   FlaskConical,
@@ -597,19 +598,6 @@ const extractDialogPaths = (selected: unknown): string[] => {
   return raw
     .map((p: any) => (typeof p === 'string' ? p : p?.path))
     .filter((p: any) => typeof p === 'string' && p.length > 0)
-}
-
-/**
- * 从文件路径提取文件名，兼容 content:// URI（URL 编码）。
- * decodeURIComponent 遇到非法 % 序列会抛 URIError，这里兜底返回原值。
- */
-const decodePathFileName = (path: string): string => {
-  const last = path.split(/[\\/]/).pop() || path
-  try {
-    return decodeURIComponent(last).split('?')[0]
-  } catch {
-    return last.split('?')[0]
-  }
 }
 
 // 从服务端加载环境音列表

--- a/src/components/settings/pages/SettingsSound.vue
+++ b/src/components/settings/pages/SettingsSound.vue
@@ -347,6 +347,7 @@ import { useI18n } from 'vue-i18n'
 import { open as openDialog } from '@tauri-apps/plugin-dialog'
 import { Button, Slider } from '../../base'
 import { MenuItem, MenuPage } from '../../ui'
+import { musicDialogFilters } from '@/utils/dialogFilters'
 import {
   musicDelete,
   musicGetAll,
@@ -576,7 +577,7 @@ const stopAllAmbient = () => {
 const triggerAmbientUpload = async () => {
   const selected = await openDialog({
     multiple: true,
-    filters: [{ name: 'Ambient', extensions: ['mp3', 'wav', 'flac', 'ogg'] }],
+    filters: musicDialogFilters(),
   })
   if (!selected) return
   selectedAmbientPaths.value = extractDialogPaths(selected)
@@ -833,9 +834,7 @@ const handleStop = () => {
 const triggerFileUpload = async () => {
   const selected = await openDialog({
     multiple: true,
-    filters: [
-      { name: 'Music', extensions: ['mp3', 'wav', 'flac', 'webm', 'weba', 'ogg'] },
-    ],
+    filters: musicDialogFilters(),
   })
   if (!selected) return
   selectedPaths.value = extractDialogPaths(selected)

--- a/src/components/settings/pages/SettingsSound.vue
+++ b/src/components/settings/pages/SettingsSound.vue
@@ -576,7 +576,7 @@ const stopAllAmbient = () => {
 const triggerAmbientUpload = async () => {
   const selected = await openDialog({
     multiple: true,
-    filters: [{ name: 'Ambient', extensions: ['mp3', 'wav', 'flac', 'ogg', 'm4a'] }],
+    filters: [{ name: 'Ambient', extensions: ['mp3', 'wav', 'flac', 'ogg'] }],
   })
   if (!selected) return
   selectedAmbientPaths.value = extractDialogPaths(selected)
@@ -615,7 +615,7 @@ const uploadAmbientFiles = async () => {
     await dialogStore.alert(t('settings.sound.ambient.selectFilesFirst'))
     return
   }
-  const allowedExts = ['.mp3', '.wav', '.flac', '.ogg', '.m4a']
+  const allowedExts = ['.mp3', '.wav', '.flac', '.ogg']
   try {
     // 串行上传（仅传源文件路径，Rust 侧复制）
     for (const path of selectedAmbientPaths.value) {
@@ -629,7 +629,11 @@ const uploadAmbientFiles = async () => {
     await loadAmbientList()
   } catch (error: any) {
     console.error('上传环境音失败:', error)
-    await dialogStore.alert(error.message || t('settings.sound.ambient.uploadFailed'))
+    const rawMsg = error.message || String(error)
+    const translated = rawMsg === 'MUSIC_INVALID_FORMAT'
+      ? t('ui.musicImport.errors.MUSIC_INVALID_FORMAT')
+      : rawMsg
+    await dialogStore.alert(translated || t('settings.sound.ambient.uploadFailed'))
   }
 }
 
@@ -830,7 +834,7 @@ const triggerFileUpload = async () => {
   const selected = await openDialog({
     multiple: true,
     filters: [
-      { name: 'Music', extensions: ['mp3', 'wav', 'flac', 'webm', 'weba', 'ogg', 'm4a'] },
+      { name: 'Music', extensions: ['mp3', 'wav', 'flac', 'webm', 'weba', 'ogg'] },
     ],
   })
   if (!selected) return

--- a/src/components/settings/pages/SettingsText.vue
+++ b/src/components/settings/pages/SettingsText.vue
@@ -887,7 +887,7 @@ async function loadImportedFonts() {
 async function handleImportFont() {
   const selected = await openDialog({
     multiple: false,
-    filters: [{ name: '字体文件', extensions: ['ttf', 'woff2'] }],
+    filters: [{ name: '字体文件', extensions: ['ttf', 'otf', 'woff', 'woff2', 'ttc'] }],
   })
   if (!selected) return
 

--- a/src/components/settings/pages/SettingsText.vue
+++ b/src/components/settings/pages/SettingsText.vue
@@ -887,7 +887,7 @@ async function loadImportedFonts() {
 async function handleImportFont() {
   const selected = await openDialog({
     multiple: false,
-    filters: [{ name: '字体文件', extensions: ['ttf', 'otf', 'woff', 'woff2', 'ttc'] }],
+    filters: [{ name: '字体文件', extensions: ['ttf', 'otf', 'woff', 'woff2'] }],
   })
   if (!selected) return
 

--- a/src/components/settings/pages/SettingsText.vue
+++ b/src/components/settings/pages/SettingsText.vue
@@ -509,6 +509,7 @@ import { MenuPage, MenuItem } from '../../ui'
 import { Slider, Text, Toggle, Button } from '../../base'
 import { useUIStore } from '../../../stores/modules/ui/ui'
 import { useDialogStore } from '../../../stores/modules/ui/dialog'
+import { useRoleArchiveStore } from '../../../stores/modules/ui/role-archive'
 import { useSettingsStore } from '../../../stores/modules/settings'
 import { useGameStore } from '../../../stores/modules/game'
 import type { ConfigItem } from '@/api/services/config'
@@ -556,6 +557,7 @@ import type { DialogView } from '@/types/lanSync'
 const router = useRouter()
 const { t } = useI18n()
 const uiStore = useUIStore()
+const roleStore = useRoleArchiveStore()
 const settingsStore = useSettingsStore()
 const gameStore = useGameStore()
 const dialogStore = useDialogStore()
@@ -893,22 +895,39 @@ async function handleImportFont() {
   if (!filePath) return
 
   try {
-    const info = await importFont(filePath)
-    registerFontFace(info.name, info.file_path)
+    const result = await importFont(filePath)
+    registerFontFace(result.font_family, result.file_path)
     clearImportedFontsCache()
     await loadImportedFonts()
+    // 发生自动修正时弹顶部 amber notice 提示用户
+    if (result.was_corrected) {
+      const originalExt = result.original_name.split('.').pop() || ''
+      roleStore.showCorrected({
+        title: t('ui.notice.autoCorrected.title'),
+        message: t('ui.notice.autoCorrected.font', {
+          original: result.original_name,
+          originalExt,
+          detected: result.detected_kind,
+          corrected: result.actual_name,
+        }),
+      })
+    }
     uiStore.showNotification({
       type: 'success',
       title: '字体导入成功',
-      message: `字体 "${info.name}" 已导入`,
+      message: `字体 "${result.font_family}" 已导入`,
       duration: 3000,
       skipTipsCheck: true,
     })
   } catch (error: any) {
+    const rawMsg = typeof error === 'string' ? error : error?.message || String(error)
+    const translated = rawMsg === 'FONT_INVALID_FORMAT'
+      ? t('ui.fontImport.errors.FONT_INVALID_FORMAT')
+      : rawMsg
     uiStore.showNotification({
       type: 'error',
       title: '字体导入失败',
-      message: typeof error === 'string' ? error : error.message || '导入失败',
+      message: translated,
       duration: 3000,
       skipTipsCheck: true,
     })

--- a/src/components/ui/ImportProgressBar.vue
+++ b/src/components/ui/ImportProgressBar.vue
@@ -2,6 +2,31 @@
   <Teleport to="body">
     <Transition name="slide-up">
       <div
+        v-if="store.corrected.phase === 'active'"
+        class="notice fixed top-8 right-8 z-[10000] flex items-start gap-3 p-4 min-w-[320px] max-w-[420px] rounded-xl backdrop-blur-[20px]"
+        :style="noticeStyle"
+      >
+        <div class="shrink-0 w-6 h-6 flex items-center justify-center text-amber-400">
+          <svg
+            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+            class="w-6 h-6"
+          >
+            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+            <line x1="12" y1="9" x2="12" y2="13" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+          </svg>
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="text-amber-400 font-bold text-sm">{{ store.corrected.title }}</div>
+          <div class="text-gray-200 text-xs mt-1 whitespace-pre-line break-words">{{ store.corrected.message }}</div>
+        </div>
+        <button
+          class="shrink-0 text-white/60 hover:text-white text-lg leading-none"
+          @click="dismissCorrected"
+        >×</button>
+      </div>
+      <div
         v-if="visible"
         :data-phase="state.phase"
         class="bar fixed bottom-[calc(32px+var(--safe-area-inset-bottom))] right-8 z-[9999] flex items-center gap-4 p-4 min-w-[340px] max-w-[440px] overflow-hidden rounded-xl backdrop-blur-[20px]"
@@ -206,7 +231,41 @@ function dismiss() {
   else store.resetExport()
 }
 
-onUnmounted(() => clearDismiss())
+function dismissCorrected() {
+  store.dismissCorrected()
+}
+
+const noticeStyle = computed(() => ({}))
+
+let noticeTimer: number | null = null
+function clearNoticeTimer() {
+  if (noticeTimer !== null) {
+    window.clearTimeout(noticeTimer)
+    noticeTimer = null
+  }
+}
+function scheduleNoticeDismiss(ms: number) {
+  clearNoticeTimer()
+  noticeTimer = window.setTimeout(() => {
+    store.dismissCorrected()
+  }, ms)
+}
+
+watch(
+  () => store.corrected.phase,
+  (phase) => {
+    if (phase === 'active') {
+      scheduleNoticeDismiss(store.corrected.durationMs)
+    } else {
+      clearNoticeTimer()
+    }
+  },
+)
+
+onUnmounted(() => {
+  clearDismiss()
+  clearNoticeTimer()
+})
 </script>
 
 <style>
@@ -243,6 +302,12 @@ onUnmounted(() => clearDismiss())
   background: rgba(15, 15, 15, 0.55);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
   border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.notice {
+  background: rgba(15, 15, 15, 0.85);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6), inset 0 0 15px rgba(251, 191, 36, 0.15);
+  border: 1px solid rgba(251, 191, 36, 0.3);
 }
 
 [data-phase="running"].bar {

--- a/src/components/ui/ImportProgressBar.vue
+++ b/src/components/ui/ImportProgressBar.vue
@@ -1,31 +1,33 @@
 <template>
   <Teleport to="body">
-    <Transition name="slide-up">
-      <div
-        v-if="store.corrected.phase === 'active'"
-        class="notice fixed top-8 right-8 z-[10000] flex items-start gap-3 p-4 min-w-[320px] max-w-[420px] rounded-xl backdrop-blur-[20px]"
-        :style="noticeStyle"
-      >
-        <div class="shrink-0 w-6 h-6 flex items-center justify-center text-amber-400">
-          <svg
-            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
-            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-            class="w-6 h-6"
-          >
-            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-            <line x1="12" y1="9" x2="12" y2="13" />
-            <line x1="12" y1="17" x2="12.01" y2="17" />
-          </svg>
-        </div>
-        <div class="flex-1 min-w-0">
-          <div class="text-amber-400 font-bold text-sm">{{ store.corrected.title }}</div>
-          <div class="text-gray-200 text-xs mt-1 whitespace-pre-line break-words">{{ store.corrected.message }}</div>
-        </div>
-        <button
-          class="shrink-0 text-white/60 hover:text-white text-lg leading-none"
-          @click="dismissCorrected"
-        >×</button>
+    <!-- notice 卡片与 import/export 进度条独立，不进入同一个 <Transition>。 -->
+    <div
+      v-if="store.corrected.phase === 'active'"
+      class="notice fixed top-8 right-8 z-[10000] flex items-start gap-3 p-4 min-w-[320px] max-w-[420px] rounded-xl backdrop-blur-[20px]"
+      :style="noticeStyle"
+    >
+      <div class="shrink-0 w-6 h-6 flex items-center justify-center text-amber-400">
+        <svg
+          xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+          class="w-6 h-6"
+        >
+          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+          <line x1="12" y1="9" x2="12" y2="13" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
       </div>
+      <div class="flex-1 min-w-0">
+        <div class="text-amber-400 font-bold text-sm">{{ store.corrected.title }}</div>
+        <div class="text-gray-200 text-xs mt-1 whitespace-pre-line break-words">{{ store.corrected.message }}</div>
+      </div>
+      <button
+        class="shrink-0 text-white/60 hover:text-white text-lg leading-none"
+        @click="dismissCorrected"
+      >×</button>
+    </div>
+
+    <Transition name="slide-up">
       <div
         v-if="visible"
         :data-phase="state.phase"

--- a/src/components/ui/ImportProgressBar.vue
+++ b/src/components/ui/ImportProgressBar.vue
@@ -65,7 +65,7 @@
           <div class="text-white font-bold text-sm leading-tight truncate">{{ title }}</div>
           <div
             v-if="message"
-            class="text-gray-300 text-xs leading-tight break-all line-clamp-2"
+            class="text-gray-300 text-xs leading-tight break-all whitespace-pre-line"
           >{{ message }}</div>
 
           <div
@@ -136,7 +136,12 @@ const title = computed(() => {
 
 const message = computed(() => {
   const s = state.value
-  if (s.phase === 'error') return s.error || s.message
+  if (s.phase === 'error') {
+    const raw = s.error || s.message
+    // 后端返回的 i18n 错误码（如 ARCHIVE_MISSING_SETTINGS_YML）优先查翻译表，
+    // 找不到则 fallback 到原文（兼容后端其他字符串错误）。
+    return t(`ui.archiveProgress.errors.${raw}`, raw)
+  }
   return s.message
 })
 

--- a/src/components/ui/ImportProgressBar.vue
+++ b/src/components/ui/ImportProgressBar.vue
@@ -4,7 +4,6 @@
     <div
       v-if="store.corrected.phase === 'active'"
       class="notice fixed top-8 right-8 z-[10000] flex items-start gap-3 p-4 min-w-[320px] max-w-[420px] rounded-xl backdrop-blur-[20px]"
-      :style="noticeStyle"
     >
       <div class="shrink-0 w-6 h-6 flex items-center justify-center text-amber-400">
         <svg
@@ -236,8 +235,6 @@ function dismiss() {
 function dismissCorrected() {
   store.dismissCorrected()
 }
-
-const noticeStyle = computed(() => ({}))
 
 let noticeTimer: number | null = null
 function clearNoticeTimer() {

--- a/src/composables/useRoleImportExport.ts
+++ b/src/composables/useRoleImportExport.ts
@@ -111,26 +111,22 @@ export function useRoleImportExport() {
     const filePath = typeof selected === 'string' ? selected : (selected as any).path
     if (!filePath) return
     const fileName = filePath.split(/[\\/]/).pop() || filePath
-    const format = detectFormat(fileName)
-    if (!format) {
-      console.warn('[RoleArchive] pickAndImport \u4e0d\u652f\u6301\u7684\u683c\u5f0f:', fileName)
-      store.import.phase = 'error'
-      store.import.error = '\u4ec5\u652f\u6301 .zip / .7z \u683c\u5f0f'
-      return
-    }
+    // \u6269\u5c55\u540d\u7f3a\u5931\u65f6\u4e0d\u518d\u786c\u62a5\u9519\uff1b\u540e\u7aef\u7528 magic \u51b3\u5b9a\u771f\u5b9e\u683c\u5f0f\u3002
+    const format: ArchiveFormat | undefined = detectFormat(fileName) ?? undefined
     await runImport(filePath, fileName, format, conflict)
   }
 
   async function runImport(
     filePath: string,
     fileName: string,
-    format: ArchiveFormat,
+    format: ArchiveFormat | undefined,
     conflict: ConflictPolicy,
   ) {
     store.resetImport()
     store.import.phase = 'running'
     store.import.fileName = truncateName(fileName)
-    store.import.format = format
+    // hint 可能为 undefined；用 'zip' 占位，等 result 返回后用真实格式覆盖。
+    store.import.format = format ?? 'zip'
     store.import.conflict = conflict
     store.import.startedAt = Date.now()
     console.log(
@@ -157,6 +153,7 @@ export function useRoleImportExport() {
       })
 
       store.import.result = result
+      store.import.format = result.format  // 后端 magic 决定的真实格式
       store.import.phase = 'done'
       store.import.percent = 100
       store.import.message = `\u5bfc\u5165\u6210\u529f: ${result.role_name}`

--- a/src/composables/useRoleImportExport.ts
+++ b/src/composables/useRoleImportExport.ts
@@ -28,6 +28,21 @@ function detectFormat(fileName: string): ArchiveFormat | null {
   return null
 }
 
+/**
+ * 把 content:// URI 末段从 percent-encoded 还原回真实文件名。
+ * Android dialog 返回的 URI 形如 `content://.../E6A998E585891784606515054.zip`，
+ * 直接 split 拿到的就是 hex 串；非 URI 路径则原样返回。
+ */
+function decodeURIComponentSafe(s: string): string {
+  // 仅对看起来像 percent-encoded 的字符串做 decode；避免误伤普通文件名里的 % 字符。
+  if (!/%[0-9A-Fa-f]{2}/.test(s)) return s
+  try {
+    return decodeURIComponent(s)
+  } catch {
+    return s
+  }
+}
+
 function isAndroidContentUri(p: string): boolean {
   return p.startsWith('content://')
 }
@@ -110,7 +125,10 @@ export function useRoleImportExport() {
     }
     const filePath = typeof selected === 'string' ? selected : (selected as any).path
     if (!filePath) return
-    const fileName = filePath.split(/[\\/]/).pop() || filePath
+    // content:// URI \u672b\u6bb5\u662f URL \u7f16\u7801\u7684\uff08\u5982 `E6A998E585891784606515054.zip`\uff09\uff0c
+    // \u5fc5\u987b decode \u540e\u624d\u80fd\u5f97\u5230\u771f\u5b9e\u6587\u4ef6\u540d\uff08`\u8bfa\u4e00\u94a6\u7075.zip`\uff09\u3002
+    const fileName =
+      decodeURIComponentSafe(filePath.split(/[\\/]/).pop() || filePath) || filePath
     // \u6269\u5c55\u540d\u7f3a\u5931\u65f6\u4e0d\u518d\u786c\u62a5\u9519\uff1b\u540e\u7aef\u7528 magic \u51b3\u5b9a\u771f\u5b9e\u683c\u5f0f\u3002
     const format: ArchiveFormat | undefined = detectFormat(fileName) ?? undefined
     await runImport(filePath, fileName, format, conflict)

--- a/src/composables/useRoleImportExport.ts
+++ b/src/composables/useRoleImportExport.ts
@@ -2,6 +2,7 @@ import { onUnmounted } from 'vue'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { open as openDialog, save as saveDialog } from '@tauri-apps/plugin-dialog'
 import { useRoleArchiveStore } from '@/stores/modules/ui/role-archive'
+import { decodePathFileName } from '@/utils/path'
 import {
   importRoleFromPath,
   exportRoleToPath,
@@ -26,21 +27,6 @@ function detectFormat(fileName: string): ArchiveFormat | null {
   if (lower.endsWith('.zip')) return 'zip'
   if (lower.endsWith('.7z')) return '7z'
   return null
-}
-
-/**
- * 把 content:// URI 末段从 percent-encoded 还原回真实文件名。
- * Android dialog 返回的 URI 形如 `content://.../E6A998E585891784606515054.zip`，
- * 直接 split 拿到的就是 hex 串；非 URI 路径则原样返回。
- */
-function decodeURIComponentSafe(s: string): string {
-  // 仅对看起来像 percent-encoded 的字符串做 decode；避免误伤普通文件名里的 % 字符。
-  if (!/%[0-9A-Fa-f]{2}/.test(s)) return s
-  try {
-    return decodeURIComponent(s)
-  } catch {
-    return s
-  }
 }
 
 function isAndroidContentUri(p: string): boolean {
@@ -127,8 +113,7 @@ export function useRoleImportExport() {
     if (!filePath) return
     // content:// URI \u672b\u6bb5\u662f URL \u7f16\u7801\u7684\uff08\u5982 `E6A998E585891784606515054.zip`\uff09\uff0c
     // \u5fc5\u987b decode \u540e\u624d\u80fd\u5f97\u5230\u771f\u5b9e\u6587\u4ef6\u540d\uff08`\u8bfa\u4e00\u94a6\u7075.zip`\uff09\u3002
-    const fileName =
-      decodeURIComponentSafe(filePath.split(/[\\/]/).pop() || filePath) || filePath
+    const fileName = decodePathFileName(filePath) || filePath
     // \u6269\u5c55\u540d\u7f3a\u5931\u65f6\u4e0d\u518d\u786c\u62a5\u9519\uff1b\u540e\u7aef\u7528 magic \u51b3\u5b9a\u771f\u5b9e\u683c\u5f0f\u3002
     const format: ArchiveFormat | undefined = detectFormat(fileName) ?? undefined
     await runImport(filePath, fileName, format, conflict)

--- a/src/locales/en/ui.ts
+++ b/src/locales/en/ui.ts
@@ -65,6 +65,23 @@ export default {
       ARCHIVE_MISSING_SETTINGS_YML: "Archive is missing settings.yml\nThis may be an older version role. Please download the new version and import it.",
     },
   },
+  fontImport: {
+    errors: {
+      FONT_INVALID_FORMAT: "Not a valid font file (ttf/otf/woff/woff2). The file may be corrupted or the extension doesn't match its content.",
+    },
+  },
+  musicImport: {
+    errors: {
+      MUSIC_INVALID_FORMAT: "Not a valid audio file (mp3/wav/flac/ogg/m4a). The file may be corrupted or the extension doesn't match its content.",
+    },
+  },
+  notice: {
+    autoCorrected: {
+      title: "Auto-corrected",
+      font: "{original} is not a {originalExt} font (detected {detected}), saved as {corrected}",
+      music: "{original} is not a {originalExt} audio file (detected {detected}), saved as {corrected}",
+    },
+  },
   menuItem: {
     defaultTitle: "Default Title",
   },

--- a/src/locales/en/ui.ts
+++ b/src/locales/en/ui.ts
@@ -61,6 +61,9 @@ export default {
     defaultExportTitle: "Character Export",
     close: "Close",
     cancel: "Cancel",
+    errors: {
+      ARCHIVE_MISSING_SETTINGS_YML: "Archive is missing settings.yml\nThis may be an older version role. Please download the new version and import it.",
+    },
   },
   menuItem: {
     defaultTitle: "Default Title",

--- a/src/locales/en/ui.ts
+++ b/src/locales/en/ui.ts
@@ -72,7 +72,7 @@ export default {
   },
   musicImport: {
     errors: {
-      MUSIC_INVALID_FORMAT: "Not a valid audio file (mp3/wav/flac/ogg/m4a). The file may be corrupted or the extension doesn't match its content.",
+      MUSIC_INVALID_FORMAT: "Not a valid audio file (mp3/wav/flac/ogg). The file may be corrupted or the extension doesn't match its content.",
     },
   },
   notice: {

--- a/src/locales/ja/ui.ts
+++ b/src/locales/ja/ui.ts
@@ -71,7 +71,7 @@ export default {
   },
   musicImport: {
     errors: {
-      MUSIC_INVALID_FORMAT: '有効な音声ファイルではありません（mp3/wav/flac/ogg/m4a）。ファイルが破損しているか、拡張子と内容が一致していません',
+      MUSIC_INVALID_FORMAT: '有効な音声ファイルではありません（mp3/wav/flac/ogg）。ファイルが破損しているか、拡張子と内容が一致していません',
     },
   },
   notice: {

--- a/src/locales/ja/ui.ts
+++ b/src/locales/ja/ui.ts
@@ -60,6 +60,9 @@ export default {
     defaultExportTitle: 'キャラクターのエクスポート',
     close: '閉じる',
     cancel: 'キャンセル',
+    errors: {
+      ARCHIVE_MISSING_SETTINGS_YML: '圧縮ファイルに settings.yml がありません\n旧バージョンのキャラクターかもしれません。新版をダウンロードしてからインポートしてください',
+    },
   },
   menuItem: {
     defaultTitle: 'デフォルトタイトル',

--- a/src/locales/ja/ui.ts
+++ b/src/locales/ja/ui.ts
@@ -64,6 +64,23 @@ export default {
       ARCHIVE_MISSING_SETTINGS_YML: '圧縮ファイルに settings.yml がありません\n旧バージョンのキャラクターかもしれません。新版をダウンロードしてからインポートしてください',
     },
   },
+  fontImport: {
+    errors: {
+      FONT_INVALID_FORMAT: '有効なフォントファイルではありません（ttf/otf/woff/woff2）。ファイルが破損しているか、拡張子と内容が一致していません',
+    },
+  },
+  musicImport: {
+    errors: {
+      MUSIC_INVALID_FORMAT: '有効な音声ファイルではありません（mp3/wav/flac/ogg/m4a）。ファイルが破損しているか、拡張子と内容が一致していません',
+    },
+  },
+  notice: {
+    autoCorrected: {
+      title: '自動修正済み',
+      font: '{original} は {originalExt} フォントではありません（検出: {detected}）。{corrected} として保存しました',
+      music: '{original} は {originalExt} 音声ファイルではありません（検出: {detected}）。{corrected} として保存しました',
+    },
+  },
   menuItem: {
     defaultTitle: 'デフォルトタイトル',
   },

--- a/src/locales/zh-CN/ui.ts
+++ b/src/locales/zh-CN/ui.ts
@@ -71,7 +71,7 @@ export default {
   },
   musicImport: {
     errors: {
-      MUSIC_INVALID_FORMAT: '不是合法的音频文件（mp3/wav/flac/ogg/m4a），文件已损坏或扩展名与内容不符',
+      MUSIC_INVALID_FORMAT: '不是合法的音频文件（mp3/wav/flac/ogg），文件已损坏或扩展名与内容不符',
     },
   },
   notice: {

--- a/src/locales/zh-CN/ui.ts
+++ b/src/locales/zh-CN/ui.ts
@@ -64,6 +64,23 @@ export default {
       ARCHIVE_MISSING_SETTINGS_YML: '压缩包缺少 settings.yml\n这可能是旧版角色，请下载新版角色后导入',
     },
   },
+  fontImport: {
+    errors: {
+      FONT_INVALID_FORMAT: '不是合法的字体文件（ttf/otf/woff/woff2），文件已损坏或扩展名与内容不符',
+    },
+  },
+  musicImport: {
+    errors: {
+      MUSIC_INVALID_FORMAT: '不是合法的音频文件（mp3/wav/flac/ogg/m4a），文件已损坏或扩展名与内容不符',
+    },
+  },
+  notice: {
+    autoCorrected: {
+      title: '已自动修正',
+      font: '{original} 不是 {originalExt} 字体格式（检测为 {detected}），已自动修正为 {corrected}',
+      music: '{original} 不是 {originalExt} 音频格式（检测为 {detected}），已自动修正为 {corrected}',
+    },
+  },
   menuItem: {
     defaultTitle: '默认标题',
   },

--- a/src/locales/zh-CN/ui.ts
+++ b/src/locales/zh-CN/ui.ts
@@ -60,6 +60,9 @@ export default {
     defaultExportTitle: '角色导出',
     close: '关闭',
     cancel: '取消',
+    errors: {
+      ARCHIVE_MISSING_SETTINGS_YML: '压缩包缺少 settings.yml\n这可能是旧版角色，请下载新版角色后导入',
+    },
   },
   menuItem: {
     defaultTitle: '默认标题',

--- a/src/locales/zh-HK/ui.ts
+++ b/src/locales/zh-HK/ui.ts
@@ -72,7 +72,7 @@ export default {
   },
   "musicImport": {
     "errors": {
-      "MUSIC_INVALID_FORMAT": "不是合法的音訊檔案（mp3/wav/flac/ogg/m4a），檔案已損壞或擴展名與內容不符"
+      "MUSIC_INVALID_FORMAT": "不是合法的音訊檔案（mp3/wav/flac/ogg），檔案已損壞或擴展名與內容不符"
     }
   },
   "notice": {

--- a/src/locales/zh-HK/ui.ts
+++ b/src/locales/zh-HK/ui.ts
@@ -65,6 +65,23 @@ export default {
       "ARCHIVE_MISSING_SETTINGS_YML": "壓縮包缺少 settings.yml\n這可能是舊版角色，請下載新版角色後匯入"
     }
   },
+  "fontImport": {
+    "errors": {
+      "FONT_INVALID_FORMAT": "不是合法的字體檔案（ttf/otf/woff/woff2），檔案已損壞或擴展名與內容不符"
+    }
+  },
+  "musicImport": {
+    "errors": {
+      "MUSIC_INVALID_FORMAT": "不是合法的音訊檔案（mp3/wav/flac/ogg/m4a），檔案已損壞或擴展名與內容不符"
+    }
+  },
+  "notice": {
+    "autoCorrected": {
+      "title": "已自動修正",
+      "font": "{original} 不是 {originalExt} 字體格式（偵測為 {detected}），已自動修正為 {corrected}",
+      "music": "{original} 不是 {originalExt} 音訊格式（偵測為 {detected}），已自動修正為 {corrected}"
+    }
+  },
   "menuItem": {
     "defaultTitle": "預設標題"
   },

--- a/src/locales/zh-HK/ui.ts
+++ b/src/locales/zh-HK/ui.ts
@@ -60,7 +60,10 @@ export default {
     "defaultImportTitle": "角色壓縮檔",
     "defaultExportTitle": "角色匯出",
     "close": "關閉",
-    "cancel": "取消"
+    "cancel": "取消",
+    "errors": {
+      "ARCHIVE_MISSING_SETTINGS_YML": "壓縮包缺少 settings.yml\n這可能是舊版角色，請下載新版角色後匯入"
+    }
   },
   "menuItem": {
     "defaultTitle": "預設標題"

--- a/src/stores/modules/ui/role-archive.ts
+++ b/src/stores/modules/ui/role-archive.ts
@@ -27,6 +27,15 @@ export interface ExportState {
   error: string
 }
 
+export type NoticePhase = 'idle' | 'active'
+
+export interface CorrectedNotice {
+  phase: NoticePhase
+  title: string
+  message: string
+  durationMs: number
+}
+
 const initialImport = (): ImportState => ({
   phase: 'idle',
   fileName: '',
@@ -50,10 +59,18 @@ const initialExport = (): ExportState => ({
   error: '',
 })
 
+const initialCorrected = (): CorrectedNotice => ({
+  phase: 'idle',
+  title: '',
+  message: '',
+  durationMs: 5000,
+})
+
 export const useRoleArchiveStore = defineStore('role-archive', {
   state: () => ({
     import: initialImport(),
     export: initialExport(),
+    corrected: initialCorrected(),
   }),
 
   actions: {
@@ -62,6 +79,15 @@ export const useRoleArchiveStore = defineStore('role-archive', {
     },
     resetExport() {
       this.export = initialExport()
+    },
+    showCorrected(payload: { title: string; message: string; durationMs?: number }) {
+      this.corrected.phase = 'active'
+      this.corrected.title = payload.title
+      this.corrected.message = payload.message
+      this.corrected.durationMs = payload.durationMs ?? 5000
+    },
+    dismissCorrected() {
+      this.corrected = initialCorrected()
     },
   },
 })

--- a/src/utils/dialogFilters.ts
+++ b/src/utils/dialogFilters.ts
@@ -1,0 +1,38 @@
+// 各模块 dialog filter 的 Android / 桌面端分流
+//
+// 为什么需要 Android mime 列表：Tauri 2 dialog plugin（tauri-plugin-dialog 2.7.x）
+// 在 Android 上把 extensions 通过 `MimeTypeMap.getMimeTypeFromExtension()` 转成 mime
+// 再传给 `Intent.EXTRA_MIME_TYPES`。如果某个扩展名在系统 MimeTypeMap 里没注册
+// （很多 Android ROM 都没注册 flac/ogg/webm），扩展名就被默默吞掉，对应文件不会
+// 出现在系统文件选择器里。Android 系统文件管理器本身能识别这些文件，只是 Tauri
+// dialog 转 mime 时丢失了。
+//
+// 解法：检测 Android 时直接传 mime（含 '/'），Kotlin 端走 `ext.contains('/')` 分支，
+// 不再过 MimeTypeMap。桌面端保留原扩展名（走 rfd → 原生文件选择器，无 mime 中转）。
+//
+// 新增导入类型时按需在两个表里同步加；不要让某一端漏掉。
+
+import { isAndroid } from './platform'
+
+/** Android 端 dialog 给 Intent.EXTRA_MIME_TYPES 的 mime 字符串。 */
+const ANDROID_MUSIC_MIME = [
+  'audio/mpeg', // mp3
+  'audio/x-wav', // wav
+  'audio/x-flac', // flac —— 桌面端常见的 flac 在部分 Android MimeTypeMap 里缺失
+  'audio/ogg', // ogg / oga
+  'audio/webm', // webm / weba（容器里包 opus/vorbis）
+]
+
+/** 桌面端用扩展名（Tauri 走 rfd，不经过 mime 转换）。 */
+const DESKTOP_MUSIC_EXT = ['mp3', 'wav', 'flac', 'webm', 'weba', 'ogg']
+
+/**
+ * 音乐 / 环境音导入 dialog 的 filter。Android / 桌面端各一套，避免 MimeTypeMap
+ * 丢扩展名导致部分格式在系统文件选择器里不可见。
+ */
+export function musicDialogFilters(): { name: string; extensions: string[] }[] {
+  if (isAndroid()) {
+    return [{ name: 'Music', extensions: ANDROID_MUSIC_MIME }]
+  }
+  return [{ name: 'Music', extensions: DESKTOP_MUSIC_EXT }]
+}

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,20 @@
+/**
+ * 从文件路径或 content:// URI 中提取文件名并解码 URL 编码。
+ *
+ * - 取路径最后一段（兼容 `/` 与 `\` 分隔符）
+ * - 去掉 query 参数（`?xxx`）
+ * - 仅对包含 `%XX` 序列的字符串做 decode（避免误伤普通文件名里的 `%` 字符）；
+ *   decode 遇到非法序列时兜底返回原值
+ *
+ * 桌面端路径、Android SAF content URI、convertFileSrc 生成的 URL 均可处理。
+ */
+export function decodePathFileName(path: string): string {
+  const last = path.split(/[\\/]/).pop() || path
+  const withoutQuery = last.split('?')[0]
+  if (!/%[0-9A-Fa-f]{2}/.test(withoutQuery)) return withoutQuery
+  try {
+    return decodeURIComponent(withoutQuery)
+  } catch {
+    return withoutQuery
+  }
+}


### PR DESCRIPTION
## 背景
LingChat 有 4 个文件导入入口，原实现格式识别不一致：

## 入口原实现问题
角色压缩包前端依赖扩展名白名单（zip/7z扩展名错就硬报错）
字体	前端用扩展名白名单（ttf/otf/woff/woff2）文件管理器不提供文件名时无法导入
音乐	前端用扩展名白名单（mp3/wav/flac/ogg/m4a）同上
具体 bug：
Android 角色导入文件夹名变 hex blob（E6A998E585891784606515054）
扩展名错但内容对的文件无法导入
## 改动
统一原则

引入 infer 0.19 crates做 magic byte 检测，4 个入口统一- format hint 改可选，后端裁决结果并写回响应
扩展名错但内容对 → 自动用 magic 决定的扩展名，弹 amber notice 告知用户
扩展名对内容错 → 拒绝并提示具体格式
Android SAF

prepare_file_import_source 返回 ImportSource { path, cleanup_after_import, display_name }
display_name 通过 SAF DISPLAY_NAME query 获取，fallback 到 percent-decoded lastPathSegment
文件名兜底（双保险）

前端 src/utils/path.ts 的 decodePathFileName：取 basename + 去 query + %XX 守卫解码
后端 looks_like_percent_encoded_blob：检测 hex blob 形态，命中时优先采用 SAF display_name
UI 提示

ImportProgressBar 顶部加 amber notice 卡片
上传命令返回 original_name / detected_kind / was_corrected
4 语言 i18n（zh-CN / zh-HK / en / ja）
测试
✅ cargo check：改动文件零 warning
✅ vue-tsc --noEmit：零类型错误
✅ Android 实机：字体 / 音乐 / 角色文件名均恢复正常