### PR TITLE
fix: 书名号《》不再被误识别为日文标签

### DIFF
--- a/src-tauri/src/ai_service/message_system/processor.rs
+++ b/src-tauri/src/ai_service/message_system/processor.rs
@@ -203,12 +203,15 @@ impl MessageProcessor {
         let curly_re = Regex::new(r"\{[^{}]*\}").unwrap();
         processed = curly_re.replace_all(&processed, "").to_string();
 
-        // 1. 统一括号风格
+        // 1. 统一括号风格（不转换书名号，书名号单独处理）
         processed = processed
             .replace('＜', "<")
-            .replace('＞', ">")
-            .replace('《', "<")
-            .replace('》', ">");
+            .replace('＞', ">");
+
+        // 移除书名号《》（保留内容，避免被误识别为日文标签）
+        processed = processed
+            .replace('《', "")
+            .replace('》', "");
 
         // 2. 修复未闭合标签（不使用正则前瞻）
         processed = Self::fix_unclosed_tags(&processed);
@@ -348,7 +351,11 @@ impl MessageProcessor {
 
 /// `Function.fix_ai_generated_text`：规范化带情绪标签的文本。语义 1:1 对照。
 pub fn fix_ai_generated_text(text: &str) -> String {
-    let text = text.replace('＜', "<").replace('＞', ">");
+    let text = text
+        .replace('＜', "<")
+        .replace('＞', ">")
+        .replace('《', "")
+        .replace('》', "");
     let re = emotion_re();
     let mut parts: Vec<String> = Vec::new();
     let mut has_any = false;


### PR DESCRIPTION
## 问题
AI 回复中带有《》书名号时，preprocess_text 将其转换为 <>，导致后续日文正则 <([^>]*)> 把书名内容当成日文提取，主文本中书名消失，仅日文界面显示为 ttsText。

## 修复
不再转换《》为 <>，而是直接移除书名号括号、保留内容，使书名留在主文本中正常显示和合成语音。

影响范围：preprocess_text 和 fix_ai_generated_text 两处。