### PR TITLE
feat: 剧本恐怖效果系统——12 种崩坏特效、突脸/强制选项事件、内容警告与编辑器隐藏

### DIFF
--- a/data/game_data/skills/lingchat-script-editor/references/event-reference.md
+++ b/data/game_data/skills/lingchat-script-editor/references/event-reference.md
@@ -129,6 +129,25 @@
 | `effect`   | 否   | string | `none` | 特效类型（如 Sakura 等） |
 | `duration` | 否   | number | —      | 持续时间                 |
 
+可用特效值（大小写敏感，与前端组件一一对应）：
+
+- 氛围类：`StarField`（星空）、`Rain`（雨）、`Sakura`（樱花）、`Snow`（雪）、`Fireworks`（烟花）
+- 恐怖/演出类：
+  - `Glitch`（画面故障：RGB 错位+扫描线+噪点+周期性整帧扭曲）
+  - `Shake`（震屏）
+  - `Flash`（血红心跳闪烁）/ `Blackout`（断电式黑闪）
+  - `Tear`（画面撕裂：背景切片横向错位抽动）
+  - `Static`（矩形噪点块满屏跳动）
+  - `Invert`（反色闪屏，随机短促爆发）
+  - `BloodDrip`（血滴粒子下落）
+  - `Veins`（黑暗暗角搏动收拢）
+  - `BSOD`（假死机蓝屏，整屏覆盖，慎用）
+  - `UiCorrupt`（UI 崩坏：全局文字 RGB 错位 + 界面抖动）
+  - `BloodUI`（UI 血化：全局文字变血红色 + 渗血辉光搏动）
+- 清除：`none` / `None` / 空串
+
+**组合叠加**：`effect` 支持用 `+` 连接多个特效同时生效，例如 `'Shake+BloodDrip'`、`'Glitch+BloodUI+Invert'`。
+
 ### 9. present_pic — 展示图片（Galgame 小窗口立绘）
 
 ```yaml
@@ -335,7 +354,6 @@
 | `prompt`                | ai_judged | string | —        | 给 AI 的判定提示                               |
 
 ### 17. unlock_achievement — 解锁成就
-
 ```yaml
 - type: unlock_achievement
   achievement_id: 'summer_star' # 成就键名（唯一，英文标识）
@@ -348,6 +366,44 @@
 | `achievement_id` | ✅   | string | —      | 成就键名（英文标识），**不能与内置成就或本剧本其他成就重名**（校验器会提示） |
 | `title`          | ✅   | string | —      | 成就标题，玩家在成就列表里看到的名字                                         |
 | `description`    | ✅   | string | —      | 达成条件说明，展示给玩家                                                     |
+
+### 18. jumpscare — 突脸惊吓（恐怖演出）
+
+```yaml
+- type: jumpscare
+  imagePath: 'jumpscare-face.webp' # Assets/Pics 下的文件名
+  soundPath: 'mscare.ogg' # 可选，Assets/Sounds 下的音效
+  duration: 0.6 # 可选，闪现秒数，默认 0.6
+```
+
+| 字段        | 必填 | 类型   | 默认值 | 说明                                |
+| ----------- | ---- | ------ | ------ | ----------------------------------- |
+| `imagePath` | ✅   | string | —      | 突脸图片（全屏闪现，黑底居中）      |
+| `soundPath` | 否   | string | —      | 同步播放的惊吓音效                  |
+| `duration`  | 否   | number | `0.6`  | 闪现时长（秒），事件本身不占时间轴  |
+
+### 19. force_choice — 强制选择（鼠标拖拽演出）
+
+```yaml
+- type: force_choice
+  forced: 继续陪着她 # 必然被选中的选项文本
+  options:
+    - text: 继续陪着她
+      actions:
+        - type: add_line
+          content: 继续陪着她
+    - text: 到此为止吧
+      actions:
+        - type: add_line
+          content: 到此为止吧
+```
+
+| 字段      | 必填 | 类型   | 默认值 | 说明                                                       |
+| --------- | ---- | ------ | ------ | ---------------------------------------------------------- |
+| `forced`  | ✅   | string | —      | 强制命中的选项文本（必须与某选项一致且未被锁定）           |
+| `options` | ✅   | list   | —      | 选项列表，字段同 `choices`（支持 `condition`/`lock_hint`） |
+
+演出行为：真实光标隐藏，假光标先跟随玩家、随后被磁力拖向 `forced` 选项并自动提交；`forced` 无效时退化为普通选项（不阻塞剧本）。
 
 ---
 
@@ -372,3 +428,12 @@
 | `set_variable`       | 设置变量         | `options`                                |
 | `chapter_end`        | 章节结束         | `end_type` + (next/options)              |
 | `unlock_achievement` | 解锁成就         | `achievement_id`, `title`, `description` |
+| `jumpscare`          | 突脸惊吓         | `imagePath`                              |
+| `force_choice`       | 强制选择         | `forced`, `options`                      |
+
+## 剧本级特殊字段（story_config.yaml）
+
+| 字段              | 说明                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| `content_warning` | 设为 `horror` 时，进入剧本前弹恐怖内容/年龄确认框                    |
+| `editor_hidden`   | 设为 `true` 时，剧本不出现在剧本编辑器列表，也无法被编辑器打开       |

--- a/src-tauri/src/ai_service/game_system/script_engine/events/background_effect_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/background_effect_event.rs
@@ -17,7 +17,25 @@ use crate::ai_service::message_system::events::emit;
 /// `GameBackground.vue` compares with `===`, so these are **case sensitive**:
 /// `starfield` and `Starfield` both silently render nothing. Anything not in
 /// this list (including the conventional `None`) clears the current effect.
-pub const KNOWN_EFFECTS: [&str; 5] = ["StarField", "Rain", "Sakura", "Snow", "Fireworks"];
+pub const KNOWN_EFFECTS: [&str; 17] = [
+    "StarField",
+    "Rain",
+    "Sakura",
+    "Snow",
+    "Fireworks",
+    "Glitch",
+    "Shake",
+    "Flash",
+    "Blackout",
+    "Tear",
+    "Static",
+    "Invert",
+    "BloodDrip",
+    "Veins",
+    "BSOD",
+    "UiCorrupt",
+    "BloodUI",
+];
 
 /// Names that explicitly mean "no effect" and therefore must not be warned about.
 const CLEARING_EFFECTS: [&str; 3] = ["none", "None", ""];
@@ -39,8 +57,12 @@ impl BackgroundEffectEvent {
         // The warning exists because the failure was previously completely
         // silent: two of the shipped scripts write `starfield` / `Starfield`
         // and get no particles at all with no diagnostic anywhere.
-        if !CLEARING_EFFECTS.contains(&effect.as_str()) && !KNOWN_EFFECTS.contains(&effect.as_str())
-        {
+        // 支持 '+' 组合叠加（如 "Glitch+BloodDrip"），逐段校验
+        let all_known = effect
+            .split('+')
+            .map(|p| p.trim())
+            .all(|p| CLEARING_EFFECTS.contains(&p) || KNOWN_EFFECTS.contains(&p));
+        if !all_known && !CLEARING_EFFECTS.contains(&effect.as_str()) {
             let hint = KNOWN_EFFECTS
                 .iter()
                 .find(|k| k.eq_ignore_ascii_case(&effect));
@@ -120,7 +142,11 @@ mod tests {
         // Mirrors the `v-if` chain in src/components/game/standard/GameBackground.vue.
         assert_eq!(
             KNOWN_EFFECTS,
-            ["StarField", "Rain", "Sakura", "Snow", "Fireworks"]
+            [
+                "StarField", "Rain", "Sakura", "Snow", "Fireworks", "Glitch", "Shake", "Flash",
+                "Blackout", "Tear", "Static", "Invert", "BloodDrip", "Veins", "BSOD", "UiCorrupt",
+                "BloodUI"
+            ]
         );
     }
 }

--- a/src-tauri/src/ai_service/game_system/script_engine/events/force_choice_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/force_choice_event.rs
@@ -1,0 +1,161 @@
+//! Force choice event — DDLC 式"鼠标被拖走"的强制选择。
+//!
+//! 与 `choices` 共用同一条 oneshot 通道和选项匹配逻辑，区别只在 payload
+//! 多带一个 `forced` 字段：前端演出结束后只能提交这个选项的文本。
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::ai_service::game_system::script_engine::events::{
+    evaluate_condition, parse_duration, register_event, ScriptContext, ScriptEvent,
+};
+use crate::ai_service::game_system::script_engine::responses::{
+    event_names::SCRIPT_FORCE_CHOICE, ChoiceItem, ForceChoicePayload,
+};
+use crate::ai_service::game_system::script_engine::utils::script_function;
+use crate::ai_service::message_system::events::emit;
+use crate::ai_service::types::{LineAttributeExt, LineBase};
+use crate::db::entities::line::LineAttribute;
+
+pub struct ForceChoiceEvent {
+    options: Vec<Value>,
+    forced: String,
+    duration: Option<f64>,
+}
+
+impl ForceChoiceEvent {
+    fn from_event_data(data: &Value) -> Self {
+        Self {
+            options: data
+                .get("options")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default(),
+            forced: data
+                .get("forced")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            duration: parse_duration(data),
+        }
+    }
+}
+
+#[async_trait]
+impl ScriptEvent for ForceChoiceEvent {
+    async fn execute(&mut self, ctx: &mut ScriptContext<'_>) -> Result<Option<String>> {
+        let vars = ctx
+            .game_status
+            .lock()
+            .await
+            .script_status
+            .clone()
+            .map(|s| s.vars);
+
+        // 与 ChoiceEvent 一致：条件不满足的选项标记 disabled + lock_hint
+        let choices: Vec<ChoiceItem> = self
+            .options
+            .iter()
+            .filter_map(|o| {
+                let text = o.get("text").and_then(|v| v.as_str())?.to_string();
+                let mut item = ChoiceItem {
+                    text,
+                    disabled: false,
+                    reason: None,
+                };
+                if let Some(ref vars) = vars {
+                    let condition = o.get("condition").and_then(|v| v.as_str()).unwrap_or("");
+                    if !condition.is_empty() && !evaluate_condition(condition, vars) {
+                        item.disabled = true;
+                        item.reason = o
+                            .get("lock_hint")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                    }
+                }
+                Some(item)
+            })
+            .collect();
+
+        // forced 必须指向一个实际存在且未被锁定的选项，否则退化成普通 choices 行为：
+        // 前端看不到有效强制项时会放任玩家自选，避免剧本卡死。
+        let forced = self.forced.clone();
+        if !forced.is_empty() && !choices.iter().any(|c| c.text == forced && !c.disabled) {
+            tracing::warn!(
+                "[ForceChoiceEvent] forced 选项 '{}' 不存在或被锁定，将不强制",
+                forced
+            );
+        }
+
+        let rx = {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let mut ch = ctx.channels.lock().await;
+            ch.choice_tx = Some(tx);
+            ch.choice_allow_free = false;
+            rx
+        };
+
+        let payload = ForceChoicePayload {
+            choices,
+            forced,
+            duration: self.duration,
+        };
+        let _ = emit(ctx.app, SCRIPT_FORCE_CHOICE, &payload);
+
+        let user_choice = rx.await.map_err(|_| anyhow!("用户选择通道已关闭"))?;
+        ctx.channels.lock().await.choice_allow_free = false;
+
+        tracing::info!("[ForceChoiceEvent] 用户选择(强制演出): {}", user_choice);
+
+        let mut script_status = ctx
+            .game_status
+            .lock()
+            .await
+            .script_status
+            .clone()
+            .ok_or_else(|| anyhow!("ScriptStatus 未设置"))?;
+
+        let matched = {
+            let mut gs = ctx.game_status.lock().await;
+            script_function::process_options(
+                &mut *gs,
+                ctx.db,
+                &mut script_status,
+                &self.options,
+                Some(&user_choice),
+            )
+            .await?
+        };
+
+        ctx.game_status.lock().await.script_status = Some(script_status);
+
+        if !matched {
+            let mut gs = ctx.game_status.lock().await;
+            let line = LineBase {
+                content: user_choice,
+                attribute: LineAttributeExt(LineAttribute::User),
+                display_name: Some(gs.player.user_name.clone()),
+                sender_role_id: Some(0),
+                ..Default::default()
+            };
+            gs.add_line(ctx.db, line).await?;
+        }
+
+        Ok(None)
+    }
+
+    fn event_type() -> &'static str {
+        "force_choice"
+    }
+
+    fn duration(&self) -> Option<f64> {
+        self.duration
+    }
+}
+
+pub fn register() {
+    register_event(ForceChoiceEvent::event_type(), |data| {
+        Box::new(ForceChoiceEvent::from_event_data(&data))
+    });
+}

--- a/src-tauri/src/ai_service/game_system/script_engine/events/jumpscare_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/jumpscare_event.rs
@@ -1,0 +1,99 @@
+//! Jumpscare event — full-screen image flash + sound sting (horror stories).
+//!
+//! Fire-and-forget: the script continues to the next event immediately;
+//! the frontend overlay hides itself after `duration` (default 0.6s).
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::ai_service::game_system::script_engine::events::{
+    parse_duration, register_event, ScriptContext, ScriptEvent,
+};
+use crate::ai_service::game_system::script_engine::responses::{
+    event_names::SCRIPT_JUMPSCARE, JumpscarePayload,
+};
+use crate::ai_service::game_system::script_engine::utils::media::{
+    resolve_script_media, MediaType,
+};
+use crate::ai_service::message_system::events::emit;
+
+pub struct JumpscareEvent {
+    image_path: String,
+    sound_path: String,
+    duration: Option<f64>,
+}
+
+impl JumpscareEvent {
+    fn from_event_data(data: &Value) -> Self {
+        Self {
+            image_path: data
+                .get("imagePath")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            sound_path: data
+                .get("soundPath")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            duration: parse_duration(data),
+        }
+    }
+}
+
+#[async_trait]
+impl ScriptEvent for JumpscareEvent {
+    async fn execute(&mut self, ctx: &mut ScriptContext<'_>) -> Result<Option<String>> {
+        let script_path = ctx
+            .game_status
+            .lock()
+            .await
+            .script_status
+            .as_ref()
+            .map(|ss| ss.script_path.clone());
+
+        let image = resolve_script_media(
+            ctx.data_dir,
+            script_path.as_deref(),
+            &self.image_path,
+            MediaType::Pic,
+        )
+        .unwrap_or_default();
+        if image.is_empty() {
+            tracing::warn!("[JumpscareEvent] 图片未找到: {}", self.image_path);
+        }
+
+        let sound = resolve_script_media(
+            ctx.data_dir,
+            script_path.as_deref(),
+            &self.sound_path,
+            MediaType::Sound,
+        )
+        .unwrap_or_default();
+
+        let payload = JumpscarePayload {
+            image_path: image,
+            sound_path: sound,
+            duration: self.duration,
+        };
+        let _ = emit(ctx.app, SCRIPT_JUMPSCARE, &payload);
+
+        Ok(None)
+    }
+
+    fn event_type() -> &'static str {
+        "jumpscare"
+    }
+
+    fn duration(&self) -> Option<f64> {
+        // 演出由前端按 payload.duration 自行收场，事件本身不占用剧本时间轴
+        None
+    }
+}
+
+pub fn register() {
+    register_event(JumpscareEvent::event_type(), |data| {
+        Box::new(JumpscareEvent::from_event_data(&data))
+    });
+}

--- a/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
@@ -15,6 +15,8 @@ pub mod choice_event;
 pub mod dialog_event;
 pub mod free_dialogue_event;
 pub mod input_event;
+pub mod jumpscare_event;
+pub mod force_choice_event;
 pub mod modify_character_event;
 pub mod music_event;
 pub mod narration_event;

--- a/src-tauri/src/ai_service/game_system/script_engine/mod.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/mod.rs
@@ -43,6 +43,9 @@ pub fn init_event_registry() {
     events::ambient_event::register();
     // 注册成就解锁事件处理器
     events::achievement_event::register();
+    // 注册恐怖演出事件处理器（突脸 / 强制选择）
+    events::jumpscare_event::register();
+    events::force_choice_event::register();
 
     tracing::info!("[ScriptEngine] 所有事件处理器已注册");
 }

--- a/src-tauri/src/ai_service/game_system/script_engine/responses.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/responses.rs
@@ -25,6 +25,8 @@ pub mod event_names {
     pub const SCRIPT_CHOICE: &str = "script:choice";
     pub const SCRIPT_END: &str = "script:end";
     pub const SCRIPT_FREE_DIALOGUE: &str = "script:free-dialogue";
+    pub const SCRIPT_JUMPSCARE: &str = "script:jumpscare";
+    pub const SCRIPT_FORCE_CHOICE: &str = "script:force-choice";
 }
 
 // ============================================================
@@ -91,6 +93,28 @@ pub struct MusicPayload {
 #[serde(rename_all = "camelCase")]
 pub struct SoundPayload {
     pub sound_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<f64>,
+}
+
+/// 突脸惊吓：全屏图片闪现 + 音效。图片为空串表示解析失败（前端应跳过）。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JumpscarePayload {
+    pub image_path: String,
+    /// 可选音效；空串表示无
+    pub sound_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<f64>,
+}
+
+/// 强制选择：前端用"鼠标被拖向 forced 选项"的演出，最终只能提交 forced。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForceChoicePayload {
+    pub choices: Vec<ChoiceItem>,
+    /// 必然被选中的选项文本（必须在 choices 里存在）
+    pub forced: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<f64>,
 }

--- a/src-tauri/src/ai_service/game_system/script_engine/script_manager.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/script_manager.rs
@@ -37,6 +37,8 @@ struct StoryConfigRaw {
     adventure: Option<AdventureConfig>,
     #[serde(default)]
     script_settings: Option<serde_json::Map<String, Value>>,
+    #[serde(default)]
+    content_warning: Option<String>,
 }
 
 /// Central orchestrator for the script/story mode engine.
@@ -165,6 +167,7 @@ impl ScriptManager {
             script_path: script_path.to_path_buf(),
             recommand_start: raw.recommand_start.unwrap_or_default(),
             adventure,
+            content_warning: raw.content_warning,
             running_client_id: None,
             current_chapter_key: String::new(),
             current_event_process: 0,

--- a/src-tauri/src/ai_service/types.rs
+++ b/src-tauri/src/ai_service/types.rs
@@ -546,6 +546,8 @@ pub struct ScriptStatus {
 
     pub recommand_start: String,
     pub adventure: AdventureConfig,
+    /// `story_config.yaml` 的内容警告标记（如 "horror"），前端据此在进入前弹确认框。
+    pub content_warning: Option<String>,
     pub running_client_id: Option<String>,
 
     pub current_chapter_key: String,

--- a/src-tauri/src/api/script.rs
+++ b/src-tauri/src/api/script.rs
@@ -20,6 +20,8 @@ pub struct ScriptSummary {
     pub description: String,
     pub folder_key: String,
     pub intro_chapter: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_warning: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -45,6 +47,7 @@ pub async fn list_scripts(app: AppHandle) -> Result<ScriptListResponse, String> 
             description: s.description.clone(),
             folder_key: s.folder_key.clone(),
             intro_chapter: s.intro_chapter.clone(),
+            content_warning: s.content_warning.clone(),
         })
         .collect();
 
@@ -65,6 +68,7 @@ pub async fn list_standalone_scripts(app: AppHandle) -> Result<ScriptListRespons
             description: s.description.clone(),
             folder_key: s.folder_key.clone(),
             intro_chapter: s.intro_chapter.clone(),
+            content_warning: s.content_warning.clone(),
         })
         .collect();
 
@@ -133,6 +137,22 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
     });
 
     Ok(())
+}
+
+/// 把系统鼠标指针拖动到窗口内的指定 CSS 坐标。
+///
+/// 用于剧本的 `force_choice` 演出（DDLC 式强制拖动鼠标）。前端传视口 CSS 像素，
+/// 这里换算成物理像素再叠加窗口内容区左上角偏移。
+#[tauri::command]
+pub async fn warp_cursor(app: AppHandle, x: f64, y: f64) -> Result<(), String> {
+    let window = app.get_webview_window("main").ok_or("主窗口不存在")?;
+    let scale = window.scale_factor().map_err(|e| e.to_string())?;
+    let inner = window.inner_position().map_err(|e| e.to_string())?;
+    let px = inner.x + (x * scale).round() as i32;
+    let py = inner.y + (y * scale).round() as i32;
+    window
+        .set_cursor_position(tauri::PhysicalPosition::new(px, py))
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/src-tauri/src/api/script_editor/commands.rs
+++ b/src-tauri/src/api/script_editor/commands.rs
@@ -50,6 +50,13 @@ pub struct ScriptPackage {
     pub chapter_count: usize,
     /// 该剧本是否已被引擎加载（未加载表示需要重启或 rescan）
     pub loaded_by_engine: bool,
+    /// 作者声明禁止编辑器打开（如内置恐怖剧本含有编辑器不支持的特殊事件）
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub editor_hidden: bool,
+}
+
+fn is_false(v: &bool) -> bool {
+    !*v
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -211,6 +218,10 @@ fn read_package(key: &str, loaded_names: &HashSet<String>) -> Result<ScriptPacka
             .to_string(),
         is_adventure,
         chapter_count: paths::enumerate_chapter_ids(&dir).len(),
+        editor_hidden: config
+            .get("editor_hidden")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
     })
 }
 
@@ -427,7 +438,9 @@ pub async fn editor_list_scripts(app: AppHandle) -> Result<Vec<ScriptPackage>, S
     let mut out = Vec::new();
     for key in paths::enumerate_script_keys() {
         match read_package(&key, &loaded) {
-            Ok(p) => out.push(p),
+            // 作者声明 editor_hidden 的剧本不在编辑器出现
+            Ok(p) if !p.editor_hidden => out.push(p),
+            Ok(_) => {}
             Err(e) => tracing::warn!("[ScriptEditor] 跳过无效剧本 {}: {}", key, e),
         }
     }
@@ -437,9 +450,13 @@ pub async fn editor_list_scripts(app: AppHandle) -> Result<Vec<ScriptPackage>, S
 #[tauri::command]
 pub async fn editor_read_script(app: AppHandle, key: String) -> Result<ScriptDetail, String> {
     let loaded = loaded_script_names(&app).await;
+    let package = read_package(&key, &loaded)?;
+    if package.editor_hidden {
+        return Err("该剧本已被作者锁定，无法在剧本编辑器中打开".to_string());
+    }
     let dir = paths::resolve_script_dir(&key)?;
     Ok(ScriptDetail {
-        package: read_package(&key, &loaded)?,
+        package,
         story_config: yaml_file::read_story_config(&dir)?,
         chapters: chapter_summaries(&dir),
         assets: read_asset_index(&dir),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -675,6 +675,7 @@ pub fn run() {
             api::script::start_script,
             api::script::script_submit_input,
             api::script::script_submit_choice,
+            api::script::warp_cursor,
             // ── 剧本编辑器 ──
             api::script_editor::editor_get_schema,
             api::script_editor::editor_list_scripts,

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@
   <AchievementToast v-if="isMainWindow" />
   <AdventureUnlockNotify v-if="isMainWindow" />
   <AppDialog v-if="isMainWindow" />
+  <HorrorEntryTransition v-if="isMainWindow" />
 </template>
 
 <script setup lang="ts">
@@ -25,6 +26,7 @@ import Notification from './components/ui/Notification.vue'
 import AchievementToast from './components/ui/AchievementToast.vue'
 import AdventureUnlockNotify from './components/ui/AdventureUnlockNotify.vue'
 import AppDialog from './components/ui/AppDialog.vue'
+import HorrorEntryTransition from './components/ui/HorrorEntryTransition.vue'
 import { initUIStore } from './stores/modules/ui/ui'
 import { i18n } from './locales'
 import { useSettingsStore } from './stores/modules/settings'

--- a/src/api/services/script-info.ts
+++ b/src/api/services/script-info.ts
@@ -19,6 +19,7 @@ export interface ScriptSummary {
   description?: string
   folder_key?: string
   intro_chapter?: string
+  content_warning?: string
 }
 
 export interface ScriptInfo {

--- a/src/api/tauri-events.ts
+++ b/src/api/tauri-events.ts
@@ -344,6 +344,14 @@ export function initializeTauriEventListeners() {
     eventQueue.addEvent(asEvent(event.payload, { type: 'choice', defaultDuration: 0 }))
   })
 
+  listen('script:jumpscare', (event) => {
+    eventQueue.addEvent(asEvent(event.payload, { type: 'jumpscare', defaultDuration: 0 }))
+  })
+
+  listen('script:force-choice', (event) => {
+    eventQueue.addEvent(asEvent(event.payload, { type: 'force_choice', defaultDuration: 0 }))
+  })
+
   listen('script:end', (event) => {
     console.log('[Tauri] script:end', event.payload)
     eventQueue.addEvent(

--- a/src/components/game/standard/GameBackground.vue
+++ b/src/components/game/standard/GameBackground.vue
@@ -53,6 +53,8 @@
       :intensity="1.5"
       :style="`z-index:${BACKGROUND_ZINDEX}`"
     />
+    <!-- 恐怖向特效（Glitch/Shake/Flash/Tear/Static/Invert/BloodDrip/Veins/BSOD/UiCorrupt/BloodUI）
+         已上移到 GameExtraUI 的 HorrorEffectsLayer，压过角色立绘渲染 -->
   </div>
 
   <!-- 背景光照叠加层（在背景上方、角色下方） -->

--- a/src/components/game/standard/GameExtraUI.vue
+++ b/src/components/game/standard/GameExtraUI.vue
@@ -16,6 +16,12 @@
     <!-- 5. 自由对话动画与提示区域 -->
     <ScriptFreeDialogueDisplay />
 
+    <!-- 5.5 强制选择（DDLC 式鼠标拖拽演出） -->
+    <ForceChoice />
+
+    <!-- 5.6 恐怖特效层（压过角色立绘与对话框） -->
+    <HorrorEffectsLayer />
+
     <!-- 6. 声效控制面板 -->
     <SoundEffectPanel />
   </div>
@@ -27,5 +33,7 @@ import GameChoices from './extra/GameChoices.vue'
 import ScriptCompleteDisplay from './extra/ScriptCompleteDisplay.vue'
 import ScriptPicDisplay from './extra/ScriptPicDisplay.vue'
 import ScriptFreeDialogueDisplay from './extra/ScriptFreeDialogueDisplay.vue'
+import ForceChoice from './extra/ForceChoice.vue'
+import HorrorEffectsLayer from './HorrorEffectsLayer.vue'
 import SoundEffectPanel from './extra/SoundEffectPanel.vue'
 </script>

--- a/src/components/game/standard/GameRoleAvatar.vue
+++ b/src/components/game/standard/GameRoleAvatar.vue
@@ -159,6 +159,22 @@ async function resolveAvatar() {
       targetAvatarUrl.value = convertFileSrc(path)
     }
   } catch {
+    // 演出专用情绪（如"崩坏"）在角色目录里可能没有对应文件，回退到"正常"再试一次
+    if (mappedEmotion !== '正常') {
+      try {
+        const fallback = await invoke<string>('get_avatar_file', {
+          characterFolder: r.character_folder,
+          emotion: '正常',
+          clothesName,
+        })
+        if (currentId === resolveAvatarId) {
+          targetAvatarUrl.value = convertFileSrc(fallback)
+        }
+        return
+      } catch {
+        // 继续走置空兜底
+      }
+    }
     if (currentId === resolveAvatarId) {
       targetAvatarUrl.value = ''
     }

--- a/src/components/game/standard/HorrorEffectsLayer.vue
+++ b/src/components/game/standard/HorrorEffectsLayer.vue
@@ -1,0 +1,48 @@
+<template>
+  <!-- 恐怖特效层：挂在 GameExtraUI（游戏 UI 最顶层），压过角色立绘与对话框 -->
+  <!-- 支持 '+' 组合叠加，如 effect: 'Glitch+BloodDrip+BloodUI' -->
+  <div class="pointer-events-none absolute inset-0" style="isolation: isolate">
+    <Glitch v-if="active.has('Glitch')" :enabled="true" />
+    <Shake v-if="active.has('Shake')" :enabled="true" />
+    <Flash v-if="active.has('Flash')" :enabled="true" mode="red" />
+    <Flash v-if="active.has('Blackout')" :enabled="true" mode="black" />
+    <Tear v-if="active.has('Tear')" :enabled="true" />
+    <Static v-if="active.has('Static')" :enabled="true" />
+    <Invert v-if="active.has('Invert')" :enabled="true" />
+    <BloodDrip v-if="active.has('BloodDrip')" :enabled="true" />
+    <Veins v-if="active.has('Veins')" :enabled="true" />
+    <Bsod v-if="active.has('BSOD')" :enabled="true" />
+    <UiCorrupt v-if="active.has('UiCorrupt')" />
+    <UiBlood v-if="active.has('BloodUI')" />
+  </div>
+
+  <!-- 突脸惊吓层：最顶层，压过一切 -->
+  <Jumpscare />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useUIStore } from '../../../stores/modules/ui/ui'
+import Glitch from './particles/Glitch.vue'
+import Shake from './particles/Shake.vue'
+import Flash from './particles/Flash.vue'
+import Tear from './particles/Tear.vue'
+import Static from './particles/Static.vue'
+import Invert from './particles/Invert.vue'
+import BloodDrip from './particles/BloodDrip.vue'
+import Veins from './particles/Veins.vue'
+import Bsod from './particles/Bsod.vue'
+import UiCorrupt from './particles/UiCorrupt.vue'
+import UiBlood from './particles/UiBlood.vue'
+import Jumpscare from './particles/Jumpscare.vue'
+
+const uiStore = useUIStore()
+
+/** 当前生效的特效集合；'none'/空串 = 清空 */
+const active = computed<Set<string>>(() => {
+  const raw = uiStore.currentBackgroundEffect
+  if (!raw || raw === 'none' || raw === 'None') return new Set()
+  return new Set(raw.split('+').map((s) => s.trim()).filter(Boolean))
+})
+</script>
+

--- a/src/components/game/standard/extra/ForceChoice.vue
+++ b/src/components/game/standard/extra/ForceChoice.vue
@@ -1,0 +1,173 @@
+<template>
+  <!-- 强制选择（DDLC 式）：真实鼠标被磁力强行拖向指定选项，然后自动提交 -->
+  <div
+    v-if="gameStore.forceChoice"
+    ref="overlayRef"
+    class="force-choice-overlay"
+    @mousemove="onMouseMove"
+  >
+    <div class="flex flex-col gap-10 w-full max-w-2xl px-4">
+      <button
+        v-for="choice in gameStore.forceChoice.choices"
+        :key="choice.text"
+        :ref="choice.text === gameStore.forceChoice!.forced ? setForcedBtn : undefined"
+        :disabled="choice.disabled || choice.text !== gameStore.forceChoice!.forced"
+        :title="choice.disabled ? choice.reason || '该选项当前不可选' : ''"
+        :class="[
+          'relative w-full py-4 px-8 border rounded-full border-white/10 backdrop-blur-xl backdrop-saturate-150',
+          choice.disabled && choice.text !== gameStore.forceChoice!.forced
+            ? 'text-white/30 bg-slate-900/20'
+            : choice.text === gameStore.forceChoice!.forced
+              ? 'text-white bg-slate-900/40 forced-target'
+              : 'text-white/40 bg-slate-900/20',
+        ]"
+      >
+        <span class="text-lg font-medium tracking-widest text-center block drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)]">
+          {{ choice.text }}
+        </span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, ref, watch, nextTick } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
+import { useGameStore } from '@/stores/modules/game'
+
+const gameStore = useGameStore()
+
+const forcedBtnEl = ref<HTMLElement | null>(null)
+
+// 当前真实鼠标位置（由 mousemove 追踪；拖动期间会被我们不断改写）
+const realPos = { x: window.innerWidth / 2, y: window.innerHeight / 2 }
+
+let timerId = 0
+let startedAt = 0
+let submitted = false
+
+function setForcedBtn(el: unknown) {
+  if (el) forcedBtnEl.value = el as HTMLElement
+}
+
+function onMouseMove(e: MouseEvent) {
+  // 玩家挣扎时取最新位置作为下一次拖拽的起点
+  realPos.x = e.clientX
+  realPos.y = e.clientY
+}
+
+const TICK_MS = 33 // 每帧拖动一步，约 30 步/秒
+const PULL_MS = 2600 // 2.6s 后完全被吸附
+
+async function tick() {
+  const fc = gameStore.forceChoice
+  const btn = forcedBtnEl.value
+  if (!fc || !btn || submitted) return
+
+  const elapsed = performance.now() - startedAt
+  // 磁力曲线：前 0.4s 几乎正常，之后加速增强直至完全吸附
+  const pull = Math.max(0, Math.min(1, (elapsed - 400) / (PULL_MS - 400)))
+
+  const rect = btn.getBoundingClientRect()
+  const tx = rect.left + rect.width / 2
+  const ty = rect.top + rect.height / 2
+
+  // 朝目标插值一步（步长随磁力变大），然后改写真实鼠标位置
+  const step = 0.06 + pull * 0.3
+  realPos.x += (tx - realPos.x) * step
+  realPos.y += (ty - realPos.y) * step
+
+  try {
+    await invoke('warp_cursor', { x: realPos.x, y: realPos.y })
+  } catch (e) {
+    console.warn('[ForceChoice] warp_cursor 失败，退化为普通选择:', e)
+    finishFallback()
+    return
+  }
+
+  const dist = Math.hypot(realPos.x - tx, realPos.y - ty)
+  if (pull >= 1 && dist < 4) {
+    submitted = true
+    // 吸附到按钮中心，停顿一拍后强制提交
+    invoke('warp_cursor', { x: tx, y: ty }).catch(() => {})
+    window.setTimeout(() => submit(fc.forced), 350)
+    return
+  }
+
+  timerId = window.setTimeout(tick, TICK_MS)
+}
+
+/** warp 不可用时的兜底：直接自动提交 forced，避免剧本卡死 */
+function finishFallback() {
+  const fc = gameStore.forceChoice
+  if (!fc || submitted) return
+  submitted = true
+  window.setTimeout(() => submit(fc.forced), 800)
+}
+
+function submit(choice: string) {
+  gameStore.appendGameMessage({
+    type: 'message',
+    displayName: gameStore.userName,
+    content: choice,
+  })
+  invoke('script_submit_choice', { choice })
+  gameStore.forceChoice = null
+}
+
+watch(
+  () => gameStore.forceChoice,
+  async (fc) => {
+    clearTimeout(timerId)
+    submitted = false
+    if (!fc) return
+    if (!fc.forced || !fc.choices.some((c) => c.text === fc.forced && !c.disabled)) {
+      // forced 无效：直接自动提交第一项，避免死锁
+      finishFallback()
+      return
+    }
+    await nextTick()
+    startedAt = performance.now()
+    timerId = window.setTimeout(tick, TICK_MS)
+  },
+)
+
+onBeforeUnmount(() => clearTimeout(timerId))
+</script>
+
+<style scoped>
+.force-choice-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 900000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-top: -15vh;
+  /* 父容器 GameExtraUI 是 pointer-events:none，必须显式夺回事件 */
+  pointer-events: auto;
+}
+
+/* 非强制项在演出期间不可点 */
+.force-choice-overlay button:disabled {
+  cursor: not-allowed;
+}
+
+/* 被吸附的目标按钮：血色呼吸微光，像有什么在"推荐"它 */
+.forced-target {
+  animation: forced-breathe 1.4s ease-in-out infinite;
+}
+
+@keyframes forced-breathe {
+  0%,
+  100% {
+    box-shadow: 0 0 8px rgba(184, 9, 26, 0.25);
+    border-color: rgba(184, 9, 26, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 22px rgba(184, 9, 26, 0.55);
+    border-color: rgba(184, 9, 26, 0.8);
+  }
+}
+</style>

--- a/src/components/game/standard/particles/BloodDrip.vue
+++ b/src/components/game/standard/particles/BloodDrip.vue
@@ -1,0 +1,113 @@
+<template>
+  <!-- 血滴粒子：红色液滴受重力下落（canvas 实现） -->
+  <canvas
+    v-if="enabled"
+    ref="canvasRef"
+    class="blood-canvas"
+  />
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+const props = defineProps({
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+  intensity: {
+    type: Number,
+    default: 1,
+    validator: (value: number) => value >= 0 && value <= 2,
+  },
+})
+
+interface Drop {
+  x: number
+  y: number
+  vy: number
+  vx: number
+  size: number
+  alpha: number
+}
+
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+let ctx: CanvasRenderingContext2D | null = null
+let animId = 0
+let drops: Drop[] = []
+let lastTime = 0
+
+const GRAVITY = 900 // px/s²
+
+function spawnDrop(W: number, fromTop: boolean): Drop {
+  return {
+    x: Math.random() * W,
+    y: fromTop ? -10 : Math.random() * window.innerHeight * 0.5,
+    vy: 20 + Math.random() * 60,
+    vx: (Math.random() - 0.5) * 15,
+    size: 2 + Math.random() * 5,
+    alpha: 0.55 + Math.random() * 0.35,
+  }
+}
+
+function loop(time: number) {
+  if (!ctx || !canvasRef.value) return
+  const W = canvasRef.value.width
+  const H = canvasRef.value.height
+  const dt = Math.min((time - lastTime) / 1000 || 0.016, 0.05)
+  lastTime = time
+
+  // 持续补充血滴，密度随强度
+  const target = Math.floor(18 * props.intensity)
+  while (drops.length < target) drops.push(spawnDrop(W, true))
+
+  ctx.clearRect(0, 0, W, H)
+  for (const d of drops) {
+    d.vy += GRAVITY * dt
+    d.x += d.vx * dt
+    d.y += d.vy * dt
+
+    // 液滴：圆头 + 上拖尾
+    ctx.fillStyle = `rgba(140, 0, 8, ${d.alpha})`
+    ctx.beginPath()
+    ctx.ellipse(d.x, d.y, d.size * 0.6, d.size * 1.6, 0, 0, Math.PI * 2)
+    ctx.fill()
+    ctx.beginPath()
+    ctx.arc(d.x, d.y + d.size * 1.2, d.size * 0.65, 0, Math.PI * 2)
+    ctx.fill()
+  }
+  drops = drops.filter((d) => d.y < H + 20)
+
+  animId = requestAnimationFrame(loop)
+}
+
+function resize() {
+  if (!canvasRef.value) return
+  canvasRef.value.width = window.innerWidth
+  canvasRef.value.height = window.innerHeight
+}
+
+onMounted(() => {
+  const c = canvasRef.value
+  if (!c) return
+  resize()
+  ctx = c.getContext('2d')
+  window.addEventListener('resize', resize)
+  animId = requestAnimationFrame(loop)
+})
+
+onBeforeUnmount(() => {
+  cancelAnimationFrame(animId)
+  window.removeEventListener('resize', resize)
+})
+</script>
+
+<style scoped>
+.blood-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+</style>

--- a/src/components/game/standard/particles/Bsod.vue
+++ b/src/components/game/standard/particles/Bsod.vue
@@ -1,0 +1,82 @@
+<template>
+  <!-- 假死机画面：模拟系统崩溃蓝屏（内容为原创恶搞文本，非真实系统信息） -->
+  <div
+    v-if="enabled"
+    class="bsod-layer"
+  >
+    <div class="bsod-face">:(</div>
+    <div class="bsod-text">
+      LingChat OS 遇到无法恢复的错误，正在尝试挽留即将消失的数据。
+    </div>
+    <div class="bsod-progress">{{ progress }}% 完成</div>
+    <div class="bsod-stop">终止代码：SCRIPT_7_NOT_FOUND</div>
+    <div class="bsod-hint">如果你看到这张脸，说明有人不想让你继续。</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+defineProps({
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+// 百分比故意卡在奇怪的区间跳动，最后停住不动
+const progress = ref(0)
+let timer = 0
+
+onMounted(() => {
+  const tick = () => {
+    if (progress.value < 99) {
+      progress.value = Math.min(99, progress.value + Math.floor(Math.random() * 23))
+    }
+    timer = window.setTimeout(tick, 700 + Math.random() * 1600)
+  }
+  tick()
+})
+
+onBeforeUnmount(() => clearTimeout(timer))
+</script>
+
+<style scoped>
+.bsod-layer {
+  position: absolute;
+  inset: 0;
+  background: #0a3d91;
+  color: #fff;
+  font-family: 'Consolas', 'Courier New', monospace;
+  padding: 12vh 10vw;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 3vh;
+}
+
+.bsod-face {
+  font-size: 14vh;
+  line-height: 1;
+}
+
+.bsod-text {
+  font-size: 3vh;
+  max-width: 60%;
+}
+
+.bsod-progress {
+  font-size: 2.4vh;
+}
+
+.bsod-stop {
+  margin-top: 4vh;
+  font-size: 1.8vh;
+  opacity: 0.8;
+}
+
+.bsod-hint {
+  font-size: 1.6vh;
+  opacity: 0.55;
+}
+</style>

--- a/src/components/game/standard/particles/Flash.vue
+++ b/src/components/game/standard/particles/Flash.vue
@@ -1,0 +1,70 @@
+<template>
+  <div
+    v-if="enabled"
+    class="flash-container"
+    :class="modeClass"
+    :style="{ '--flash-opacity': Math.min(0.45 + intensity * 0.3, 0.9) }"
+  ></div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps({
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+  intensity: {
+    type: Number,
+    default: 1,
+    validator: (value: number) => value >= 0 && value <= 2,
+  },
+  // red = 血红闪烁（惊悚），black =  blackout 断电式黑闪
+  mode: {
+    type: String,
+    default: 'red',
+    validator: (value: string) => ['red', 'black'].includes(value),
+  },
+})
+
+const modeClass = computed(() => (props.mode === 'black' ? 'flash-black' : 'flash-red'))
+</script>
+
+<style scoped>
+.flash-container {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+/* 心跳式两段闪：亮-暗-亮-长暗，比匀速闪烁更有压迫感 */
+.flash-red {
+  background: rgb(120, 0, 10);
+  animation: flash-pulse 1.6s ease-in-out infinite;
+}
+
+.flash-black {
+  background: #000;
+  animation: flash-pulse 2.2s ease-in-out infinite;
+}
+
+@keyframes flash-pulse {
+  0%,
+  100% {
+    opacity: 0;
+  }
+  8% {
+    opacity: var(--flash-opacity, 0.75);
+  }
+  16% {
+    opacity: 0;
+  }
+  30% {
+    opacity: calc(var(--flash-opacity, 0.75) * 0.6);
+  }
+  45% {
+    opacity: 0;
+  }
+}
+</style>

--- a/src/components/game/standard/particles/Glitch.vue
+++ b/src/components/game/standard/particles/Glitch.vue
@@ -1,0 +1,240 @@
+<template>
+  <div
+    v-if="enabled"
+    class="glitch-container"
+    :class="{ 'glitch-surge': surging }"
+  >
+    <!-- RGB 通道错位层 -->
+    <div class="glitch-layer glitch-red"></div>
+    <div class="glitch-layer glitch-cyan"></div>
+    <!-- 扫描线 -->
+    <div class="glitch-scanlines"></div>
+    <!-- 随机切片抖动条 -->
+    <div
+      v-for="(s, i) in slices"
+      :key="i"
+      class="glitch-slice"
+      :style="s"
+    ></div>
+    <!-- 噪点闪屏 -->
+    <div
+      v-if="noiseOn"
+      class="glitch-noise"
+    ></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+const props = defineProps({
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+  intensity: {
+    type: Number,
+    default: 1,
+    validator: (value: number) => value >= 0 && value <= 2,
+  },
+})
+
+interface SliceStyle {
+  top: string
+  height: string
+  transform: string
+  opacity: number
+  background: string
+}
+
+const slices = ref<SliceStyle[]>([])
+const noiseOn = ref(false)
+// 周期性"大故障"：整帧扭曲 + 色相偏移
+const surging = ref(false)
+
+let sliceTimer = 0
+let noiseTimer = 0
+let surgeTimer = 0
+
+function reshuffleSlices() {
+  const count = Math.floor(4 + props.intensity * 4)
+  const next: SliceStyle[] = []
+  for (let i = 0; i < count; i++) {
+    const offset = (Math.random() - 0.5) * 120 * props.intensity
+    next.push({
+      top: `${Math.random() * 100}%`,
+      height: `${6 + Math.random() * 42}px`,
+      transform: `translateX(${offset}px)`,
+      opacity: 0.3 + Math.random() * 0.5,
+      background:
+        Math.random() > 0.5
+          ? 'rgba(255, 0, 60, 0.5)'
+          : 'rgba(0, 255, 220, 0.45)',
+    })
+  }
+  slices.value = next
+  sliceTimer = window.setTimeout(() => {
+    slices.value = []
+    sliceTimer = window.setTimeout(reshuffleSlices, 100 + Math.random() * 420)
+  }, 70 + Math.random() * 130)
+}
+
+function flashNoise() {
+  noiseOn.value = true
+  noiseTimer = window.setTimeout(() => {
+    noiseOn.value = false
+    noiseTimer = window.setTimeout(flashNoise, 180 + Math.random() * 800)
+  }, 60 + Math.random() * 90)
+}
+
+function surge() {
+  surging.value = true
+  surgeTimer = window.setTimeout(() => {
+    surging.value = false
+    surgeTimer = window.setTimeout(surge, 1500 + Math.random() * 4000)
+  }, 120 + Math.random() * 220)
+}
+
+onMounted(() => {
+  if (!props.enabled) return
+  reshuffleSlices()
+  flashNoise()
+  surge()
+})
+
+onBeforeUnmount(() => {
+  clearTimeout(sliceTimer)
+  clearTimeout(noiseTimer)
+  clearTimeout(surgeTimer)
+})
+</script>
+
+<style scoped>
+.glitch-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+/* 大故障期间整帧扭曲 + 色相偏移 */
+.glitch-surge {
+  animation: glitch-surge-anim 0.12s steps(2) infinite;
+  filter: hue-rotate(90deg) saturate(2);
+}
+
+@keyframes glitch-surge-anim {
+  0% {
+    transform: translateX(-8px) skewX(2deg);
+  }
+  50% {
+    transform: translateX(7px) skewX(-1.5deg);
+  }
+  100% {
+    transform: translateX(-3px);
+  }
+}
+
+.glitch-layer {
+  position: absolute;
+  inset: 0;
+  mix-blend-mode: screen;
+}
+
+.glitch-red {
+  background: rgba(255, 0, 60, 0.13);
+  animation: glitch-shift-a 0.9s steps(2) infinite;
+}
+
+.glitch-cyan {
+  background: rgba(0, 255, 220, 0.12);
+  animation: glitch-shift-b 1.1s steps(2) infinite;
+}
+
+@keyframes glitch-shift-a {
+  0% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-12px);
+  }
+  40% {
+    transform: translateX(6px);
+  }
+  60% {
+    transform: translateX(0);
+  }
+  85% {
+    transform: translateX(-6px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+@keyframes glitch-shift-b {
+  0% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(10px);
+  }
+  50% {
+    transform: translateX(-8px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+.glitch-scanlines {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent 2px,
+    rgba(0, 0, 0, 0.18) 3px,
+    transparent 4px
+  );
+  animation: scanline-move 8s linear infinite;
+}
+
+@keyframes scanline-move {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 0 100px;
+  }
+}
+
+.glitch-slice {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  mix-blend-mode: screen;
+}
+
+.glitch-noise {
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(rgba(255, 255, 255, 0.4) 1px, transparent 1px),
+    radial-gradient(rgba(0, 0, 0, 0.5) 1px, transparent 1px);
+  background-size:
+    3px 3px,
+    4px 4px;
+  background-position:
+    0 0,
+    1px 2px;
+  mix-blend-mode: overlay;
+  opacity: 0.65;
+}
+</style>

--- a/src/components/game/standard/particles/Invert.vue
+++ b/src/components/game/standard/particles/Invert.vue
@@ -1,0 +1,61 @@
+<template>
+  <!-- 反色闪屏：白色叠层 + difference 混合 = 画面反色，随机短促爆发 -->
+  <div
+    v-if="enabled && active"
+    class="invert-layer"
+  ></div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const props = defineProps({
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+  intensity: {
+    type: Number,
+    default: 1,
+    validator: (value: number) => value >= 0 && value <= 2,
+  },
+})
+
+const active = ref(false)
+let timer = 0
+
+function burst() {
+  if (!props.enabled) return
+  active.value = true
+  // 反色持续 80~220ms
+  timer = window.setTimeout(() => {
+    active.value = false
+    // 间隔随强度缩短：0.4s ~ 3s
+    const gap = (400 + Math.random() * 2600) / props.intensity
+    timer = window.setTimeout(burst, gap)
+  }, 80 + Math.random() * 140)
+}
+
+onMounted(burst)
+watch(
+  () => props.enabled,
+  (v) => {
+    if (v) burst()
+    else {
+      active.value = false
+      clearTimeout(timer)
+    }
+  },
+)
+onBeforeUnmount(() => clearTimeout(timer))
+</script>
+
+<style scoped>
+.invert-layer {
+  position: absolute;
+  inset: 0;
+  background: #fff;
+  mix-blend-mode: difference;
+  pointer-events: none;
+}
+</style>

--- a/src/components/game/standard/particles/Jumpscare.vue
+++ b/src/components/game/standard/particles/Jumpscare.vue
@@ -1,0 +1,123 @@
+<template>
+  <!-- 突脸惊吓：全屏黑底 + 图片急速放大冲入 + 高频抖动 + 自带音效 -->
+  <div
+    v-if="visible"
+    class="jumpscare-layer"
+  >
+    <div class="jumpscare-shake">
+      <img
+        class="jumpscare-img"
+        :src="imgSrc"
+        alt=""
+        draggable="false"
+      />
+    </div>
+    <audio ref="audioRef"></audio>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { convertFileSrc } from '@tauri-apps/api/core'
+import { useUIStore } from '../../../../stores/modules/ui/ui'
+
+const uiStore = useUIStore()
+
+const visible = ref(false)
+const audioRef = ref<HTMLAudioElement | null>(null)
+let hideTimer = 0
+
+const imgSrc = computed(() => {
+  const p = uiStore.jumpscareImage
+  if (!p) return ''
+  if (p.startsWith('http') || p.startsWith('data:') || p.startsWith('blob:')) return p
+  return convertFileSrc(p)
+})
+
+watch(
+  () => uiStore.jumpscareUntil,
+  (until) => {
+    clearTimeout(hideTimer)
+    if (!until || !uiStore.jumpscareImage) return
+
+    visible.value = true
+
+    // 音效：组件自管，避免与全局短效音效的"同路径不重播"冲突
+    if (uiStore.jumpscareSound && audioRef.value) {
+      audioRef.value.src = convertFileSrc(uiStore.jumpscareSound)
+      audioRef.value.volume = 1
+      audioRef.value.play().catch(() => {})
+    }
+
+    const remain = until - Date.now()
+    hideTimer = window.setTimeout(() => {
+      visible.value = false
+      if (audioRef.value) {
+        audioRef.value.pause()
+        audioRef.value.currentTime = 0
+      }
+      uiStore.clearJumpscare()
+    }, Math.max(150, remain))
+  },
+)
+
+onBeforeUnmount(() => {
+  clearTimeout(hideTimer)
+})
+</script>
+
+<style scoped>
+/* 脱离 GameBackground 的层叠上下文，压过对话框等所有 UI */
+.jumpscare-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 1000000;
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.jumpscare-shake {
+  animation: jumpscare-shake 0.07s linear infinite;
+}
+
+.jumpscare-img {
+  max-width: 100vw;
+  max-height: 100vh;
+  object-fit: contain;
+  animation: jumpscare-zoom 0.5s cubic-bezier(0.1, 1.4, 0.3, 1) both;
+  filter: contrast(1.15) saturate(1.2);
+}
+
+/* 急速放大冲入视野 */
+@keyframes jumpscare-zoom {
+  from {
+    transform: scale(0.55);
+    opacity: 0.4;
+  }
+  to {
+    transform: scale(1.12);
+    opacity: 1;
+  }
+}
+
+@keyframes jumpscare-shake {
+  0% {
+    transform: translate(0, 0);
+  }
+  25% {
+    transform: translate(-9px, 5px);
+  }
+  50% {
+    transform: translate(8px, -6px);
+  }
+  75% {
+    transform: translate(-5px, -8px);
+  }
+  100% {
+    transform: translate(6px, 7px);
+  }
+}
+</style>

--- a/src/components/game/standard/particles/Shake.vue
+++ b/src/components/game/standard/particles/Shake.vue
@@ -1,0 +1,105 @@
+<template>
+  <!--
+    震屏特效：本身只是全屏指针事件透明的占位层，
+    通过 watch 把震动动画类挂到游戏画面容器上，
+    卸载/关闭时负责还原，避免残留抖动。
+  -->
+  <div
+    v-show="false"
+    class="shake-anchor"
+    ref="anchorRef"
+  ></div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const props = defineProps({
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+  intensity: {
+    type: Number,
+    default: 1,
+    validator: (value: number) => value >= 0 && value <= 2,
+  },
+})
+
+const anchorRef = ref<HTMLElement | null>(null)
+const shakeTarget = ref<HTMLElement | null>(null)
+
+const SHAKE_CLASS = 'ling-shake-active'
+
+function findShakeTarget(anchor: HTMLElement | null): HTMLElement | null {
+  // 锚点的父级是粒子层，粒子层的父级即游戏画面容器；找不到就退回 body
+  const layer = anchor?.parentElement
+  const target = (layer?.parentElement as HTMLElement | null) ?? document.body
+  if (!layer?.parentElement) {
+    console.warn('[Shake] 未找到画面容器，退回 document.body')
+  }
+  return target
+}
+
+function applyShake() {
+  if (!shakeTarget.value) return
+  shakeTarget.value.style.setProperty('--shake-amplitude', `${8 * props.intensity}px`)
+  shakeTarget.value.classList.add(SHAKE_CLASS)
+}
+
+function removeShake() {
+  shakeTarget.value?.classList.remove(SHAKE_CLASS)
+  shakeTarget.value?.style.removeProperty('--shake-amplitude')
+}
+
+onMounted(() => {
+  shakeTarget.value = findShakeTarget(anchorRef.value)
+  if (props.enabled) applyShake()
+})
+
+watch(
+  () => props.enabled,
+  (val) => {
+    if (val) applyShake()
+    else removeShake()
+  },
+)
+
+watch(
+  () => props.intensity,
+  () => {
+    if (props.enabled) applyShake()
+  },
+)
+
+onBeforeUnmount(removeShake)
+</script>
+
+<style>
+/* 非 scoped：类挂在组件外的容器上 */
+.ling-shake-active {
+  animation: ling-shake 0.16s linear infinite;
+  will-change: transform;
+}
+
+@keyframes ling-shake {
+  0% {
+    transform: translate(0, 0);
+  }
+  20% {
+    transform: translate(var(--shake-amplitude, 8px), calc(var(--shake-amplitude, 8px) * -0.6));
+  }
+  40% {
+    transform: translate(calc(var(--shake-amplitude, 8px) * -0.8), var(--shake-amplitude, 8px));
+  }
+  60% {
+    transform: translate(var(--shake-amplitude, 8px), calc(var(--shake-amplitude, 8px) * 0.5));
+  }
+  80% {
+    transform: translate(calc(var(--shake-amplitude, 8px) * -0.5), calc(var(--shake-amplitude, 8px) * -1));
+  }
+  100% {
+    transform: translate(0, 0);
+  }
+}
+</style>

--- a/src/components/game/standard/particles/Static.vue
+++ b/src/components/game/standard/particles/Static.vue
@@ -1,0 +1,90 @@
+<template>
+  <!-- 电视雪花/矩形噪点：随机色块在网格上跳动（DDLC RectStatic 风格） -->
+  <canvas
+    v-if="enabled"
+    ref="canvasRef"
+    class="static-canvas"
+  />
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+const props = defineProps({
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+  intensity: {
+    type: Number,
+    default: 1,
+    validator: (value: number) => value >= 0 && value <= 2,
+  },
+})
+
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+let ctx: CanvasRenderingContext2D | null = null
+let animId = 0
+let lastFrame = 0
+
+const CELL = 32
+const PALETTE = ['#0a0a0a', '#1a1a1a', '#2d0a10', '#0a1a1a', '#3d0007', '#062a26', '#111']
+
+function draw(time: number) {
+  if (!ctx || !canvasRef.value) return
+  // 每 ~70ms 重排一次，太快会晃眼
+  if (time - lastFrame < 70) {
+    animId = requestAnimationFrame(draw)
+    return
+  }
+  lastFrame = time
+
+  const W = canvasRef.value.width
+  const H = canvasRef.value.height
+  ctx.clearRect(0, 0, W, H)
+
+  const cols = Math.ceil(W / CELL)
+  const rows = Math.ceil(H / CELL)
+  // 覆盖率随强度提升，基础约 6%
+  const chance = 0.06 * props.intensity
+  for (let x = 0; x < cols; x++) {
+    for (let y = 0; y < rows; y++) {
+      if (Math.random() < chance) {
+        ctx.fillStyle = PALETTE[(Math.random() * PALETTE.length) | 0]
+        ctx.fillRect(x * CELL, y * CELL, CELL, CELL)
+      }
+    }
+  }
+  animId = requestAnimationFrame(draw)
+}
+
+function resize() {
+  if (!canvasRef.value) return
+  canvasRef.value.width = window.innerWidth
+  canvasRef.value.height = window.innerHeight
+}
+
+onMounted(() => {
+  const c = canvasRef.value
+  if (!c) return
+  resize()
+  ctx = c.getContext('2d')
+  window.addEventListener('resize', resize)
+  animId = requestAnimationFrame(draw)
+})
+
+onBeforeUnmount(() => {
+  cancelAnimationFrame(animId)
+  window.removeEventListener('resize', resize)
+})
+</script>
+
+<style scoped>
+.static-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+</style>

--- a/src/components/game/standard/particles/Tear.vue
+++ b/src/components/game/standard/particles/Tear.vue
@@ -1,0 +1,111 @@
+<template>
+  <!-- 画面撕裂：把当前背景图切成若干水平长条，随机横向错位 -->
+  <div
+    v-if="enabled && bgUrl"
+    class="tear-container"
+  >
+    <div
+      v-for="(s, i) in slices"
+      :key="i"
+      class="tear-slice"
+      :style="s"
+    ></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { convertFileSrc } from '@tauri-apps/api/core'
+import { useUIStore } from '../../../../stores/modules/ui/ui'
+
+const props = defineProps({
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+  intensity: {
+    type: Number,
+    default: 1,
+    validator: (value: number) => value >= 0 && value <= 2,
+  },
+})
+
+const uiStore = useUIStore()
+
+const bgUrl = computed(() => {
+  const bg = uiStore.currentBackground
+  if (!bg) return ''
+  if (bg.startsWith('http') || bg.startsWith('data:') || bg.startsWith('@/')) return bg
+  return convertFileSrc(bg)
+})
+
+interface Slice {
+  top: string
+  height: string
+  backgroundImage: string
+  backgroundPosition: string
+  backgroundSize: string
+  transform: string
+  opacity: number
+}
+
+const SLICE_COUNT = 14
+const slices = ref<Slice[]>([])
+let timer = 0
+
+function buildSlices() {
+  const next: Slice[] = []
+  for (let i = 0; i < SLICE_COUNT; i++) {
+    const top = (i / SLICE_COUNT) * 100
+    const height = 100 / SLICE_COUNT
+    next.push({
+      top: `${top}%`,
+      height: `${height}%`,
+      backgroundImage: `url(${bgUrl.value})`,
+      backgroundPosition: `center ${(top / (100 - height)) * 100}%`,
+      backgroundSize: 'cover',
+      transform: 'translateX(0)',
+      opacity: 0.85,
+    })
+  }
+  slices.value = next
+}
+
+function jitter() {
+  // 每条切片按"开/关"节奏随机错位，还原 DDLC Tear 的抽动观感
+  for (const s of slices.value) {
+    if (Math.random() < 0.45) {
+      const offset = (Math.random() - 0.5) * 90 * props.intensity
+      s.transform = `translateX(${offset}px)`
+    } else {
+      s.transform = 'translateX(0)'
+    }
+  }
+  timer = window.setTimeout(jitter, 90 + Math.random() * 260)
+}
+
+onMounted(() => {
+  if (!props.enabled) return
+  buildSlices()
+  jitter()
+})
+
+onBeforeUnmount(() => clearTimeout(timer))
+</script>
+
+<style scoped>
+.tear-container {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.tear-slice {
+  position: absolute;
+  left: -5%;
+  width: 110%;
+  background-repeat: no-repeat;
+  will-change: transform;
+}
+</style>

--- a/src/components/game/standard/particles/UiBlood.vue
+++ b/src/components/game/standard/particles/UiBlood.vue
@@ -1,0 +1,54 @@
+<template>
+  <!-- 血红 UI：给 body 挂全局类，让界面文字变为血红色（剧本演出用，可随时关闭） -->
+  <div
+    v-show="false"
+    class="ui-blood-anchor"
+  ></div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, watch } from 'vue'
+
+const props = defineProps({
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+const CLASS = 'ling-ui-blood'
+
+function apply() {
+  if (props.enabled) document.body.classList.add(CLASS)
+  else document.body.classList.remove(CLASS)
+}
+
+onMounted(apply)
+watch(() => props.enabled, apply)
+onBeforeUnmount(() => document.body.classList.remove(CLASS))
+</script>
+
+<style>
+/* 非 scoped：作用于全局 UI。仅在 body.ling-ui-blood 下生效 */
+body.ling-ui-blood #app * {
+  color: #b8091a !important;
+  text-shadow:
+    0 0 8px rgba(184, 9, 26, 0.75),
+    1px 0 rgba(60, 0, 5, 0.6) !important;
+}
+
+/* 整体轻微搏动，像文字在渗血 */
+body.ling-ui-blood #app {
+  animation: ui-blood-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes ui-blood-pulse {
+  0%,
+  100% {
+    filter: brightness(1);
+  }
+  50% {
+    filter: brightness(0.82) saturate(1.4);
+  }
+}
+</style>

--- a/src/components/game/standard/particles/UiCorrupt.vue
+++ b/src/components/game/standard/particles/UiCorrupt.vue
@@ -1,0 +1,63 @@
+<template>
+  <!-- UI 崩坏：给 body 挂全局类，让对话框/按钮等 UI 文字出现 RGB 错位与抖动 -->
+  <div
+    v-show="false"
+    class="ui-corrupt-anchor"
+  ></div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, watch } from 'vue'
+
+const props = defineProps({
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+const CLASS = 'ling-ui-corrupt'
+
+function apply() {
+  if (props.enabled) document.body.classList.add(CLASS)
+  else document.body.classList.remove(CLASS)
+}
+
+onMounted(apply)
+watch(() => props.enabled, apply)
+onBeforeUnmount(() => document.body.classList.remove(CLASS))
+</script>
+
+<style>
+/* 非 scoped：作用于全局 UI。仅在 body.ling-ui-corrupt 下生效 */
+body.ling-ui-corrupt #app {
+  animation: ui-corrupt-jitter 0.9s steps(2) infinite;
+}
+
+/* 文字 RGB 错位（色散） */
+body.ling-ui-corrupt #app * {
+  text-shadow:
+    1.5px 0 rgba(255, 0, 60, 0.7),
+    -1.5px 0 rgba(0, 255, 220, 0.7) !important;
+}
+
+@keyframes ui-corrupt-jitter {
+  0%,
+  88%,
+  100% {
+    transform: translate(0, 0);
+    filter: none;
+  }
+  90% {
+    transform: translate(-3px, 1px);
+    filter: hue-rotate(40deg);
+  }
+  94% {
+    transform: translate(3px, -2px);
+    filter: hue-rotate(-30deg) saturate(1.6);
+  }
+  97% {
+    transform: translate(-1px, 2px);
+  }
+}
+</style>

--- a/src/components/game/standard/particles/Veins.vue
+++ b/src/components/game/standard/particles/Veins.vue
@@ -1,0 +1,81 @@
+<template>
+  <!-- 黑暗侵蚀：四角暗角像血管一样搏动收拢，画面边缘轻微抖动 -->
+  <div
+    v-if="enabled"
+    class="veins-layer"
+    :style="{ '--vein-strength': 0.55 + intensity * 0.25 }"
+  ></div>
+</template>
+
+<script setup lang="ts">
+defineProps({
+  enabled: {
+    type: Boolean,
+    default: true,
+  },
+  intensity: {
+    type: Number,
+    default: 1,
+    validator: (value: number) => value >= 0 && value <= 2,
+  },
+})
+</script>
+
+<style scoped>
+.veins-layer {
+  position: absolute;
+  inset: -3%;
+  pointer-events: none;
+  background: radial-gradient(
+    ellipse at center,
+    transparent 28%,
+    rgba(10, 0, 2, calc(var(--vein-strength, 0.8) * 0.55)) 62%,
+    rgba(5, 0, 1, var(--vein-strength, 0.8)) 100%
+  );
+  animation:
+    veins-pulse 2.6s ease-in-out infinite,
+    veins-drift 7s ease-in-out infinite;
+}
+
+/* 搏动：暗角周期性收紧，模拟心跳 */
+@keyframes veins-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.85;
+  }
+  12% {
+    transform: scale(1.04);
+    opacity: 1;
+  }
+  24% {
+    transform: scale(0.99);
+    opacity: 0.8;
+  }
+  36% {
+    transform: scale(1.02);
+    opacity: 0.95;
+  }
+  55% {
+    transform: scale(1);
+    opacity: 0.85;
+  }
+}
+
+/* 漂移：整体轻微游走，避免死板 */
+@keyframes veins-drift {
+  0%,
+  100% {
+    translate: 0 0;
+  }
+  25% {
+    translate: 1.2% 0.8%;
+  }
+  50% {
+    translate: -0.8% 1.2%;
+  }
+  75% {
+    translate: 0.6% -1%;
+  }
+}
+</style>

--- a/src/components/settings/pages/SettingsAdventure.vue
+++ b/src/components/settings/pages/SettingsAdventure.vue
@@ -298,9 +298,12 @@ import { getAvatarFile } from '@/api/services/character'
 import { Birdhouse, Book, FileText, UserPlus } from 'lucide-vue-next'
 import { getStandaloneScriptList, startScript as startScriptApi } from '@/api/services/script-info'
 import type { ScriptSummary } from '@/api/services/script-info'
+import { useDialogStore } from '@/stores/modules/ui/dialog'
+import { i18n } from '@/locales'
 
 const gameStore = useGameStore()
 const uiStore = useUIStore()
+const dialogStore = useDialogStore()
 const router = useRouter()
 // 独立剧本相关状态
 const standaloneScripts = ref<ScriptSummary[]>([])
@@ -337,6 +340,18 @@ const goToCharacterTab = () => {
 
 // 开始游玩独立剧本
 const startStandaloneScript = async (script: ScriptSummary) => {
+  // 带内容警告的剧本（如恐怖向）先弹确认，取消则不启动
+  if (script.content_warning === 'horror') {
+    const confirmed = await dialogStore.confirm(
+      i18n.global.t('views.contentWarning.horrorMessage'),
+      i18n.global.t('views.contentWarning.horrorTitle'),
+    )
+    if (!confirmed) return
+
+    // 确认后先"卡死 → 花屏"再启动（恐怖演出的一部分）
+    await uiStore.beginHorrorEntry()
+  }
+
   try {
     await startScriptApi(script.script_name)
     // 可选：关闭设置面板，开始剧本

--- a/src/components/ui/HorrorEntryTransition.vue
+++ b/src/components/ui/HorrorEntryTransition.vue
@@ -1,0 +1,153 @@
+<template>
+  <!-- 恐怖剧本入口过渡：确认警告后"卡死 → 花屏"，然后才真正进入游戏 -->
+  <Teleport to="body">
+    <div
+      v-if="uiStore.horrorEntryPhase !== ''"
+      class="horror-entry-overlay"
+      :class="`phase-${uiStore.horrorEntryPhase}`"
+    >
+      <!-- 花屏阶段：满屏噪点 + 反色 + RGB 错位 -->
+      <canvas
+        v-if="uiStore.horrorEntryPhase === 'static'"
+        ref="canvasRef"
+        class="static-canvas"
+      ></canvas>
+      <div
+        v-if="uiStore.horrorEntryPhase === 'static'"
+        class="invert-flash"
+      ></div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { useUIStore } from '../../stores/modules/ui/ui'
+
+const uiStore = useUIStore()
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+let rafId = 0
+let audioCtx: AudioContext | null = null
+
+function drawStatic() {
+  const c = canvasRef.value
+  if (!c) return
+  c.width = window.innerWidth
+  c.height = window.innerHeight
+  const ctx = c.getContext('2d')
+  if (!ctx) return
+
+  const image = ctx.createImageData(c.width, c.height)
+  const buf = new Uint32Array(image.data.buffer)
+  let frame = 0
+
+  const paint = () => {
+    // 噪点：黑/白/暗红/青随机像素，每帧全量重填
+    for (let i = 0; i < buf.length; i++) {
+      const r = Math.random()
+      buf[i] =
+        r < 0.72
+          ? 0xff000000 // 黑
+          : r < 0.88
+            ? 0xffffffff // 白
+            : r < 0.96
+              ? 0xff1010b8 // 暗红（BGR 序）
+              : 0xffb8b000 // 青
+    }
+    ctx.putImageData(image, 0, 0)
+    frame++
+    rafId = requestAnimationFrame(paint)
+  }
+  paint()
+}
+
+/** WebAudio 合成一记短促的故障爆音（无需音频素材） */
+function playGlitchBurst() {
+  try {
+    audioCtx = audioCtx || new AudioContext()
+    const dur = 0.35
+    const buf = audioCtx.createBuffer(1, audioCtx.sampleRate * dur, audioCtx.sampleRate)
+    const data = buf.getChannelData(0)
+    for (let i = 0; i < data.length; i++) {
+      const t = i / data.length
+      data[i] = (Math.random() * 2 - 1) * (1 - t) * 0.5
+    }
+    const src = audioCtx.createBufferSource()
+    src.buffer = buf
+    const gain = audioCtx.createGain()
+    gain.gain.value = 0.7
+    src.connect(gain).connect(audioCtx.destination)
+    src.start()
+  } catch {
+    // 浏览器自动播放策略拦截时静默跳过
+  }
+}
+
+watch(
+  () => uiStore.horrorEntryPhase,
+  async (phase) => {
+    cancelAnimationFrame(rafId)
+    if (phase === 'static') {
+      // RGB 错位施加到整个 UI
+      document.body.classList.add('ling-ui-corrupt')
+      playGlitchBurst()
+      await nextTick()
+      drawStatic()
+    } else {
+      document.body.classList.remove('ling-ui-corrupt')
+    }
+  },
+)
+
+onBeforeUnmount(() => {
+  cancelAnimationFrame(rafId)
+  document.body.classList.remove('ling-ui-corrupt')
+  audioCtx?.close().catch(() => {})
+})
+</script>
+
+<style scoped>
+.horror-entry-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000000;
+}
+
+/* 卡死阶段：透明但吞掉所有输入，光标变成等待——画面看起来完全没响应 */
+.phase-freeze {
+  cursor: wait;
+  background: transparent;
+}
+
+.phase-static {
+  background: #000;
+}
+
+.static-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* 反色一闪 */
+.invert-flash {
+  position: absolute;
+  inset: 0;
+  background: #fff;
+  mix-blend-mode: difference;
+  animation: invert-blink 0.55s steps(2) both;
+}
+
+@keyframes invert-blink {
+  0%,
+  40% {
+    opacity: 1;
+  }
+  20%,
+  60%,
+  100% {
+    opacity: 0;
+  }
+}
+</style>

--- a/src/components/views/menu/page/GameModeOptions.vue
+++ b/src/components/views/menu/page/GameModeOptions.vue
@@ -5,7 +5,7 @@
     </StartLine>
 
     <StartLine>
-      <StartItem disabled="true">{{ $t('views.menu.storyMode') }}</StartItem>
+      <StartItem @click="startStoryMode">{{ $t('views.menu.storyMode') }}</StartItem>
     </StartLine>
 
     <StartLine>
@@ -34,5 +34,10 @@ const gameStore = useGameStore()
 const startFreeDialogue = () => {
   gameStore.exitStoryMode()
   router.push('/chat')
+}
+
+// 进入剧情模式：切到剧本列表页
+const startStoryMode = () => {
+  emit('open-scripts')
 }
 </script>

--- a/src/components/views/menu/page/ScriptModeOptions.vue
+++ b/src/components/views/menu/page/ScriptModeOptions.vue
@@ -50,6 +50,9 @@ import { StartItem, StartLine, StartList } from '../base'
 import { useRouter } from 'vue-router'
 import { type ScriptSummary, startScript } from '@/api/services/script-info'
 import { useGameStore } from '@/stores/modules/game'
+import { useDialogStore } from '@/stores/modules/ui/dialog'
+import { useUIStore } from '@/stores/modules/ui/ui'
+import { i18n } from '@/locales'
 
 const emit = defineEmits<{
   (e: 'back'): void
@@ -64,11 +67,25 @@ const props = defineProps({
 
 const router = useRouter()
 const gameStore = useGameStore()
+const dialogStore = useDialogStore()
+const uiStore = useUIStore()
 
 const currentPage = ref(1)
 const pageSize = 3
 
 const selectScript = async (script: ScriptSummary) => {
+  // 带内容警告的剧本（如恐怖向）先弹确认，取消则不进入
+  if (script.content_warning === 'horror') {
+    const confirmed = await dialogStore.confirm(
+      i18n.global.t('views.contentWarning.horrorMessage'),
+      i18n.global.t('views.contentWarning.horrorTitle'),
+    )
+    if (!confirmed) return
+
+    // 确认后先"卡死 → 花屏"再进入（恐怖演出的一部分）
+    await uiStore.beginHorrorEntry()
+  }
+
   await router.push('/chat')
 
   gameStore.enterStoryMode(script.script_name)

--- a/src/controllers/emotion/config.ts
+++ b/src/controllers/emotion/config.ts
@@ -34,6 +34,8 @@ export const EMOTION_CONFIG_EMO: EmotionMap = {
   惊讶: '惊讶',
   正常: '正常',
   平静: '平静',
+  // 剧本演出专用情绪（恐怖剧本的崩坏立绘等）；角色目录缺对应文件时回退"正常"
+  崩坏: '崩坏',
 }
 
 export const EMOTION_CONFIG: EmotionConfigMap = {

--- a/src/core/events/processors/force-choice-processor.ts
+++ b/src/core/events/processors/force-choice-processor.ts
@@ -1,0 +1,19 @@
+import type { IEventProcessor } from '../event-processor'
+import type { ScriptForceChoiceEvent } from '../../../types'
+import { useGameStore } from '../../../stores/modules/game'
+
+export default class ForceChoiceProcessor implements IEventProcessor {
+  canHandle(eventType: string): boolean {
+    return eventType === 'force_choice'
+  }
+
+  async processEvent(event: ScriptForceChoiceEvent): Promise<void> {
+    const gameStore = useGameStore()
+
+    gameStore.forceChoice = {
+      choices: event.choices,
+      forced: event.forced,
+    }
+    gameStore.currentStatus = 'input'
+  }
+}

--- a/src/core/events/processors/jumpscare-processor.ts
+++ b/src/core/events/processors/jumpscare-processor.ts
@@ -1,0 +1,21 @@
+import type { IEventProcessor } from '../event-processor'
+import type { ScriptJumpscareEvent } from '../../../types'
+import { useGameStore } from '../../../stores/modules/game'
+import { useUIStore } from '../../../stores/modules/ui/ui'
+
+export default class JumpscareProcessor implements IEventProcessor {
+  canHandle(eventType: string): boolean {
+    return eventType === 'jumpscare'
+  }
+
+  async processEvent(event: ScriptJumpscareEvent): Promise<void> {
+    const gameStore = useGameStore()
+    const uiStore = useUIStore()
+
+    gameStore.currentStatus = 'presenting'
+
+    if (!event.imagePath) return
+    // duration 缺省 0.6s：足够看清，又短到来不及躲开
+    uiStore.triggerJumpscare(event.imagePath, event.soundPath || '', event.duration ?? 0.6)
+  }
+}

--- a/src/core/events/processors/script-end-processor.ts
+++ b/src/core/events/processors/script-end-processor.ts
@@ -27,5 +27,7 @@ export default class ScriptEndProcessor implements IEventProcessor {
     gameStore.exitStoryMode()
     const uiStore = useUIStore()
     uiStore.showPlayerHintLine = ''
+    // 恐怖特效/突脸不得带出剧本外
+    uiStore.resetHorrorEffects()
   }
 }

--- a/src/locales/en/views.ts
+++ b/src/locales/en/views.ts
@@ -59,6 +59,11 @@ export default {
     miniGame: "Mini Games (In Development)",
     back: "Back",
   },
+  contentWarning: {
+    horrorTitle: "⚠ Content Warning",
+    horrorMessage:
+      "This story contains horror, jumpscares and disturbing content. Recommended for players aged 16 and above.\nIf you feel unwell while playing, please quit immediately.\n\nAre you sure you want to continue?",
+  },
   pet: {
     chatInput: {
       placeholder: "Type a message...",

--- a/src/locales/ja/views.ts
+++ b/src/locales/ja/views.ts
@@ -58,6 +58,11 @@ export default {
     miniGame: 'ミニゲーム（開発中）',
     back: '戻る',
   },
+  contentWarning: {
+    horrorTitle: '⚠ コンテンツ警告',
+    horrorMessage:
+      'このシナリオにはホラー・驚かせる演出・精神的に不快な内容が含まれます。16歳以上のプレイヤーに推奨されます。\nプレイ中に気分が悪くなった場合は、すぐに終了してください。\n\n本当に続けますか？',
+  },
   pet: {
     chatInput: {
       placeholder: 'メッセージを入力...',

--- a/src/locales/zh-CN/views.ts
+++ b/src/locales/zh-CN/views.ts
@@ -52,11 +52,16 @@ export default {
     credits: '致谢名单',
     exitGame: '退出游戏',
     freeDialogue: '自由对话模式',
-    storyMode: '剧情模式（在自由模式进入）',
+    storyMode: '剧情模式',
     scriptEditor: '创意工坊',
     cloudWorkshop: '云·创意工坊',
     miniGame: '小游戏（开发中）',
     back: '返回',
+  },
+  contentWarning: {
+    horrorTitle: '⚠ 内容警告',
+    horrorMessage:
+      '本剧本包含恐怖、惊吓与心理不适元素，建议 16 岁及以上玩家游玩。\n如在游玩过程中感到不适，请立即退出。\n\n确定要继续吗？',
   },
   pet: {
     chatInput: {

--- a/src/locales/zh-HK/views.ts
+++ b/src/locales/zh-HK/views.ts
@@ -59,6 +59,10 @@ export default {
     "miniGame": "小遊戲（開發緊）",
     "back": "返回"
   },
+  "contentWarning": {
+    "horrorTitle": "⚠ 內容警告",
+    "horrorMessage": "本劇本包含恐怖、驚嚇同心理不適元素，建議 16 歲或以上玩家遊玩。\n如果遊玩期間感到不適，請立即退出。\n\n確定要繼續嗎？"
+  },
   "pet": {
     "chatInput": {
       "placeholder": "輸入訊息...",

--- a/src/stores/modules/game/actions.ts
+++ b/src/stores/modules/game/actions.ts
@@ -85,11 +85,14 @@ setGameMessages(this: GameState, messages: GameMessage[]) {
     }
     const uiStore = useUIStore()
     uiStore.bgMusicMode = 'loop-single'
+    // 进入新剧本前清掉可能残留的恐怖特效（上次异常退出/重启等情况）
+    uiStore.resetHorrorEffects()
   },
 
   /** 标记退出剧情模式，回到自由对话模式 */
   exitStoryMode(this: GameState) {
     this.runningScript = null
+    this.forceChoice = null
   },
 
   // 设置当前场景（仅更新 store，不调用 API）

--- a/src/stores/modules/game/state.ts
+++ b/src/stores/modules/game/state.ts
@@ -60,6 +60,8 @@ export interface GameRole {
 
 export interface GameState {
   runningScript: ScriptInfo | null
+  /** 强制选择演出（DDLC 式鼠标拖拽）；非 null 时 ForceChoice 组件接管选择 */
+  forceChoice: { choices: ScriptChoiceItem[]; forced: string } | null
 
   gameRoles: Record<number, GameRole>
   presentRoleIds: number[]
@@ -85,6 +87,7 @@ export interface GameState {
 
 export const state: GameState = {
   runningScript: null,
+  forceChoice: null,
 
   gameRoles: {},
   presentRoleIds: [],

--- a/src/stores/modules/ui/ui.ts
+++ b/src/stores/modules/ui/ui.ts
@@ -51,6 +51,16 @@ interface UIState {
   currentAvatarAudio: string
   autoMode: boolean
 
+  /** 突脸惊吓：图片路径（空串 = 无演出） */
+  jumpscareImage: string
+  /** 突脸音效路径（由 Jumpscare 组件自行播放） */
+  jumpscareSound: string
+  /** 突脸收场时间戳（ms, Date.now() 基准），到点组件自行隐藏 */
+  jumpscareUntil: number
+
+  /** 恐怖剧本入口过渡阶段：'' 无 / 'freeze' 卡死 / 'static' 花屏 */
+  horrorEntryPhase: '' | 'freeze' | 'static'
+
   // 环境音轨道列表（多轨并行，最多8轨）
   ambientTracks: Array<{
     id: string         // 唯一标识（基于时间戳+随机数）
@@ -119,6 +129,13 @@ export const useUIStore = defineStore('ui', {
     currentSoundEffect: 'None',
     currentAvatarAudio: 'None',
     autoMode: false,
+
+    // 突脸惊吓演出初始状态
+    jumpscareImage: '',
+    jumpscareSound: '',
+    jumpscareUntil: 0,
+
+    horrorEntryPhase: '',
 
     // 环境音轨道列表初始值
     ambientTracks: [],
@@ -207,6 +224,59 @@ export const useUIStore = defineStore('ui', {
     // 设置背景效果（写入 settings store）
     setBackgroundEffect(effect: string) {
       useSettingsStore().setBackgroundEffect(effect)
+    },
+    /** 触发突脸惊吓：图片全屏闪现 durationSec 秒，自带音效 */
+    triggerJumpscare(image: string, sound: string, durationSec: number) {
+      this.jumpscareImage = image
+      this.jumpscareSound = sound
+      this.jumpscareUntil = Date.now() + Math.max(0.15, durationSec) * 1000
+    },
+    /** 立即收场（组件卸载或剧本结束时兜底调用） */
+    clearJumpscare() {
+      this.jumpscareImage = ''
+      this.jumpscareSound = ''
+      this.jumpscareUntil = 0
+    },
+    /**
+     * 恐怖特效残留清理：当前特效包含恐怖向名称时重置为 'None'。
+     * 剧本异常退出/中途返回/重启后都可能残留，在剧本结束、进入剧本、应用启动时调用。
+     */
+    resetHorrorEffects() {
+      const HORROR = [
+        'Glitch',
+        'Shake',
+        'Flash',
+        'Blackout',
+        'Tear',
+        'Static',
+        'Invert',
+        'BloodDrip',
+        'Veins',
+        'BSOD',
+        'UiCorrupt',
+        'BloodUI',
+      ]
+      const current = useSettingsStore().display.backgroundEffect
+      if (HORROR.some((h) => current.includes(h))) {
+        useSettingsStore().setBackgroundEffect('None')
+      }
+      this.clearJumpscare()
+    },
+    /**
+     * 恐怖剧本入口过渡：卡死 1.1s → 花屏 0.8s，结束后 resolve。
+     * 调用方 await 它再执行真正的进入逻辑。
+     */
+    beginHorrorEntry(): Promise<void> {
+      return new Promise((resolve) => {
+        this.horrorEntryPhase = 'freeze'
+        setTimeout(() => {
+          this.horrorEntryPhase = 'static'
+        }, 1100)
+        setTimeout(() => {
+          this.horrorEntryPhase = ''
+          resolve()
+        }, 1900)
+      })
     },
     // 设置对话音效开关（写入 settings store）
     setEnableChatEffectSound(enabled: boolean) {
@@ -586,6 +656,9 @@ export function initUIStore() {
   initialized = true
 
   const store = useUIStore()
+
+  // 启动时清掉上次会话残留的恐怖特效（设置是持久化的，血色 UI 不能带进新会话）
+  store.resetHorrorEffects()
 
   // 从 CSS 变量同步安全区值（由 Android 原生 / iOS env() 注入）
   function syncSafeArea() {

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -127,6 +127,20 @@ export interface ScriptEndEvent extends ScriptEvent {
   completed?: boolean
 }
 
+/** 突脸惊吓事件：全屏图片闪现 + 音效 */
+export interface ScriptJumpscareEvent extends ScriptEvent {
+  type: 'jumpscare'
+  imagePath: string
+  soundPath?: string
+}
+
+/** 强制选择事件：鼠标被拖向 forced 选项，最终只能提交它 */
+export interface ScriptForceChoiceEvent extends ScriptEvent {
+  type: 'force_choice'
+  choices: ScriptChoiceItem[]
+  forced: string
+}
+
 export interface ScriptErrorEvent extends ScriptEvent {
   type: 'error'
   error_code?: string
@@ -157,3 +171,5 @@ export type ScriptEventType =
   | ScriptChoiceEvent
   | ScriptPresentPicEvent
   | ScriptFreeDialogueEvent
+  | ScriptJumpscareEvent
+  | ScriptForceChoiceEvent


### PR DESCRIPTION
## 概述

为剧本系统加入一套 DDLC 风格的恐怖/崩坏表现能力：新的画面特效、两个新剧本事件、内容警告确认流程，以及剧本对编辑器隐藏的能力。所有能力均为通用引擎特性，由剧本 YAML 声明式触发。

## 后端（Rust）

- `background_effect` 事件扩充至 17 种特效：原有 5 种氛围类之外，新增 12 种 Glitch / Shake / Flash / Blackout / Tear / Static / Invert / BloodDrip / Veins / BSOD / UiCorrupt / BloodUI，并支持用 `+` 组合叠加（如 `glitch+shake`）；`KNOWN_EFFECTS` 集中在 `background_effect_event.rs`，schema 与测试断言自动跟随
- 新事件 `script:jumpscare`：全屏突脸图片 + 音效 + 震屏
- 新事件 `script:force-choice`：DDLC 同款强制选择，通过新增 `warp_cursor` Tauri 命令插值拖动真实鼠标指针，把光标强行拉向指定选项
- `story_config.yaml` 新字段：
  - `content_warning`（如 `horror`）：经 `ScriptStatus`/`ScriptSummary` 透传给前端，进入剧本前弹确认框
  - `editor_hidden`：剧本在剧本编辑器列表中隐藏、`editor_read_script` 直接拒绝，防止被编辑器改动

## 前端（Vue）

- 新增 `HorrorEffectsLayer`：恐怖特效统一挂载层，层级压过角色立绘；`particles/` 下 14 个特效组件
- 新增 `ForceChoice` 组件：选项吸附动画配合 `warp_cursor`
- 新增 `HorrorEntryTransition`：确认内容警告后「画面卡死 → 花屏」再进入游戏
- `ScriptModeOptions` / `SettingsAdventure` 双入口接入内容警告确认
- 情绪配置加入崩坏立绘回退：素材缺失时回退「正常」，避免黑图
- 兜底清理：剧本结束 / 进入剧情模式 / store 初始化三处重置恐怖 UI 状态，防止血红 UI 等效果泄漏到主界面
- 四语言（zh-CN/zh-HK/ja/en）文案补齐

## 文档

- 更新 `data/game_data/skills/lingchat-script-editor/references/event-reference.md`，登记新特效与新事件

## 说明

- 演示用剧本与素材不包含在本 PR 中（`data/game_data/scripts/standalone/**` 本就被 gitignore；部分音效素材有版权限制，不进仓库）
- 本机 `cargo test` 因 0xc0000139（DLL 问题）无法运行，已用 `pnpm build`（vue-tsc）+ `cargo check` 验证编译通过
