### PR TITLE
fix: 修复存读档退出剧本状态的问题

### DIFF
--- a/src-tauri/src/ai_service/game_system/auto_save.rs
+++ b/src-tauri/src/ai_service/game_system/auto_save.rs
@@ -150,28 +150,44 @@ impl AutoSaveManager {
             .map_err(|e| format!("保存记忆库失败: {}", e))?;
 
         // 4e. Persist script state (if running)
-        if let Some(ref script_status) = service.game_status.lock().await.script_status {
-            let vars_json = serde_json::to_string(&script_status.vars).unwrap_or_default();
-            let _ = SaveRepo::upsert_running_script(
-                &self.db,
-                save_id,
-                &script_status.folder_key,
-                &vars_json,
-                &script_status.current_chapter_key,
-                script_status.current_event_process,
-            )
-            .await
-            .map_err(|e| {
-                tracing::warn!("[AutoSave] 保存剧本状态失败: {}", e);
-            });
-        } else {
-            // 无剧本进行中：清理该槽位残留的剧本状态。
-            // 否则新会话启动时（line_list 仅剩启动残留）会把对话覆盖成空，
-            // 而旧的事件序号残留在 running_script 里 → 产生"空对话 + 深位置"的损坏存档。
-            if let Ok(Some(save_model)) = SaveRepo::get_save_by_id(&self.db, save_id).await {
-                if let Some(rs_id) = save_model.running_script_id {
-                    let _ = SaveRepo::delete_running_script(&self.db, rs_id).await;
-                    let _ = SaveRepo::update_save_running_script(&self.db, save_id, None).await;
+        {
+            let gs = service.game_status.lock().await;
+            if let Some(ref script_status) = gs.script_status {
+                let vars_json = serde_json::to_string(&script_status.vars).unwrap_or_default();
+                // 玩家阅读位置（前端上报）：与引擎位置并存，读档优先据此恢复
+                let player_read_chapter = if gs.player_read_chapter.is_empty() {
+                    None
+                } else {
+                    Some(gs.player_read_chapter.clone())
+                };
+                let player_read_sequence = if gs.player_read_seq > 0 {
+                    Some(gs.player_read_seq)
+                } else {
+                    None
+                };
+                let _ = SaveRepo::upsert_running_script(
+                    &self.db,
+                    save_id,
+                    &script_status.folder_key,
+                    &vars_json,
+                    &script_status.current_chapter_key,
+                    script_status.current_event_process,
+                    player_read_chapter,
+                    player_read_sequence,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::warn!("[AutoSave] 保存剧本状态失败: {}", e);
+                });
+            } else {
+                // 无剧本进行中：清理该槽位残留的剧本状态。
+                // 否则新会话启动时（line_list 仅剩启动残留）会把对话覆盖成空，
+                // 而旧的事件序号残留在 running_script 里 → 产生"空对话 + 深位置"的损坏存档。
+                if let Ok(Some(save_model)) = SaveRepo::get_save_by_id(&self.db, save_id).await {
+                    if let Some(rs_id) = save_model.running_script_id {
+                        let _ = SaveRepo::delete_running_script(&self.db, rs_id).await;
+                        let _ = SaveRepo::update_save_running_script(&self.db, save_id, None).await;
+                    }
                 }
             }
         }

--- a/src-tauri/src/ai_service/game_system/auto_save.rs
+++ b/src-tauri/src/ai_service/game_system/auto_save.rs
@@ -164,6 +164,16 @@ impl AutoSaveManager {
             .map_err(|e| {
                 tracing::warn!("[AutoSave] 保存剧本状态失败: {}", e);
             });
+        } else {
+            // 无剧本进行中：清理该槽位残留的剧本状态。
+            // 否则新会话启动时（line_list 仅剩启动残留）会把对话覆盖成空，
+            // 而旧的事件序号残留在 running_script 里 → 产生"空对话 + 深位置"的损坏存档。
+            if let Ok(Some(save_model)) = SaveRepo::get_save_by_id(&self.db, save_id).await {
+                if let Some(rs_id) = save_model.running_script_id {
+                    let _ = SaveRepo::delete_running_script(&self.db, rs_id).await;
+                    let _ = SaveRepo::update_save_running_script(&self.db, save_id, None).await;
+                }
+            }
         }
 
         drop(service);
@@ -204,9 +214,11 @@ impl AutoSaveManager {
         let service = self.ai_service.lock().await;
         let lines = &service.game_status.lock().await.line_list;
 
-        // 初始化时 line_list 自带一条 system 台词（角色人设），
-        // 只有大于 1 条时才说明有实际对话发生，才需要自动存档。
-        if lines.len() <= 1 {
+        // 初始化时 line_list 自带 system 人设 + 可能的换装旁白（共 1~2 行），
+        // 这属于"启动残留"，不是实际会话内容——此时自动存档会把存档槽覆盖成空，
+        // 而残留的剧本事件序号却保留下来，产生"空对话 + 深位置"的损坏存档。
+        // 只有 >2 行时才说明有实际对话/剧本内容，才需要自动存档。
+        if lines.len() <= 2 {
             return None;
         }
 

--- a/src-tauri/src/ai_service/game_system/game_status.rs
+++ b/src-tauri/src/ai_service/game_system/game_status.rs
@@ -200,7 +200,9 @@ impl GameStatus {
             LineBase {
                 content: PromptRole::Narrator.build_prompt(&prompt),
                 attribute: LineAttributeExt(LineAttribute::User),
-                display_name: Some("旁白".to_string()),
+                // 「系统旁白」标记：换装/入场等系统注入的旁白，不进对话历史
+                // （前端按 display_name 过滤），但保留在 line_list 供 LLM 上下文。
+                display_name: Some("系统旁白".to_string()),
                 ..Default::default()
             },
         )

--- a/src-tauri/src/ai_service/game_system/game_status.rs
+++ b/src-tauri/src/ai_service/game_system/game_status.rs
@@ -46,6 +46,11 @@ pub struct GameStatus {
 
     pub script_status: Option<ScriptStatus>,
 
+    /// 剧本状态纪元：每次读档恢复剧本/启动剧本运行都会递增。
+    /// `on_script_end` 只清理与当前纪元一致的 `script_status`，
+    /// 防止「旧剧本任务的收尾」误清「读档新恢复的剧本状态」。
+    pub script_epoch: u64,
+
     /// 当前激活的存档 ID（用于 MemoryBank 持久化/载入/自动压缩）
     pub active_save_id: Option<i32>,
 
@@ -84,6 +89,7 @@ impl GameStatus {
             completed_scripts: HashSet::new(),
             last_dialog_time: None,
             script_status: None,
+            script_epoch: 0,
             active_save_id: None,
             preview_generation: 0,
             player_entered: false,

--- a/src-tauri/src/ai_service/game_system/game_status.rs
+++ b/src-tauri/src/ai_service/game_system/game_status.rs
@@ -51,6 +51,13 @@ pub struct GameStatus {
     /// 防止「旧剧本任务的收尾」误清「读档新恢复的剧本状态」。
     pub script_epoch: u64,
 
+    /// 玩家阅读位置——章节 key（前端经 update_player_read_position 上报，瞬态不落快照）。
+    /// 存档时写入 running_script，读档据此从玩家实际阅读点续跑（而非引擎执行位置）。
+    pub player_read_chapter: String,
+
+    /// 玩家阅读位置——事件序号（前端上报，瞬态不落快照）。
+    pub player_read_seq: i32,
+
     /// 当前激活的存档 ID（用于 MemoryBank 持久化/载入/自动压缩）
     pub active_save_id: Option<i32>,
 
@@ -90,6 +97,8 @@ impl GameStatus {
             last_dialog_time: None,
             script_status: None,
             script_epoch: 0,
+            player_read_chapter: String::new(),
+            player_read_seq: 0,
             active_save_id: None,
             preview_generation: 0,
             player_entered: false,

--- a/src-tauri/src/ai_service/game_system/memory_builder.rs
+++ b/src-tauri/src/ai_service/game_system/memory_builder.rs
@@ -127,7 +127,7 @@ impl MemoryBuilder {
                             .map(|l| {
                                 let name = l.base.display_name.as_deref().unwrap_or("未知");
                                 let s = match name {
-                                    "旁白" | "系统" => l.base.content.clone(),
+                                    "旁白" | "系统" | "系统旁白" => l.base.content.clone(),
                                     _ => format!("{}: {}", name, l.base.content),
                                 };
                                 s

--- a/src-tauri/src/ai_service/game_system/script_engine/chapter.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/chapter.rs
@@ -25,7 +25,7 @@ pub struct Chapter {
 
 impl Chapter {
     /// Construct a `Chapter` from a chapter config dict and script status.
-    pub fn new(chapter_id: String, chapter_config: Value, _script_status: &ScriptStatus) -> Self {
+    pub fn new(chapter_id: String, chapter_config: Value, script_status: &ScriptStatus) -> Self {
         let chapter_name = chapter_config
             .get("name")
             .and_then(|v| v.as_str())
@@ -38,10 +38,19 @@ impl Chapter {
             .cloned()
             .unwrap_or_default();
 
+        // 读档续跑恢复：若当前章节与存档记录章节一致，则从存档事件序号继续执行。
+        // 旧存档事件序号为 0（或已越界），分别回退为从章节开头重放 / 钳制到最后一个事件，
+        // 保证 `chapter_end` 仍会执行、故事能继续。
+        let resume_progress = if script_status.current_chapter_key == chapter_id {
+            script_status.current_event_process.max(0) as usize
+        } else {
+            0
+        };
+
         Self {
             _chapter_id: chapter_id,
             chapter_name,
-            events_handler: EventsHandler::new(event_list),
+            events_handler: EventsHandler::with_progress(event_list, resume_progress),
         }
     }
 
@@ -55,13 +64,19 @@ impl Chapter {
         let _ = emit(ctx.app, SCRIPT_CHAPTER_CHANGE, &payload);
 
         tracing::info!(
-            "[ScriptEngine] 开始章节: '{}' ({} events)",
+            "[ScriptEngine] 开始章节: '{}' ({} events, resume from #{})",
             self.chapter_name,
-            self.events_handler.event_list.len()
+            self.events_handler.event_list.len(),
+            self.events_handler.progress
         );
 
         // Execute events one by one
         while !self.events_handler.is_finished() {
+            // 在事件执行前记录「即将执行」的事件序号：保守位置，保证存档点永不超前于已展示的剧情
+            // （若在事件执行中存档，续跑会重放该事件而非跳过后续剧情）。
+            if let Some(ref mut ss) = ctx.game_status.lock().await.script_status {
+                ss.current_event_process = self.events_handler.progress as i32;
+            }
             self.events_handler.process_next_event(ctx).await?;
         }
 

--- a/src-tauri/src/ai_service/game_system/script_engine/chapter.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/chapter.rs
@@ -47,10 +47,14 @@ impl Chapter {
             0
         };
 
+        let mut events_handler = EventsHandler::with_progress(event_list, resume_progress);
+        // 记录章节 key，供 script:progress 广播携带（前端记录玩家阅读位置所在章节）
+        events_handler.chapter_key = chapter_id.clone();
+
         Self {
             _chapter_id: chapter_id,
             chapter_name,
-            events_handler: EventsHandler::with_progress(event_list, resume_progress),
+            events_handler,
         }
     }
 

--- a/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
@@ -6,9 +6,13 @@ use serde_json::Value;
 use tauri::Manager;
 
 use crate::ai_service::game_system::script_engine::events::{
-    parse_duration, register_event, ScriptContext, ScriptEvent,
+    parse_duration, register_event, wait_for_frontend_continue, ScriptContext, ScriptEvent,
+};
+use crate::ai_service::game_system::script_engine::responses::{
+    event_names::SCRIPT_LLM_RETRY, LlmRetryPayload,
 };
 use crate::ai_service::game_system::script_engine::utils::script_function;
+use crate::ai_service::message_system::events::emit;
 use crate::ai_service::message_system::generator::{
     GeneratorDeps, GeneratorSource, MessageGenerator,
 };
@@ -112,10 +116,15 @@ impl ScriptEvent for AIDialogueEvent {
 
         let generator = MessageGenerator::new(deps);
 
-        // LLM 调用失败**绝不终止剧本**（玩家玩到一半不能被踢出）：
-        // 持续重试直到成功，退避间隔递增（上限 8 秒）。瞬时网络抖动秒级恢复；
-        // 长故障时玩家可自行退出剧本（退出会 abort 本任务，on_script_end 收尾）。
-        // LLM 未配置在更早处已拦截，不在此重试。
+        // LLM 调用失败**绝不踢出玩家**（剧本连续性优先，不跳过对话、不退出剧本）：
+        // 1) 先自动重试 3 次（退避约 1s/2s/3s，覆盖瞬时网络抖动）；
+        // 2) 仍失败则广播「重试」提示并等待玩家点击「继续」——玩家点继续经
+        //    `script_event_continue` 回执到 continue_tx（与旁白共用等待通道，
+        //    引擎顺序执行无冲突），此后重置自动重试计数再来一轮；
+        // 3) 玩家不想等可退出剧本：stop_script abort 本任务即终止。
+        // 重试回溯点正确性：失败时 process_next_event 未返回（进度仍停在当前
+        // ai_dialogue）、add_assistant_line 未执行（line_list 无残留），重新生成
+        // 的上下文与首次一致。
         let mut attempt: u64 = 0;
         loop {
             match generator.process_message(None).await {
@@ -123,12 +132,28 @@ impl ScriptEvent for AIDialogueEvent {
                 Err(e) => {
                     attempt += 1;
                     tracing::warn!(
-                        "[AIDialogueEvent] LLM 生成失败（第 {} 次重试，持续重试不终止剧本）: {}",
+                        "[AIDialogueEvent] LLM 生成失败（第 {} 次重试）: {}",
                         attempt,
                         e
                     );
-                    let wait_ms = 500u64.saturating_mul(attempt.min(16));
-                    tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+                    if attempt > 3 {
+                        // 自动重试耗尽：交还玩家控制
+                        let _ = emit(
+                            ctx.app,
+                            SCRIPT_LLM_RETRY,
+                            &LlmRetryPayload {
+                                message: format!(
+                                    "AI 响应失败（已尝试 {} 次），点击「继续」重试",
+                                    attempt
+                                ),
+                            },
+                        );
+                        wait_for_frontend_continue(&ctx.channels).await;
+                        attempt = 0;
+                        continue;
+                    }
+                    // 自动重试退避（约 1s/2s/3s）
+                    tokio::time::sleep(std::time::Duration::from_secs(attempt as u64)).await;
                 }
             }
         }

--- a/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
@@ -111,7 +111,34 @@ impl ScriptEvent for AIDialogueEvent {
         };
 
         let generator = MessageGenerator::new(deps);
-        generator.process_message(None).await?;
+
+        // LLM 调用失败（网络抖动/服务瞬时错误）时重试，避免一次失败就中断整个剧本
+        // （run_to_completion 会把玩家踢回自由对话）。上限 3 次、间隔递增；持续失败
+        // 才向上抛错，由 run_to_completion 统一收尾。LLM 未配置在更早处已拦截，不在此重试。
+        let mut last_err: Option<anyhow::Error> = None;
+        for attempt in 0..3 {
+            match generator.process_message(None).await {
+                Ok(_) => {
+                    last_err = None;
+                    break;
+                }
+                Err(e) => {
+                    last_err = Some(e);
+                    tracing::warn!(
+                        "[AIDialogueEvent] LLM 生成失败（第 {}/3 次），退避后重试: {}",
+                        attempt + 1,
+                        last_err.as_ref().expect("last_err 已赋值")
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(
+                        500 * (attempt as u64 + 1),
+                    ))
+                    .await;
+                }
+            }
+        }
+        if let Some(e) = last_err {
+            return Err(e);
+        }
 
         tracing::info!("[AIDialogueEvent] 执行完毕");
 

--- a/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
@@ -112,32 +112,25 @@ impl ScriptEvent for AIDialogueEvent {
 
         let generator = MessageGenerator::new(deps);
 
-        // LLM 调用失败（网络抖动/服务瞬时错误）时重试，避免一次失败就中断整个剧本
-        // （run_to_completion 会把玩家踢回自由对话）。上限 3 次、间隔递增；持续失败
-        // 才向上抛错，由 run_to_completion 统一收尾。LLM 未配置在更早处已拦截，不在此重试。
-        let mut last_err: Option<anyhow::Error> = None;
-        for attempt in 0..3 {
+        // LLM 调用失败**绝不终止剧本**（玩家玩到一半不能被踢出）：
+        // 持续重试直到成功，退避间隔递增（上限 8 秒）。瞬时网络抖动秒级恢复；
+        // 长故障时玩家可自行退出剧本（退出会 abort 本任务，on_script_end 收尾）。
+        // LLM 未配置在更早处已拦截，不在此重试。
+        let mut attempt: u64 = 0;
+        loop {
             match generator.process_message(None).await {
-                Ok(_) => {
-                    last_err = None;
-                    break;
-                }
+                Ok(_) => break,
                 Err(e) => {
-                    last_err = Some(e);
+                    attempt += 1;
                     tracing::warn!(
-                        "[AIDialogueEvent] LLM 生成失败（第 {}/3 次），退避后重试: {}",
-                        attempt + 1,
-                        last_err.as_ref().expect("last_err 已赋值")
+                        "[AIDialogueEvent] LLM 生成失败（第 {} 次重试，持续重试不终止剧本）: {}",
+                        attempt,
+                        e
                     );
-                    tokio::time::sleep(std::time::Duration::from_millis(
-                        500 * (attempt as u64 + 1),
-                    ))
-                    .await;
+                    let wait_ms = 500u64.saturating_mul(attempt.min(16));
+                    tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
                 }
             }
-        }
-        if let Some(e) = last_err {
-            return Err(e);
         }
 
         tracing::info!("[AIDialogueEvent] 执行完毕");

--- a/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/ai_dialogue_event.rs
@@ -6,13 +6,9 @@ use serde_json::Value;
 use tauri::Manager;
 
 use crate::ai_service::game_system::script_engine::events::{
-    parse_duration, register_event, wait_for_frontend_continue, ScriptContext, ScriptEvent,
-};
-use crate::ai_service::game_system::script_engine::responses::{
-    event_names::SCRIPT_LLM_RETRY, LlmRetryPayload,
+    generate_with_retry, parse_duration, register_event, ScriptContext, ScriptEvent,
 };
 use crate::ai_service::game_system::script_engine::utils::script_function;
-use crate::ai_service::message_system::events::emit;
 use crate::ai_service::message_system::generator::{
     GeneratorDeps, GeneratorSource, MessageGenerator,
 };
@@ -116,47 +112,10 @@ impl ScriptEvent for AIDialogueEvent {
 
         let generator = MessageGenerator::new(deps);
 
-        // LLM 调用失败**绝不踢出玩家**（剧本连续性优先，不跳过对话、不退出剧本）：
-        // 1) 先自动重试 3 次（退避约 1s/2s/3s，覆盖瞬时网络抖动）；
-        // 2) 仍失败则广播「重试」提示并等待玩家点击「继续」——玩家点继续经
-        //    `script_event_continue` 回执到 continue_tx（与旁白共用等待通道，
-        //    引擎顺序执行无冲突），此后重置自动重试计数再来一轮；
-        // 3) 玩家不想等可退出剧本：stop_script abort 本任务即终止。
-        // 重试回溯点正确性：失败时 process_next_event 未返回（进度仍停在当前
-        // ai_dialogue）、add_assistant_line 未执行（line_list 无残留），重新生成
-        // 的上下文与首次一致。
-        let mut attempt: u64 = 0;
-        loop {
-            match generator.process_message(None).await {
-                Ok(_) => break,
-                Err(e) => {
-                    attempt += 1;
-                    tracing::warn!(
-                        "[AIDialogueEvent] LLM 生成失败（第 {} 次重试）: {}",
-                        attempt,
-                        e
-                    );
-                    if attempt > 3 {
-                        // 自动重试耗尽：交还玩家控制
-                        let _ = emit(
-                            ctx.app,
-                            SCRIPT_LLM_RETRY,
-                            &LlmRetryPayload {
-                                message: format!(
-                                    "AI 响应失败（已尝试 {} 次），点击「继续」重试",
-                                    attempt
-                                ),
-                            },
-                        );
-                        wait_for_frontend_continue(&ctx.channels).await;
-                        attempt = 0;
-                        continue;
-                    }
-                    // 自动重试退避（约 1s/2s/3s）
-                    tokio::time::sleep(std::time::Duration::from_secs(attempt as u64)).await;
-                }
-            }
-        }
+        // LLM 调用失败**绝不踢出玩家**：自动重试 3 次后广播「重试」提示、等玩家点
+        // 「继续」再试（详见 generate_with_retry 的注释：不跳过对话、不退出剧本，
+        // 重试回溯点正确——进度停在当前事件、line_list 无残留）。
+        generate_with_retry(ctx, &generator).await?;
 
         tracing::info!("[AIDialogueEvent] 执行完毕");
 

--- a/src-tauri/src/ai_service/game_system/script_engine/events/free_dialogue_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/free_dialogue_event.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use tauri::Manager;
 
 use crate::ai_service::game_system::script_engine::events::{
-    parse_duration, register_event, ScriptContext, ScriptEvent,
+    generate_with_retry, parse_duration, register_event, ScriptContext, ScriptEvent,
 };
 use crate::ai_service::game_system::script_engine::responses::{
     event_names::{SCRIPT_FREE_DIALOGUE, SCRIPT_INPUT},
@@ -91,6 +91,20 @@ impl ScriptEvent for FreeDialogueEvent {
             .clone()
             .ok_or_else(|| anyhow!("ScriptStatus 未设置"))?;
 
+        // 读档续跑续轮：free_dialogue 是多轮块，rounds 是局部变量不保存会导致
+        // 块中存档读档后整块重放（轮次重置 + 每轮重调 LLM + 历史重复）。
+        // 把「已完成的轮次」写进 script_status.vars（key 带事件索引，避免多个
+        // free_dialogue 互相覆盖；__ 前缀是内部约定，不参与剧本作者的条件判断）。
+        // 每轮 LLM 回复完成后写回，因此：
+        //  - 玩家在「本轮 input 已显示但未输入」时存档 → vars 仍是上一轮值 → 续跑重新进入本轮；
+        //  - 玩家在「本轮回复后」存档 → vars 已是本轮值 → 续跑从下一轮继续。
+        let round_key = format!("__free_dialogue_rounds_{}", script_status.current_event_process);
+        let saved_rounds = script_status
+            .vars
+            .get(&round_key)
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+
         let role_id = {
             let mut gs = ctx.game_status.lock().await;
             let role = script_function::get_role(&mut *gs, ctx.db, &script_status, &self.character)
@@ -145,8 +159,8 @@ impl ScriptEvent for FreeDialogueEvent {
         let end_prompt = replace_placeholder(&self.end_prompt, &game_status_guard);
         drop(game_status_guard); // 尽早释放锁
 
-        // ---- 主循环（支持无限轮次） ----
-        let mut rounds: i32 = 0;
+        // ---- 主循环（支持无限轮次；读档续跑时从已进行轮次继续） ----
+        let mut rounds: i32 = saved_rounds;
         loop {
             let mut is_last_round = false;
 
@@ -222,8 +236,17 @@ impl ScriptEvent for FreeDialogueEvent {
                     .await?;
             }
 
-            // ---- 调用 AI 生成回复 ----
-            generator.process_message(None).await?;
+            // ---- 调用 AI 生成回复（失败不踢出：自动重试 3 次后等玩家点「继续」重试） ----
+            generate_with_retry(ctx, &generator).await?;
+
+            // 本轮完成：把轮次写回 vars，读档续跑据此从下一轮继续
+            // （存档在「本轮 input 已显示但未输入」时，vars 仍是上一轮值 → 续跑重新进入本轮）
+            {
+                let mut gs = ctx.game_status.lock().await;
+                if let Some(ref mut ss) = gs.script_status {
+                    ss.vars.insert(round_key.clone(), serde_json::json!(rounds));
+                }
+            }
 
             if is_last_round {
                 break;

--- a/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
@@ -92,6 +92,11 @@ pub struct ScriptContext<'a> {
     /// 标记，前端据此丢弃中止后迟到的流式回复（见 `ReplyResponse.preview_gen`）。
     /// 正式游玩显式置 `false`。
     pub is_preview: bool,
+
+    /// 本次剧本运行的唯一纪元号（每次 start_script / 读档续跑递增）。
+    /// 用于区分「旧剧本任务」与「读档恢复的新状态」：旧任务的收尾
+    /// （on_script_end）只清理它自己那一代的状态，避免清掉新恢复的剧本。
+    pub run_epoch: u64,
 }
 
 // ============================================================

--- a/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
@@ -36,7 +36,11 @@ use tokio::sync::Mutex;
 
 use crate::ai_service::config::AIServiceConfig;
 use crate::ai_service::game_system::game_status::GameStatus;
+use crate::ai_service::game_system::script_engine::responses::{
+    event_names::SCRIPT_LLM_RETRY, LlmRetryPayload,
+};
 use crate::ai_service::llm::LlmClient;
+use crate::ai_service::message_system::events::emit;
 
 // ============================================================
 // 剧本共享通道（剧本运行期间的用户输入/选择）
@@ -87,6 +91,55 @@ pub async fn wait_for_frontend_continue(channels: &SharedScriptChannels) {
 }
 
 pub type SharedScriptChannels = Arc<Mutex<ScriptChannels>>;
+
+/// 带 LLM 失败重试的剧本内 AI 生成（供 ai_dialogue / free_dialogue 复用）。
+///
+/// 玩家**绝不会因 LLM 调用失败被踢出剧本**（剧本连续性优先，不跳过对话、不退出）：
+/// 1) 自动重试 3 次（退避约 1s/2s/3s，覆盖瞬时网络抖动）；
+/// 2) 仍失败则广播 `script:llm-retry` 并等待玩家点击「继续」——玩家点继续经
+///    `script_event_continue` 回执到 continue_tx（与旁白共用等待通道，顺序执行无冲突），
+///    此后重置自动重试计数再来一轮；
+/// 3) 玩家不想等可退出剧本：stop_script abort 本任务即终止。
+///
+/// 重试回溯点正确：失败时调用方的事件进度未前进、`add_assistant_line` 未执行
+/// （line_list 无残留），重新生成的 LLM 上下文与首次一致。
+pub async fn generate_with_retry(
+    ctx: &mut ScriptContext<'_>,
+    generator: &crate::ai_service::message_system::generator::MessageGenerator,
+) -> Result<()> {
+    let mut attempt: u64 = 0;
+    loop {
+        match generator.process_message(None).await {
+            Ok(_) => return Ok(()),
+            Err(e) => {
+                attempt += 1;
+                tracing::warn!(
+                    "[ScriptEngine] LLM 生成失败（第 {} 次重试）: {}",
+                    attempt,
+                    e
+                );
+                if attempt > 3 {
+                    // 自动重试耗尽：交还玩家控制
+                    let _ = emit(
+                        ctx.app,
+                        SCRIPT_LLM_RETRY,
+                        &LlmRetryPayload {
+                            message: format!(
+                                "AI 响应失败（已尝试 {} 次），点击「继续」重试",
+                                attempt
+                            ),
+                        },
+                    );
+                    wait_for_frontend_continue(&ctx.channels).await;
+                    attempt = 0;
+                    continue;
+                }
+                // 自动重试退避（约 1s/2s/3s）
+                tokio::time::sleep(std::time::Duration::from_secs(attempt as u64)).await;
+            }
+        }
+    }
+}
 
 // ============================================================
 // ScriptContext —— 事件处理器所需的依赖打包

--- a/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/mod.rs
@@ -53,6 +53,13 @@ pub struct ScriptChannels {
     /// `script_submit_input` 据此判断：当选项挂起时，输入框里打的字可以转投
     /// `choice_tx` 而不是被拒绝——否则选项永远无法解决，剧本永久阻塞。
     pub choice_allow_free: bool,
+    /// 旁白/主人公/立绘等「按玩家阅读节奏显示」的事件，等待前端确认玩家已继续。
+    ///
+    /// 引擎在这些事件上等待，使**台词写入（line_list）与玩家实际阅读同步**——
+    /// 否则引擎预跑会把后续剧情整段写进 line_list，存档捕获到「尚未行进至」的内容，
+    /// 读档后历史出现超前剧情、位置错乱。玩家点击「继续」经 `script_event_continue`
+    /// 在此通道上回执，引擎再推进。
+    pub continue_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
 impl ScriptChannels {
@@ -61,8 +68,22 @@ impl ScriptChannels {
             input_tx: None,
             choice_tx: None,
             choice_allow_free: false,
+            continue_tx: None,
         }
     }
+}
+
+/// 等待前端展示完当前事件并由玩家点击「继续」（引擎与画面/台词同步推进）。
+/// 带 10 分钟超时兜底，防止前端异常时剧本永久挂起（试玩中止等场景由
+/// `editor_stop_preview` 显式清通道解除）。
+pub async fn wait_for_frontend_continue(channels: &SharedScriptChannels) {
+    let rx = {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let mut ch = channels.lock().await;
+        ch.continue_tx = Some(tx);
+        rx
+    };
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(600), rx).await;
 }
 
 pub type SharedScriptChannels = Arc<Mutex<ScriptChannels>>;

--- a/src-tauri/src/ai_service/game_system/script_engine/events/narration_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/narration_event.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::ai_service::game_system::script_engine::events::{
-    parse_duration, register_event, ScriptContext, ScriptEvent,
+    parse_duration, register_event, wait_for_frontend_continue, ScriptContext, ScriptEvent,
 };
 use crate::ai_service::game_system::script_engine::responses::{
     event_names::SCRIPT_NARRATION, NarrationPayload,
@@ -48,6 +48,10 @@ impl ScriptEvent for NarrationEvent {
             .filter(|line| !line.is_empty())
             .collect();
 
+        // 逐行 emit + 逐行等待前端「继续」：
+        // 1) 让引擎与玩家阅读同步（预跑否则会把后续剧情整段写进 line_list，存档捕获超前内容）；
+        // 2) 逐行等待使「点击继续的次数」与「等待次数」严格 1:1，多行旁白不会产生多余回执
+        //    提前推进下一个事件。
         for line in lines {
             let payload = NarrationPayload {
                 text: line.to_string(),
@@ -55,9 +59,14 @@ impl ScriptEvent for NarrationEvent {
                 duration: self.duration,
             };
             let _ = emit(ctx.app, SCRIPT_NARRATION, &payload);
+            // 带 duration（YAML 明确自动推进）时不阻塞，与前端 shouldWaitForUser 语义一致；
+            // 缺省则逐行等待玩家「继续」，让台词写入与阅读同步（见 execute 头注释）。
+            if self.duration.is_none() {
+                wait_for_frontend_continue(&ctx.channels).await;
+            }
         }
 
-        // Add as ASSISTANT line (keep the original text with newlines)
+        // 玩家读完所有行后才写入台词（line_list 与玩家阅读对齐，存档不捕获超前内容）
         let line = LineBase {
             content: PromptRole::Narrator.build_prompt(&self.text.clone()),
             attribute: LineAttributeExt(LineAttribute::User),

--- a/src-tauri/src/ai_service/game_system/script_engine/events/player_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/player_event.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::ai_service::game_system::script_engine::events::{
-    parse_duration, register_event, ScriptContext, ScriptEvent,
+    parse_duration, register_event, wait_for_frontend_continue, ScriptContext, ScriptEvent,
 };
 use crate::ai_service::game_system::script_engine::responses::{
     event_names::SCRIPT_PLAYER, PlayerPayload,
@@ -58,6 +58,12 @@ impl ScriptEvent for PlayerEvent {
             ..Default::default()
         };
         ctx.game_status.lock().await.add_line(ctx.db, line).await?;
+
+        // 与旁白一致：等待前端展示完并点击「继续」后再推进（引擎与画面/台词同步）。
+        // 带 duration（自动推进）时不阻塞，与前端 shouldWaitForUser 语义一致。
+        if self.duration.is_none() {
+            wait_for_frontend_continue(&ctx.channels).await;
+        }
 
         Ok(None)
     }

--- a/src-tauri/src/ai_service/game_system/script_engine/events/present_pic_event.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events/present_pic_event.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::ai_service::game_system::script_engine::events::{
-    parse_duration, register_event, ScriptContext, ScriptEvent,
+    parse_duration, register_event, wait_for_frontend_continue, ScriptContext, ScriptEvent,
 };
 use crate::ai_service::game_system::script_engine::responses::{
     event_names::SCRIPT_PRESENT_PIC, PresentPicPayload,
@@ -62,6 +62,12 @@ impl ScriptEvent for PresentPicEvent {
             duration: self.duration,
         };
         let _ = emit(ctx.app, SCRIPT_PRESENT_PIC, &payload);
+
+        // 与旁白一致：等待前端展示完并点击「继续」后再推进（引擎与画面/台词同步）。
+        // 带 duration（自动推进）时不阻塞，与前端 shouldWaitForUser 语义一致。
+        if self.duration.is_none() {
+            wait_for_frontend_continue(&ctx.channels).await;
+        }
 
         Ok(None)
     }

--- a/src-tauri/src/ai_service/game_system/script_engine/events_handler.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events_handler.rs
@@ -8,7 +8,11 @@ use serde_json::Value;
 
 use crate::ai_service::game_system::game_status::GameStatus;
 use crate::ai_service::game_system::script_engine::events::{create_event, ScriptContext};
+use crate::ai_service::game_system::script_engine::responses::{
+    event_names::SCRIPT_PROGRESS, ScriptProgressPayload,
+};
 use crate::ai_service::game_system::script_engine::utils::script_function::replace_placeholder;
+use crate::ai_service::message_system::events::emit;
 
 /// Processes a chapter's event list sequentially.
 pub struct EventsHandler {
@@ -18,6 +22,9 @@ pub struct EventsHandler {
     pub event_list: Vec<Value>,
     /// Set when a chapter_end event returns a result (the next chapter name).
     pub chapter_result: Option<String>,
+    /// 当前章节 key（YAML 文件名）。script:progress 广播时随事件序号一起携带，
+    /// 供前端记录「玩家阅读位置」所在的章节。
+    pub chapter_key: String,
 }
 
 impl EventsHandler {
@@ -26,6 +33,7 @@ impl EventsHandler {
             progress: 0,
             event_list,
             chapter_result: None,
+            chapter_key: String::new(),
         }
     }
 
@@ -79,6 +87,17 @@ impl EventsHandler {
 
         let mut handler = create_event(&event_type, event_data)
             .ok_or_else(|| anyhow!("未注册的事件类型: '{}'", event_type))?;
+
+        // 事件实际执行前，向前端广播其（章节 + 事件序号）。不阻塞引擎（预跑不受影响）；
+        // 前端在事件队列里与其后的内容事件相邻、保序消费，据此记录「玩家阅读位置」。
+        let _ = emit(
+            ctx.app,
+            SCRIPT_PROGRESS,
+            &ScriptProgressPayload {
+                chapter: self.chapter_key.clone(),
+                seq: (self.progress - 1) as i32,
+            },
+        );
 
         if let Some(result) = handler.execute(ctx).await? {
             self.chapter_result = Some(result);

--- a/src-tauri/src/ai_service/game_system/script_engine/events_handler.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/events_handler.rs
@@ -29,6 +29,14 @@ impl EventsHandler {
         }
     }
 
+    /// 从指定事件序号开始执行（读档续跑恢复用）。
+    /// 超出章节事件总数时回退到最后一个事件，保证 `chapter_end` 仍会执行、故事能继续。
+    pub fn with_progress(event_list: Vec<Value>, progress: usize) -> Self {
+        let mut handler = Self::new(event_list);
+        handler.progress = progress.min(handler.event_list.len().saturating_sub(1));
+        handler
+    }
+
     pub fn is_finished(&self) -> bool {
         self.chapter_result.is_some() || self.progress >= self.event_list.len()
     }

--- a/src-tauri/src/ai_service/game_system/script_engine/responses.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/responses.rs
@@ -28,6 +28,8 @@ pub mod event_names {
     /// 事件进度广播：每实际执行一个事件，把（章节 key + 事件序号）推给前端，
     /// 前端据此记录「玩家阅读位置」，读档按玩家位置续跑（而非引擎执行位置）。
     pub const SCRIPT_PROGRESS: &str = "script:progress";
+    /// LLM 生成失败、等待玩家「继续」重试（AI 对话事件在自动重试耗尽后广播）。
+    pub const SCRIPT_LLM_RETRY: &str = "script:llm-retry";
 }
 
 // ============================================================
@@ -205,4 +207,14 @@ pub struct ScriptEndPayload {
     /// reaching its end. The frontend must not credit the player with an
     /// adventure completion in that case.
     pub completed: bool,
+}
+
+/// LLM 生成失败、等待玩家点击「继续」重试（script:llm-retry）。
+/// 前端收到后显示提示文本并进入「等待继续」状态；玩家点击继续经
+/// `script_event_continue` 回执到 continue_tx，引擎据此重新调用 LLM。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LlmRetryPayload {
+    /// 展示给玩家的提示文案（如「AI 响应失败，点击继续重试」）
+    pub message: String,
 }

--- a/src-tauri/src/ai_service/game_system/script_engine/responses.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/responses.rs
@@ -25,11 +25,25 @@ pub mod event_names {
     pub const SCRIPT_CHOICE: &str = "script:choice";
     pub const SCRIPT_END: &str = "script:end";
     pub const SCRIPT_FREE_DIALOGUE: &str = "script:free-dialogue";
+    /// 事件进度广播：每实际执行一个事件，把（章节 key + 事件序号）推给前端，
+    /// 前端据此记录「玩家阅读位置」，读档按玩家位置续跑（而非引擎执行位置）。
+    pub const SCRIPT_PROGRESS: &str = "script:progress";
 }
 
 // ============================================================
 // Payload types (fields match frontend `src/types/script.ts`)
 // ============================================================
+
+/// 剧本事件进度（script:progress）——引擎实际执行每个事件前广播一次。
+/// 不阻塞引擎（预跑不受影响）；前端在队列里与其后的内容事件相邻、保序消费。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScriptProgressPayload {
+    /// 当前章节 key（YAML 文件名，如 "main" / "Intro/intro"）
+    pub chapter: String,
+    /// 事件在章节事件数组中的序号
+    pub seq: i32,
+}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/ai_service/game_system/script_engine/script_manager.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/script_manager.rs
@@ -304,6 +304,10 @@ impl ScriptManager {
             }
             // 记录本次运行的纪元号（on_script_end 据此判断是否清理剧本状态）
             gs.script_epoch = ctx.run_epoch;
+            // 清空玩家阅读位置暂存：本次运行的阅读位置由前端随 script:progress 重新上报，
+            // 避免残留上一轮剧本/读档前的位置，导致存档写入错误章节。
+            gs.player_read_chapter.clear();
+            gs.player_read_seq = 0;
         }
 
         // Load player info from script settings

--- a/src-tauri/src/ai_service/game_system/script_engine/script_manager.rs
+++ b/src-tauri/src/ai_service/game_system/script_engine/script_manager.rs
@@ -7,11 +7,12 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use serde_json::Value;
+use tokio::sync::Mutex;
 
 use crate::ai_service::game_system::script_engine::chapter::Chapter;
 use crate::ai_service::game_system::script_engine::events::ScriptContext;
@@ -45,6 +46,17 @@ pub struct ScriptManager {
     pub all_scripts: HashMap<String, ScriptStatus>,
     /// Whether a script is currently running (shared so callers can read without lock).
     pub is_running: Arc<AtomicBool>,
+    /// 当前运行中的剧本任务句柄（start_script/start_adventure/试玩 spawn 时登记）。
+    /// 读档等场景需要「掐断旧任务」时据此 abort 并等待收尾，避免双任务竞争。
+    pub current_run: Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+/// 剧本运行纪元计数器：每次启动剧本/读档续跑递增，用于区分新旧剧本任务。
+static NEXT_SCRIPT_EPOCH: AtomicU64 = AtomicU64::new(1);
+
+/// 分配一个新的剧本运行纪元号。
+pub fn next_script_epoch() -> u64 {
+    NEXT_SCRIPT_EPOCH.fetch_add(1, Ordering::SeqCst)
 }
 
 impl ScriptManager {
@@ -57,6 +69,7 @@ impl ScriptManager {
         let mut manager = Self {
             all_scripts: HashMap::new(),
             is_running: Arc::new(AtomicBool::new(false)),
+            current_run: Mutex::new(None),
         };
         manager.init_all_scripts(data_dir);
         manager
@@ -261,7 +274,37 @@ impl ScriptManager {
     /// Initialize a script: register its roles, set script_status, load player info.
     pub async fn init_script(script: &ScriptStatus, ctx: &mut ScriptContext<'_>) -> Result<()> {
         // Set script_status on GameStatus
-        ctx.game_status.lock().await.script_status = Some(script.clone());
+        {
+            let mut gs = ctx.game_status.lock().await;
+            // 若 load_save 已恢复同一剧本的进度（current_chapter_key 非空），
+            // 保留其章节/事件/变量，使 run_script 能从存档章节续跑；仅合并剧本元数据。
+            let has_resume = gs
+                .script_status
+                .as_ref()
+                .map(|s| s.folder_key == script.folder_key && !s.current_chapter_key.is_empty())
+                .unwrap_or(false);
+            if has_resume {
+                if let Some(ref mut ss) = gs.script_status {
+                    ss.name = script.name.clone();
+                    ss.description = script.description.clone();
+                    ss.intro_chapter = script.intro_chapter.clone();
+                    ss.settings = script.settings.clone();
+                    ss.script_path = script.script_path.clone();
+                    ss.recommand_start = script.recommand_start.clone();
+                    ss.adventure = script.adventure.clone();
+                    tracing::info!(
+                        "[ScriptManager] 续跑恢复: 剧本 '{}' 从章节 '{}' 事件 {} 继续",
+                        script.name,
+                        ss.current_chapter_key,
+                        ss.current_event_process
+                    );
+                }
+            } else {
+                gs.script_status = Some(script.clone());
+            }
+            // 记录本次运行的纪元号（on_script_end 据此判断是否清理剧本状态）
+            gs.script_epoch = ctx.run_epoch;
+        }
 
         // Load player info from script settings
         if let Some(user_name) = script.settings.get("user_name").and_then(|v| v.as_str()) {
@@ -405,18 +448,31 @@ impl ScriptManager {
                     settings.system_prompt_example_old.as_deref(),
                     prompt_options,
                 );
-                let sys_line = LineBase {
-                    content: ai_prompt,
-                    attribute: LineAttributeExt(LineAttribute::System),
-                    sender_role_id: Some(role_id),
-                    display_name: Some(settings.ai_name.clone()),
-                    ..Default::default()
-                };
-                ctx.game_status
+                // 若该角色已有 system 人设台词（如读档恢复时已补建），跳过避免重复注入
+                let already_has_system = ctx
+                    .game_status
                     .lock()
                     .await
-                    .add_line(ctx.db, sys_line)
-                    .await?;
+                    .line_list
+                    .iter()
+                    .any(|l| {
+                        matches!(l.attribute(), LineAttribute::System)
+                            && l.base.sender_role_id == Some(role_id)
+                    });
+                if !already_has_system {
+                    let sys_line = LineBase {
+                        content: ai_prompt,
+                        attribute: LineAttributeExt(LineAttribute::System),
+                        sender_role_id: Some(role_id),
+                        display_name: Some(settings.ai_name.clone()),
+                        ..Default::default()
+                    };
+                    ctx.game_status
+                        .lock()
+                        .await
+                        .add_line(ctx.db, sys_line)
+                        .await?;
+                }
             }
         }
 
@@ -434,7 +490,13 @@ impl ScriptManager {
             .ok_or_else(|| anyhow!("ScriptStatus 未设置"))?
             .clone();
 
-        let mut next_chapter = script.intro_chapter.clone();
+        // 若已恢复存档进度（current_chapter_key 非空），从存档章节续跑；
+        // 否则按剧本 intro_chapter 正常开始。
+        let mut next_chapter = if !script.current_chapter_key.is_empty() {
+            script.current_chapter_key.clone()
+        } else {
+            script.intro_chapter.clone()
+        };
 
         // Resolve "Intro/intro" style paths → find the actual yaml file
         let chapters_dir = script.script_path.join("Chapters");
@@ -497,16 +559,23 @@ impl ScriptManager {
 
         // Extract data under one lock, then mutate under a second lock.
         // tokio::sync::Mutex is NOT reentrant — nesting lock().await deadlocks.
-        let (folder, is_adventure) = {
+        // 仅当当前 script_status 属于本次运行（纪元一致）时才记录/清理；
+        // 读档恢复的新剧本状态不会被旧任务的收尾误清。
+        let (folder, is_adventure, epoch_matches) = {
             let gs = ctx.game_status.lock().await;
+            let epoch_matches = gs.script_epoch == ctx.run_epoch;
             match gs.script_status.as_ref() {
-                Some(ss) => (Some(ss.path_key()), ss.adventure.is_adventure),
-                None => (None, false),
+                Some(ss) => (
+                    Some(ss.path_key()),
+                    ss.adventure.is_adventure,
+                    epoch_matches,
+                ),
+                None => (None, false, epoch_matches),
             }
         };
 
         // Now re-acquire the lock and do all writes in one critical section
-        {
+        if epoch_matches {
             let mut gs = ctx.game_status.lock().await;
             if let Some(folder) = folder {
                 if completed {
@@ -519,11 +588,16 @@ impl ScriptManager {
                 }
             }
             gs.script_status = None;
+            tracing::info!("[ScriptManager] 剧本状态已清除");
+        } else {
+            tracing::info!(
+                "[ScriptManager] 本次运行({})已结束，但当前剧本状态属于其他运行({})，跳过清理",
+                ctx.run_epoch,
+                ctx.game_status.lock().await.script_epoch
+            );
         }
 
         is_running.store(false, Ordering::SeqCst);
-
-        tracing::info!("[ScriptManager] 剧本状态已清除");
 
         Ok(())
     }

--- a/src-tauri/src/api/adventure.rs
+++ b/src-tauri/src/api/adventure.rs
@@ -202,7 +202,19 @@ pub async fn start_adventure(app: AppHandle, adventure_folder: String) -> Result
     let llm = crate::ai_service::llm::slot_snapshot(&state.chat.llm).await;
     let achievement_manager = state.achievement_manager.clone();
 
-    tokio::spawn(async move {
+    // 单剧本同时运行保护（原子 CAS）：与 start_script 共用同一守卫，避免双任务竞争。
+    // 忙时返回明确错误而非静默忽略。
+    if is_running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err(format!(
+            "已有剧本正在运行，忽略重复启动请求: '{}'",
+            adventure_folder
+        ));
+    }
+
+    let handle = tokio::spawn(async move {
         let mut ctx = ScriptContext {
             db: &db,
             data_dir: &data_dir,
@@ -212,6 +224,7 @@ pub async fn start_adventure(app: AppHandle, adventure_folder: String) -> Result
             llm: llm.as_ref(),
             channels,
             is_preview: false,
+            run_epoch: crate::ai_service::game_system::script_engine::script_manager::next_script_epoch(),
         };
 
         match ScriptManager::execute_script(&script, &mut ctx, &is_running).await {
@@ -234,6 +247,12 @@ pub async fn start_adventure(app: AppHandle, adventure_folder: String) -> Result
             Err(e) => tracing::error!("[AdventureAPI] 冒险执行错误: {}", e),
         }
     });
+
+    // 登记当前运行句柄：读档等场景需要「掐断旧任务」时据此 abort 并等待收尾。
+    {
+        let service = ai_service.lock().await;
+        *service.script_manager.current_run.lock().await = Some(handle);
+    }
 
     Ok(())
 }

--- a/src-tauri/src/api/adventure.rs
+++ b/src-tauri/src/api/adventure.rs
@@ -249,8 +249,10 @@ pub async fn start_adventure(app: AppHandle, adventure_folder: String) -> Result
     });
 
     // 登记当前运行句柄：读档等场景需要「掐断旧任务」时据此 abort 并等待收尾。
+    // 注意不能复用上面的 `ai_service`：它已被 async move 闭包整体移入，
+    // 这里用 `state` 重新取引用（AppHandle 仍可访问）。
     {
-        let service = ai_service.lock().await;
+        let service = state.ai_service.lock().await;
         *service.script_manager.current_run.lock().await = Some(handle);
     }
 

--- a/src-tauri/src/api/adventure.rs
+++ b/src-tauri/src/api/adventure.rs
@@ -214,6 +214,11 @@ pub async fn start_adventure(app: AppHandle, adventure_folder: String) -> Result
         ));
     }
 
+    // 为句柄登记块另留一份 ai_service 引用：`ai_service` 即将被 async move 闭包
+    // 整体移入；`state` 借用 `app`，若活到 `app` 移入之后会触发 E0505。
+    // 故登记块只能用这份克隆，不再触碰 `state`/`ai_service`。
+    let ai_service_register = state.ai_service.clone();
+
     let handle = tokio::spawn(async move {
         let mut ctx = ScriptContext {
             db: &db,
@@ -249,10 +254,8 @@ pub async fn start_adventure(app: AppHandle, adventure_folder: String) -> Result
     });
 
     // 登记当前运行句柄：读档等场景需要「掐断旧任务」时据此 abort 并等待收尾。
-    // 注意不能复用上面的 `ai_service`：它已被 async move 闭包整体移入，
-    // 这里用 `state` 重新取引用（AppHandle 仍可访问）。
     {
-        let service = state.ai_service.lock().await;
+        let service = ai_service_register.lock().await;
         *service.script_manager.current_run.lock().await = Some(handle);
     }
 

--- a/src-tauri/src/api/game.rs
+++ b/src-tauri/src/api/game.rs
@@ -608,13 +608,17 @@ pub(crate) async fn build_web_init_data(
         last_bgm_paused,
         last_bgm_mode,
         last_ambient_tracks,
+        // 用 name（story_config 的 script_name）而非 folder_key：start_script 通过
+        // `all_scripts.get(name)` 定位剧本（all_scripts 的 key 是 name），folder_key
+        // 只用于 load_save 恢复时的匹配。这里若返回 folder_key，读档续跑会因
+        // 「剧本不存在」失败（常见于 script_name 与目录名不同的剧本）。
         active_script: service
             .game_status
             .lock()
             .await
             .script_status
             .as_ref()
-            .map(|s| s.folder_key.clone()),
+            .map(|s| s.name.clone()),
     };
     Ok(result)
 }

--- a/src-tauri/src/api/game.rs
+++ b/src-tauri/src/api/game.rs
@@ -47,6 +47,8 @@ pub struct WebInitData {
     pub last_bgm_mode: Option<String>,
     /// 上次环境音轨道（JSON 字符串，前端解析）
     pub last_ambient_tracks: Option<String>,
+    /// 当前进行中的剧本 folder_key（读档恢复剧本时，前端据此进入剧情模式并续跑）
+    pub active_script: Option<String>,
 }
 
 /// 精简的角色设定，匹配前端 `CharacterSettings` 接口
@@ -606,6 +608,13 @@ pub(crate) async fn build_web_init_data(
         last_bgm_paused,
         last_bgm_mode,
         last_ambient_tracks,
+        active_script: service
+            .game_status
+            .lock()
+            .await
+            .script_status
+            .as_ref()
+            .map(|s| s.folder_key.clone()),
     };
     Ok(result)
 }

--- a/src-tauri/src/api/game.rs
+++ b/src-tauri/src/api/game.rs
@@ -892,7 +892,9 @@ pub async fn notify_player_entry(app: AppHandle) -> Result<(), String> {
             LineBase {
                 content: prompt,
                 attribute: LineAttributeExt(LineAttribute::User),
-                display_name: Some("旁白".to_string()),
+                // 「系统旁白」标记：入场问候是系统注入的旁白，不进对话历史
+                // （前端按 display_name 过滤），但保留在 line_list 供 AI 开场回复上下文。
+                display_name: Some("系统旁白".to_string()),
                 ..Default::default()
             },
         )

--- a/src-tauri/src/api/save.rs
+++ b/src-tauri/src/api/save.rs
@@ -308,9 +308,12 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
         );
         // 清掉通道残留（旧任务可能持有 sender），并复位运行标记：
         // abort 不会走 on_script_end，故 is_running 需要手动复位。
+        // continue_tx 一并清掉：旧任务可能正等在旁白「继续」回执上，残留的 sender
+        // 会干扰新任务的事件推进。
         let mut ch = state.script_channels.lock().await;
         ch.input_tx = None;
         ch.choice_tx = None;
+        ch.continue_tx = None;
         ch.choice_allow_free = false;
         drop(ch);
         service

--- a/src-tauri/src/api/save.rs
+++ b/src-tauri/src/api/save.rs
@@ -187,10 +187,13 @@ pub async fn create_save(
             } else {
                 Some(gs.player_read_chapter.clone())
             };
-            let player_read_sequence = if gs.player_read_seq > 0 {
-                Some(gs.player_read_seq)
-            } else {
+            // 以 player_read_chapter 非空为「是否上报过」标志：首个内容事件的事件
+            // 序号可能是 0（如剧本第一行旁白），不能因 seq>0 而漏存——否则读档
+            // 时玩家位置为空，只能回退引擎位置。
+            let player_read_sequence = if gs.player_read_chapter.is_empty() {
                 None
+            } else {
+                Some(gs.player_read_seq.max(0))
             };
             let _ = SaveRepo::upsert_running_script(
                 db,
@@ -515,10 +518,13 @@ pub async fn update_save(
             } else {
                 Some(gs.player_read_chapter.clone())
             };
-            let player_read_sequence = if gs.player_read_seq > 0 {
-                Some(gs.player_read_seq)
-            } else {
+            // 以 player_read_chapter 非空为「是否上报过」标志：首个内容事件的事件
+            // 序号可能是 0（如剧本第一行旁白），不能因 seq>0 而漏存——否则读档
+            // 时玩家位置为空，只能回退引擎位置。
+            let player_read_sequence = if gs.player_read_chapter.is_empty() {
                 None
+            } else {
+                Some(gs.player_read_seq.max(0))
             };
             let _ = SaveRepo::upsert_running_script(
                 db,

--- a/src-tauri/src/api/save.rs
+++ b/src-tauri/src/api/save.rs
@@ -5,6 +5,7 @@ use crate::ai_service::game_system::game_status::GameStatusSnapshot;
 use crate::api::game::build_web_init_data;
 use crate::api::game::WebInitData;
 use crate::config::AppConfig;
+use crate::db::entities::line::LineAttribute;
 use crate::db::managers::role_repo::RoleRepo;
 use crate::db::managers::save_repo::SaveRepo;
 use crate::utils::prompt::PromptOptions;
@@ -276,6 +277,16 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
     let snapshot: GameStatusSnapshot = serde_json::from_str(&save_model.status).unwrap_or_default();
     service.game_status.lock().await.apply_snapshot(&snapshot);
 
+    // 7.5 多人物剧本：预加载在场角色（含剧本 NPC），保证读档后立绘/角色名立即可用。
+    //     role_manager.get_loaded 只对已加载角色返回（build_web_init_data 的 onstage_roles
+    //     依赖它）；NPC 若暂无记忆不会被第 8 步 restore_memory_banks 自动 get_role，会漏掉。
+    {
+        let onstage_ids = service.game_status.lock().await.onstage_role_ids.clone();
+        for rid in onstage_ids {
+            let _ = service.game_status.lock().await.get_role(db, rid).await;
+        }
+    }
+
     // 8. 恢复 MemoryBank
     let _ = service
         .restore_memory_banks(save_id)
@@ -428,10 +439,12 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
                 script.current_event_process = restore_seq;
 
                 // 读档续跑：若恢复位置来自「玩家阅读位置」且指向「AI 对话」事件，
-                // 说明玩家已看过该事件的回复（前端只在内容展示时上报位置）。
-                // 前进一位跳过它，避免读档后重新调用 LLM 生成——那会带来数秒延迟、
-                // 回复内容变化，且网络失败会直接中断整个剧本（玩家被踢回自由对话）。
-                // 仅玩家阅读位置触发跳过：引擎位置代表「正在执行/可能尚未看到」，不跳过。
+                // **仅当**该事件的回复已完整生成（line_list 末尾是 assistant 行——
+                // add_assistant_line 在回复最后一句 is_final 时写入）才前进一位跳过：
+                // 此时玩家已看完全部回复，跳过不会跳剧情，且避免读档后重新调用 LLM
+                // （数秒延迟、内容变化、网络失败中断剧本）。
+                // 若回复未生成完（玩家读到一半就存档），则**不跳过**、正常重放重新生成
+                // ——宁可重放也绝不跳剧情（这是 issue 的初衷）。
                 if from_player_read {
                     let chapter_path = if restore_chapter.ends_with(".yaml") {
                         script.script_path.join("Chapters").join(&restore_chapter)
@@ -452,11 +465,27 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
                                     if ev.get("type").and_then(|v| v.as_str())
                                         == Some("ai_dialogue")
                                     {
-                                        script.current_event_process += 1;
-                                        tracing::info!(
-                                            "[LoadSave] 恢复位置指向已展示的 AI 对话事件（#{}），前进一位跳过，不重新调用 LLM",
-                                            restore_seq
-                                        );
+                                        let reply_complete = {
+                                            let gs = service.game_status.lock().await;
+                                            gs.line_list.last().map_or(false, |l| {
+                                                matches!(
+                                                    l.attribute(),
+                                                    LineAttribute::Assistant
+                                                )
+                                            })
+                                        };
+                                        if reply_complete {
+                                            script.current_event_process += 1;
+                                            tracing::info!(
+                                                "[LoadSave] 恢复位置指向已完整生成的 AI 对话事件（#{}），前进一位跳过，不重新调用 LLM",
+                                                restore_seq
+                                            );
+                                        } else {
+                                            tracing::info!(
+                                                "[LoadSave] 恢复位置指向 AI 对话事件（#{}）但回复未生成完，正常重放重新生成（不跳剧情）",
+                                                restore_seq
+                                            );
+                                        }
                                     }
                                 }
                             }

--- a/src-tauri/src/api/save.rs
+++ b/src-tauri/src/api/save.rs
@@ -219,6 +219,7 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
     let db = &state.db;
 
     let mut service = state.ai_service.lock().await;
+    let load_started = std::time::Instant::now();
 
     // 1. 获取存档
     let save_model = SaveRepo::get_save_by_id(db, save_id)
@@ -230,6 +231,11 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
     let line_list = SaveRepo::get_gameline_list(db, save_id)
         .await
         .map_err(|e| format!("读取台词失败: {}", e))?;
+    tracing::info!(
+        "[LoadSave] 读取存档与台词: {} 行, 耗时 {:.0}ms",
+        line_list.len(),
+        load_started.elapsed().as_millis()
+    );
 
     // 3. 获取主角 role_id
     let main_role_id = save_model
@@ -272,6 +278,10 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
         .restore_memory_banks(save_id)
         .await
         .map_err(|e| eprintln!("[SAVE_WARN] 恢复记忆库失败: {}", e));
+    tracing::info!(
+        "[LoadSave] 导入设定/载入台词/恢复快照/记忆库完成, 耗时 {:.0}ms",
+        load_started.elapsed().as_millis()
+    );
 
     // 8.3 若旧剧本任务仍在运行，abort 其句柄并等待收尾，避免双任务竞争：
     //     旧任务会继续推进事件进度（导致存档事件序号超前于对话内容、续跑跳过剧情），
@@ -282,6 +292,7 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
         .load(std::sync::atomic::Ordering::SeqCst)
     {
         tracing::info!("[LoadSave] 检测到旧剧本任务仍在运行，正在中止并等待收尾...");
+        let abort_started = std::time::Instant::now();
         let handle = {
             let mut current = service.script_manager.current_run.lock().await;
             current.take()
@@ -291,6 +302,10 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
             // abort 后任务在其下一个 await 点被取消，此处等待其真正收尾
             let _ = handle.await;
         }
+        tracing::info!(
+            "[LoadSave] 旧剧本任务中止完成, 耗时 {:.0}ms",
+            abort_started.elapsed().as_millis()
+        );
         // 清掉通道残留（旧任务可能持有 sender），并复位运行标记：
         // abort 不会走 on_script_end，故 is_running 需要手动复位。
         let mut ch = state.script_channels.lock().await;
@@ -431,10 +446,11 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
     // 10. 返回前端初始化数据
     let init = build_web_init_data(&service, &app).await?;
     tracing::info!(
-        "[LoadSave] 读档完成: save_id={} 台词数={} active_script={:?}",
+        "[LoadSave] 读档完成: save_id={} 台词数={} active_script={:?} 总耗时 {:.0}ms",
         save_id,
         init.lines.len(),
-        init.active_script
+        init.active_script,
+        load_started.elapsed().as_millis()
     );
     Ok(init)
 }

--- a/src-tauri/src/api/save.rs
+++ b/src-tauri/src/api/save.rs
@@ -256,13 +256,145 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
         .await
         .map_err(|e| eprintln!("[SAVE_WARN] 恢复记忆库失败: {}", e));
 
-    // 9. 恢复剧本状态（若有）
+    // 8.3 若旧剧本任务仍在运行，abort 其句柄并等待收尾，避免双任务竞争：
+    //     旧任务会继续推进事件进度（导致存档事件序号超前于对话内容、续跑跳过剧情），
+    //     且新任务设置通道会顶掉旧任务的 sender，旧任务报"通道已关闭"后 teardown 会清掉新恢复的状态。
+    if service
+        .script_manager
+        .is_running
+        .load(std::sync::atomic::Ordering::SeqCst)
+    {
+        tracing::info!("[LoadSave] 检测到旧剧本任务仍在运行，正在中止并等待收尾...");
+        let handle = {
+            let mut current = service.script_manager.current_run.lock().await;
+            current.take()
+        };
+        if let Some(handle) = handle {
+            handle.abort();
+            // abort 后任务在其下一个 await 点被取消，此处等待其真正收尾
+            let _ = handle.await;
+        }
+        // 清掉通道残留（旧任务可能持有 sender），并复位运行标记：
+        // abort 不会走 on_script_end，故 is_running 需要手动复位。
+        let mut ch = state.script_channels.lock().await;
+        ch.input_tx = None;
+        ch.choice_tx = None;
+        ch.choice_allow_free = false;
+        drop(ch);
+        service
+            .script_manager
+            .is_running
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        // abort 后旧任务不会执行 on_script_end 清理，显式清掉残留的剧本状态，
+        // 下面第 9 步再按存档重建（无剧本的存档则保持 None，不会误报 active_script）。
+        service.game_status.lock().await.script_status = None;
+    }
+
+    // 8.5 为缺少 system 人设台词的发言/在场 NPC 补建 system 行（缓解"人设丢失"告警）。
+    //     仅补内存中的 line_list，下次存档时随 sync_lines 持久化。
+    {
+        use crate::ai_service::types::{GameLine, LineAttributeExt, LineBase};
+        use crate::db::entities::line::LineAttribute;
+        let mut gs = service.game_status.lock().await;
+        let mut involved: std::collections::HashSet<i32> = std::collections::HashSet::new();
+        for l in gs.line_list.iter() {
+            if let Some(sid) = l.base.sender_role_id {
+                if sid != 0 {
+                    involved.insert(sid);
+                }
+            }
+        }
+        involved.extend(gs.present_role_ids.iter().copied());
+        let has_system: std::collections::HashSet<i32> = gs
+            .line_list
+            .iter()
+            .filter(|l| matches!(l.attribute(), LineAttribute::System))
+            .filter_map(|l| l.base.sender_role_id)
+            .collect();
+        for rid in involved {
+            if has_system.contains(&rid) {
+                continue;
+            }
+            let (sys_prompt, display_name) = {
+                let role = match gs.role_manager.get_loaded(rid) {
+                    Some(r) => r,
+                    None => continue,
+                };
+                if role
+                    .settings
+                    .system_prompt
+                    .as_deref()
+                    .unwrap_or("")
+                    .trim()
+                    .is_empty()
+                {
+                    continue;
+                }
+                (
+                    crate::utils::prompt::sys_prompt_builder_by_settings(
+                        &role.settings,
+                        prompt_options,
+                    ),
+                    role.display_name.clone(),
+                )
+            };
+            let sys_line = LineBase {
+                content: sys_prompt,
+                attribute: LineAttributeExt(LineAttribute::System),
+                sender_role_id: Some(rid),
+                display_name,
+                ..Default::default()
+            };
+            gs.line_list.insert(0, GameLine::from_base(sys_line, vec![]));
+            tracing::info!("[LoadSave] 为角色 {} 补建 system 人设台词（存档缺少）", rid);
+        }
+    }
+
+    // 9. 恢复剧本状态（若有）——重建 script_status，使剧本可从存档章节续跑。
+    //    原实现只查询 running_script 后丢弃，导致读档后剧本永远无法继续。
     if let Some(rs_id) = save_model.running_script_id {
-        let _ = SaveRepo::get_running_script(db, rs_id).await;
+        if let Some(rs) = SaveRepo::get_running_script(db, rs_id)
+            .await
+            .map_err(|e| format!("查询剧本状态失败: {}", e))?
+        {
+            let script = service
+                .script_manager
+                .all_scripts
+                .values()
+                .find(|s| s.folder_key == rs.script_folder)
+                .cloned();
+            if let Some(mut script) = script {
+                script.current_chapter_key = rs.current_chapter.clone();
+                script.current_event_process = rs.event_sequence;
+                script.vars = serde_json::from_str(&rs.variable_info).unwrap_or_default();
+                let mut gs = service.game_status.lock().await;
+                gs.script_status = Some(script);
+                // 递增剧本纪元：此后旧剧本任务的收尾（on_script_end）不会清理这份新恢复的状态
+                gs.script_epoch = gs.script_epoch.wrapping_add(1);
+                tracing::info!(
+                    "[LoadSave] 已恢复剧本状态: {} 章节={} 事件={}",
+                    rs.script_folder,
+                    rs.current_chapter,
+                    rs.event_sequence
+                );
+            } else {
+                tracing::warn!(
+                    "[LoadSave] 存档引用的剧本 '{}' 未在剧本目录中找到，跳过剧本恢复",
+                    rs.script_folder
+                );
+            }
+        }
     }
 
     // 10. 返回前端初始化数据
-    build_web_init_data(&service, &app).await
+    let init = build_web_init_data(&service, &app).await?;
+    tracing::info!(
+        "[LoadSave] 读档完成: save_id={} 台词数={} active_script={:?}",
+        save_id,
+        init.lines.len(),
+        init.active_script
+    );
+    Ok(init)
 }
 
 #[tauri::command]

--- a/src-tauri/src/api/save.rs
+++ b/src-tauri/src/api/save.rs
@@ -414,16 +414,55 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
                     };
                     p.exists()
                 };
-                let (restore_chapter, restore_seq) = match rs.player_read_chapter.as_deref() {
-                    Some(ch) if !ch.is_empty() && chapter_exists(ch) => (
-                        rs.player_read_chapter.clone().unwrap_or_default(),
-                        rs.player_read_sequence.unwrap_or(rs.event_sequence),
-                    ),
-                    _ => (rs.current_chapter.clone(), rs.event_sequence),
-                };
+                let (restore_chapter, restore_seq, from_player_read) =
+                    match rs.player_read_chapter.as_deref() {
+                        Some(ch) if !ch.is_empty() && chapter_exists(ch) => (
+                            rs.player_read_chapter.clone().unwrap_or_default(),
+                            rs.player_read_sequence.unwrap_or(rs.event_sequence),
+                            true,
+                        ),
+                        _ => (rs.current_chapter.clone(), rs.event_sequence, false),
+                    };
 
-                script.current_chapter_key = restore_chapter;
+                script.current_chapter_key = restore_chapter.clone();
                 script.current_event_process = restore_seq;
+
+                // 读档续跑：若恢复位置来自「玩家阅读位置」且指向「AI 对话」事件，
+                // 说明玩家已看过该事件的回复（前端只在内容展示时上报位置）。
+                // 前进一位跳过它，避免读档后重新调用 LLM 生成——那会带来数秒延迟、
+                // 回复内容变化，且网络失败会直接中断整个剧本（玩家被踢回自由对话）。
+                // 仅玩家阅读位置触发跳过：引擎位置代表「正在执行/可能尚未看到」，不跳过。
+                if from_player_read {
+                    let chapter_path = if restore_chapter.ends_with(".yaml") {
+                        script.script_path.join("Chapters").join(&restore_chapter)
+                    } else {
+                        script
+                            .script_path
+                            .join("Chapters")
+                            .join(format!("{}.yaml", restore_chapter))
+                    };
+                    if let Ok(content) = std::fs::read_to_string(&chapter_path) {
+                        if let Ok(serde_yaml::Value::Mapping(map)) =
+                            serde_yaml::from_str::<serde_yaml::Value>(&content)
+                        {
+                            if let Some(serde_yaml::Value::Sequence(events)) = map.get("events") {
+                                if let Some(serde_yaml::Value::Mapping(ev)) =
+                                    events.get(restore_seq.max(0) as usize)
+                                {
+                                    if ev.get("type").and_then(|v| v.as_str())
+                                        == Some("ai_dialogue")
+                                    {
+                                        script.current_event_process += 1;
+                                        tracing::info!(
+                                            "[LoadSave] 恢复位置指向已展示的 AI 对话事件（#{}），前进一位跳过，不重新调用 LLM",
+                                            restore_seq
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 script.vars = serde_json::from_str(&rs.variable_info).unwrap_or_default();
                 let mut gs = service.game_status.lock().await;
                 gs.script_status = Some(script);

--- a/src-tauri/src/api/save.rs
+++ b/src-tauri/src/api/save.rs
@@ -176,18 +176,35 @@ pub async fn create_save(
         .map_err(|e| format!("保存记忆库失败: {}", e))?;
 
     // 7. 持久化剧本状态（若有）
-    if let Some(ref script_status) = service.game_status.lock().await.script_status {
-        let vars_json = serde_json::to_string(&script_status.vars).unwrap_or_default();
-        let _ = SaveRepo::upsert_running_script(
-            db,
-            save_id,
-            &script_status.folder_key,
-            &vars_json,
-            &script_status.current_chapter_key,
-            script_status.current_event_process,
-        )
-        .await
-        .map_err(|e| eprintln!("[SAVE_WARN] create_save: 保存剧本状态失败: {}", e));
+    {
+        let gs = service.game_status.lock().await;
+        if let Some(ref script_status) = gs.script_status {
+            let vars_json = serde_json::to_string(&script_status.vars).unwrap_or_default();
+            // 玩家阅读位置（前端上报）：与引擎位置（event_sequence）并存，读档优先据此恢复。
+            // 剧本未开始时为空（init_script 已清），写 None 表示无上报记录，读档回退引擎位置。
+            let player_read_chapter = if gs.player_read_chapter.is_empty() {
+                None
+            } else {
+                Some(gs.player_read_chapter.clone())
+            };
+            let player_read_sequence = if gs.player_read_seq > 0 {
+                Some(gs.player_read_seq)
+            } else {
+                None
+            };
+            let _ = SaveRepo::upsert_running_script(
+                db,
+                save_id,
+                &script_status.folder_key,
+                &vars_json,
+                &script_status.current_chapter_key,
+                script_status.current_event_process,
+                player_read_chapter,
+                player_read_sequence,
+            )
+            .await
+            .map_err(|e| eprintln!("[SAVE_WARN] create_save: 保存剧本状态失败: {}", e));
+        }
     }
 
     Ok(CreateSaveResponse {
@@ -364,18 +381,43 @@ pub async fn load_save(app: AppHandle, save_id: i32) -> Result<WebInitData, Stri
                 .find(|s| s.folder_key == rs.script_folder)
                 .cloned();
             if let Some(mut script) = script {
-                script.current_chapter_key = rs.current_chapter.clone();
-                script.current_event_process = rs.event_sequence;
+                // 优先按「玩家阅读位置」恢复（前端上报，避免从引擎预跑位置续跑导致"跳剧情"）。
+                // 仅当玩家位置所在章节在当前剧本目录中真实存在时采用，否则回退引擎位置
+                // （剧本内容在存档后被修改、或旧档无上报记录的场景）。
+                let chapters_dir = script.script_path.join("Chapters");
+                let chapter_exists = |chapter: &str| -> bool {
+                    let p = if chapter.ends_with(".yaml") {
+                        chapters_dir.join(chapter)
+                    } else {
+                        chapters_dir.join(format!("{}.yaml", chapter))
+                    };
+                    p.exists()
+                };
+                let (restore_chapter, restore_seq) = match rs.player_read_chapter.as_deref() {
+                    Some(ch) if !ch.is_empty() && chapter_exists(ch) => (
+                        rs.player_read_chapter.clone().unwrap_or_default(),
+                        rs.player_read_sequence.unwrap_or(rs.event_sequence),
+                    ),
+                    _ => (rs.current_chapter.clone(), rs.event_sequence),
+                };
+
+                script.current_chapter_key = restore_chapter;
+                script.current_event_process = restore_seq;
                 script.vars = serde_json::from_str(&rs.variable_info).unwrap_or_default();
                 let mut gs = service.game_status.lock().await;
                 gs.script_status = Some(script);
+                // 重置玩家阅读位置暂存：前端续跑后会随 `script:progress` 重新上报
+                gs.player_read_chapter.clear();
+                gs.player_read_seq = 0;
                 // 递增剧本纪元：此后旧剧本任务的收尾（on_script_end）不会清理这份新恢复的状态
                 gs.script_epoch = gs.script_epoch.wrapping_add(1);
                 tracing::info!(
-                    "[LoadSave] 已恢复剧本状态: {} 章节={} 事件={}",
+                    "[LoadSave] 已恢复剧本状态: {} 章节={} 事件={}（玩家位置: 章节={:?} 事件={:?}）",
                     rs.script_folder,
                     rs.current_chapter,
-                    rs.event_sequence
+                    rs.event_sequence,
+                    rs.player_read_chapter,
+                    rs.player_read_sequence
                 );
             } else {
                 tracing::warn!(
@@ -444,18 +486,34 @@ pub async fn update_save(
         .map_err(|e| format!("保存记忆库失败: {}", e))?;
 
     // 6. 持久化剧本状态
-    if let Some(ref script_status) = service.game_status.lock().await.script_status {
-        let vars_json = serde_json::to_string(&script_status.vars).unwrap_or_default();
-        let _ = SaveRepo::upsert_running_script(
-            db,
-            save_id,
-            &script_status.folder_key,
-            &vars_json,
-            &script_status.current_chapter_key,
-            script_status.current_event_process,
-        )
-        .await
-        .map_err(|e| eprintln!("[SAVE_WARN] update_save: 保存剧本状态失败: {}", e));
+    {
+        let gs = service.game_status.lock().await;
+        if let Some(ref script_status) = gs.script_status {
+            let vars_json = serde_json::to_string(&script_status.vars).unwrap_or_default();
+            // 玩家阅读位置（前端上报）：与引擎位置并存，读档优先据此恢复
+            let player_read_chapter = if gs.player_read_chapter.is_empty() {
+                None
+            } else {
+                Some(gs.player_read_chapter.clone())
+            };
+            let player_read_sequence = if gs.player_read_seq > 0 {
+                Some(gs.player_read_seq)
+            } else {
+                None
+            };
+            let _ = SaveRepo::upsert_running_script(
+                db,
+                save_id,
+                &script_status.folder_key,
+                &vars_json,
+                &script_status.current_chapter_key,
+                script_status.current_event_process,
+                player_read_chapter,
+                player_read_sequence,
+            )
+            .await
+            .map_err(|e| eprintln!("[SAVE_WARN] update_save: 保存剧本状态失败: {}", e));
+        }
     }
 
     Ok(())

--- a/src-tauri/src/api/script.rs
+++ b/src-tauri/src/api/script.rs
@@ -236,3 +236,38 @@ pub async fn update_player_read_position(
     gs.player_read_seq = seq.max(0);
     Ok(())
 }
+
+/// 中止当前正在运行的剧本任务并复位运行标记（前端退出剧本模式时调用）。
+///
+/// 剧本的 AI 对话事件在 LLM 调用失败时会**持续重试不终止**（玩家不能被踢出剧本）；
+/// 若玩家主动退出剧本而后台任务仍在跑（is_running 仍为 true），不中止会导致
+/// 之后无法再次启动剧本（CAS 守卫拒绝）。abort 不走 on_script_end，
+/// 此处显式清理输入/选择/继续通道与剧本状态。
+#[tauri::command]
+pub async fn stop_script(app: AppHandle) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let mut service = state.ai_service.lock().await;
+
+    let handle = {
+        let mut current = service.script_manager.current_run.lock().await;
+        current.take()
+    };
+    if let Some(handle) = handle {
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    let mut ch = state.script_channels.lock().await;
+    ch.input_tx = None;
+    ch.choice_tx = None;
+    ch.continue_tx = None;
+    ch.choice_allow_free = false;
+    drop(ch);
+
+    service
+        .script_manager
+        .is_running
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+    service.game_status.lock().await.script_status = None;
+    Ok(())
+}

--- a/src-tauri/src/api/script.rs
+++ b/src-tauri/src/api/script.rs
@@ -203,6 +203,19 @@ pub async fn script_submit_choice(app: AppHandle, choice: String) -> Result<(), 
     }
 }
 
+/// 前端告知剧本引擎：当前事件已展示完毕、玩家已点击「继续」。
+/// 旁白/主人公/立绘等「阅读型事件」会在此通道上等待，实现引擎与玩家阅读同步推进
+/// （台词写入与玩家实际阅读对齐，存档不捕获超前剧情）。前端在每条消息点「继续」时调用。
+#[tauri::command]
+pub async fn script_event_continue(app: AppHandle) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let mut channels = state.script_channels.lock().await;
+    if let Some(tx) = channels.continue_tx.take() {
+        let _ = tx.send(());
+    }
+    Ok(())
+}
+
 /// 前端上报「玩家阅读位置」（章节 key + 事件序号）。
 ///
 /// 剧本引擎预跑，存档记录的是引擎执行位置（可能超前于玩家实际读到的地方）；

--- a/src-tauri/src/api/script.rs
+++ b/src-tauri/src/api/script.rs
@@ -110,6 +110,11 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
         return Err(format!("已有剧本正在运行，忽略重复启动请求: '{}'", script_name));
     }
 
+    // 为句柄登记块另留一份 ai_service 引用：`ai_service` 即将被 async move 闭包
+    // 整体移入；`state` 借用 `app`，若活到 `app` 移入之后会触发 E0505。
+    // 故登记块只能用这份克隆，不再触碰 `state`/`ai_service`。
+    let ai_service_register = state.ai_service.clone();
+
     // Run script in background task (does NOT hold AIService lock across awaits)
     let handle = tokio::spawn(async move {
         let mut ctx = ScriptContext {
@@ -146,10 +151,8 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
     });
 
     // 登记当前运行句柄：读档等场景需要「掐断旧任务」时据此 abort 并等待收尾。
-    // 注意不能复用上面的 `ai_service`：它已被 async move 闭包整体移入，
-    // 这里用 `state` 重新取引用（AppHandle 仍可访问）。
     {
-        let service = state.ai_service.lock().await;
+        let service = ai_service_register.lock().await;
         *service.script_manager.current_run.lock().await = Some(handle);
     }
 

--- a/src-tauri/src/api/script.rs
+++ b/src-tauri/src/api/script.rs
@@ -197,3 +197,22 @@ pub async fn script_submit_choice(app: AppHandle, choice: String) -> Result<(), 
         Err("当前没有等待选择的脚本事件".to_string())
     }
 }
+
+/// 前端上报「玩家阅读位置」（章节 key + 事件序号）。
+///
+/// 剧本引擎预跑，存档记录的是引擎执行位置（可能超前于玩家实际读到的地方）；
+/// 玩家在读到每条消息时经 `script:progress` 拿到其事件序号，读档前把当前阅读位置
+/// 上报到这里暂存，手动/自动存档时写入 `running_script.player_read_*`，
+/// 读档据此从玩家阅读点续跑，而不是从引擎位置（避免"跳剧情"）。
+#[tauri::command]
+pub async fn update_player_read_position(
+    app: AppHandle,
+    chapter: String,
+    seq: i32,
+) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    let mut gs = state.ai_service.lock().await.game_status.lock().await;
+    gs.player_read_chapter = chapter;
+    gs.player_read_seq = seq.max(0);
+    Ok(())
+}

--- a/src-tauri/src/api/script.rs
+++ b/src-tauri/src/api/script.rs
@@ -7,6 +7,7 @@ use crate::ai_service::game_system::script_engine::events::ScriptContext;
 use crate::ai_service::game_system::script_engine::ScriptManager;
 use crate::AppState;
 use serde::Serialize;
+use std::sync::atomic::Ordering;
 use tauri::{AppHandle, Manager};
 
 // ============================================================
@@ -98,8 +99,19 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
         (script, game_status, config, is_running)
     };
 
+    // 单剧本同时运行保护（原子 CAS）：引擎同一时刻只支持一个剧本任务。
+    // 双任务会互相顶掉输入/选项通道，导致「用户输入通道已关闭」与事件进度错乱。
+    // 读档续跑已在 load_save 中掐断旧任务；此守卫兜底其他路径的重复启动。
+    // 忙时返回明确错误而非静默忽略，前端据此可靠重试。
+    if is_running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err(format!("已有剧本正在运行，忽略重复启动请求: '{}'", script_name));
+    }
+
     // Run script in background task (does NOT hold AIService lock across awaits)
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         let mut ctx = ScriptContext {
             db: &db,
             data_dir: &data_dir,
@@ -109,6 +121,7 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
             llm: llm.as_ref(),
             channels,
             is_preview: false,
+            run_epoch: crate::ai_service::game_system::script_engine::script_manager::next_script_epoch(),
         };
 
         match ScriptManager::execute_script(&script, &mut ctx, &is_running).await {
@@ -131,6 +144,12 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
             Err(e) => tracing::error!("[ScriptAPI] 剧本执行错误: {}", e),
         }
     });
+
+    // 登记当前运行句柄：读档等场景需要「掐断旧任务」时据此 abort 并等待收尾。
+    {
+        let service = ai_service.lock().await;
+        *service.script_manager.current_run.lock().await = Some(handle);
+    }
 
     Ok(())
 }

--- a/src-tauri/src/api/script.rs
+++ b/src-tauri/src/api/script.rs
@@ -146,8 +146,10 @@ pub async fn start_script(app: AppHandle, script_name: String) -> Result<(), Str
     });
 
     // 登记当前运行句柄：读档等场景需要「掐断旧任务」时据此 abort 并等待收尾。
+    // 注意不能复用上面的 `ai_service`：它已被 async move 闭包整体移入，
+    // 这里用 `state` 重新取引用（AppHandle 仍可访问）。
     {
-        let service = ai_service.lock().await;
+        let service = state.ai_service.lock().await;
         *service.script_manager.current_run.lock().await = Some(handle);
     }
 
@@ -211,7 +213,9 @@ pub async fn update_player_read_position(
     seq: i32,
 ) -> Result<(), String> {
     let state = app.state::<AppState>();
-    let mut gs = state.ai_service.lock().await.game_status.lock().await;
+    // 链式 lock 会产生被提前释放的临时 guard（E0716），先绑定 service 再取 game_status
+    let service = state.ai_service.lock().await;
+    let mut gs = service.game_status.lock().await;
     gs.player_read_chapter = chapter;
     gs.player_read_seq = seq.max(0);
     Ok(())

--- a/src-tauri/src/api/script_editor/commands.rs
+++ b/src-tauri/src/api/script_editor/commands.rs
@@ -1466,6 +1466,7 @@ pub async fn editor_start_preview(
             channels,
             // 试玩产出标记：ai:reply 会带 preview_gen，前端据此丢弃迟到的流式回复
             is_preview: true,
+            run_epoch: crate::ai_service::game_system::script_engine::script_manager::next_script_epoch(),
         };
         use crate::ai_service::game_system::script_engine::ScriptManager;
 

--- a/src-tauri/src/api/script_editor/commands.rs
+++ b/src-tauri/src/api/script_editor/commands.rs
@@ -1910,6 +1910,9 @@ pub async fn editor_stop_preview(app: AppHandle) -> Result<(), String> {
         if let Some(tx) = ch.input_tx.take() {
             let _ = tx.send(String::new());
         }
+        // 清掉旁白等「阅读型事件」的继续回执通道：试玩中止时若引擎正等在
+        // continue_tx 上，不清理会一直挂到 10 分钟超时兜底。
+        ch.continue_tx = None;
         ch.choice_allow_free = false;
     }
 

--- a/src-tauri/src/db/entities/running_script.rs
+++ b/src-tauri/src/db/entities/running_script.rs
@@ -11,6 +11,10 @@ pub struct Model {
     pub variable_info: String,
     pub current_chapter: String,
     pub event_sequence: i32,
+    /// 玩家阅读位置——章节 key（前端上报，读档优先据此恢复；NULL = 无上报记录）
+    pub player_read_chapter: Option<String>,
+    /// 玩家阅读位置——事件序号（前端上报，读档优先据此恢复；NULL = 无上报记录）
+    pub player_read_sequence: Option<i32>,
     pub save_id: i32,
 }
 

--- a/src-tauri/src/db/managers/save_repo.rs
+++ b/src-tauri/src/db/managers/save_repo.rs
@@ -488,6 +488,8 @@ impl SaveRepo {
         variable_info: &str,
         current_chapter: &str,
         event_sequence: i32,
+        player_read_chapter: Option<String>,
+        player_read_sequence: Option<i32>,
     ) -> Result<i32> {
         // Check if save already has a running_script
         let save_model = Self::get_save_by_id(db, save_id)
@@ -506,6 +508,8 @@ impl SaveRepo {
                 active.variable_info = Set(variable_info.to_string());
                 active.current_chapter = Set(current_chapter.to_string());
                 active.event_sequence = Set(event_sequence);
+                active.player_read_chapter = Set(player_read_chapter);
+                active.player_read_sequence = Set(player_read_sequence);
                 active.update(db).await.map_err(|e| anyhow!("{e}"))?;
                 return Ok(existing_id);
             }
@@ -517,6 +521,8 @@ impl SaveRepo {
             variable_info: Set(variable_info.to_string()),
             current_chapter: Set(current_chapter.to_string()),
             event_sequence: Set(event_sequence),
+            player_read_chapter: Set(player_read_chapter),
+            player_read_sequence: Set(player_read_sequence),
             save_id: Set(save_id),
             ..Default::default()
         };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -675,6 +675,7 @@ pub fn run() {
             api::script::start_script,
             api::script::script_submit_input,
             api::script::script_submit_choice,
+            api::script::script_event_continue,
             api::script::update_player_read_position,
             // ── 剧本编辑器 ──
             api::script_editor::editor_get_schema,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -677,6 +677,7 @@ pub fn run() {
             api::script::script_submit_choice,
             api::script::script_event_continue,
             api::script::update_player_read_position,
+            api::script::stop_script,
             // ── 剧本编辑器 ──
             api::script_editor::editor_get_schema,
             api::script_editor::editor_list_scripts,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -675,6 +675,7 @@ pub fn run() {
             api::script::start_script,
             api::script::script_submit_input,
             api::script::script_submit_choice,
+            api::script::update_player_read_position,
             // ── 剧本编辑器 ──
             api::script_editor::editor_get_schema,
             api::script_editor::editor_list_scripts,

--- a/src-tauri/src/migration/m20260818_000001_add_player_read_sequence.rs
+++ b/src-tauri/src/migration/m20260818_000001_add_player_read_sequence.rs
@@ -1,0 +1,90 @@
+use sea_orm::Statement;
+use sea_orm_migration::prelude::*;
+
+/// 为 running_script 增加「玩家阅读位置」两列。
+///
+/// 背景：剧本引擎预跑，存档记录的是**引擎执行位置**（event_sequence），可能超前于
+/// 玩家实际阅读到的位置；读档从引擎位置续跑会让玩家觉得"跳剧情"。前端在玩家读到
+/// 每条消息时上报「玩家阅读位置」（章节 + 事件序号），存到这两列，读档优先据此恢复。
+///
+/// 稳定性说明：只加可空列，SQLite 元数据级操作，不动已有行/索引；旧库升级后旧行
+/// 两列自动为 NULL，读档时回退到引擎位置，行为不变。
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // 防御性预检：SQLite 的 ADD COLUMN 没有 IF NOT EXISTS 语法，先查
+        // pragma_table_info 确认列不存在再执行，防重复执行时报「duplicate column」。
+        let existing: Vec<String> = manager
+            .get_connection()
+            .query_all(Statement::from_string(
+                manager.get_database_backend(),
+                "SELECT name FROM pragma_table_info('running_script')".to_string(),
+            ))
+            .await?
+            .into_iter()
+            .map(|row| {
+                row.try_get_by_index::<String>(0)
+                    .unwrap_or_else(|_| String::new())
+            })
+            .collect();
+
+        if !existing.iter().any(|c| c == "player_read_chapter") {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(RunningScript::Table)
+                        .add_column(
+                            ColumnDef::new(RunningScript::PlayerReadChapter)
+                                .string()
+                                .null(),
+                        )
+                        .to_owned(),
+                )
+                .await?;
+        }
+        if !existing.iter().any(|c| c == "player_read_sequence") {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(RunningScript::Table)
+                        .add_column(
+                            ColumnDef::new(RunningScript::PlayerReadSequence)
+                                .integer()
+                                .null(),
+                        )
+                        .to_owned(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(RunningScript::Table)
+                    .drop_column(RunningScript::PlayerReadChapter)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(RunningScript::Table)
+                    .drop_column(RunningScript::PlayerReadSequence)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum RunningScript {
+    Table,
+    PlayerReadChapter,
+    PlayerReadSequence,
+}

--- a/src-tauri/src/migration/mod.rs
+++ b/src-tauri/src/migration/mod.rs
@@ -13,6 +13,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260807_000001_add_skill_agent_reasoning::Migration),
             Box::new(m20260814_000001_add_skill_agent_token_usage::Migration),
             Box::new(m20260815_000001_add_skill_agent_cached_tokens::Migration),
+            Box::new(m20260818_000001_add_player_read_sequence::Migration),
         ]
     }
 }
@@ -24,3 +25,4 @@ pub mod m20260803_000001_create_skill_agent_tables;
 pub mod m20260807_000001_add_skill_agent_reasoning;
 pub mod m20260814_000001_add_skill_agent_token_usage;
 pub mod m20260815_000001_add_skill_agent_cached_tokens;
+pub mod m20260818_000001_add_player_read_sequence;

--- a/src/api/services/game-info.ts
+++ b/src/api/services/game-info.ts
@@ -64,6 +64,8 @@ export interface WebInitData {
   last_bgm_mode?: string | null
   /** 上次会话环境音轨道（JSON 字符串） */
   last_ambient_tracks?: string | null
+  /** 当前进行中的剧本 folder_key（读档恢复剧本时，前端据此进入剧情模式并续跑） */
+  active_script?: string | null
 }
 
 /**

--- a/src/api/tauri-events.ts
+++ b/src/api/tauri-events.ts
@@ -368,6 +368,18 @@ export function initializeTauriEventListeners() {
     } as ScriptEventType)
   })
 
+  // LLM 生成失败、等待玩家点击「继续」重试（AI 对话自动重试耗尽后广播）。
+  // 入队消费：玩家点击继续 → continue() 里的 script_event_continue 回执给引擎。
+  listen('script:llm-retry', (event) => {
+    const p = event.payload as { message?: string }
+    console.log('[Tauri] script:llm-retry', event.payload)
+    eventQueue.addEvent({
+      type: 'retry',
+      duration: 0,
+      message: p.message ?? '',
+    } as ScriptEventType)
+  })
+
   // === God Agent multi-dialogue event ===
 
   listen('character:switch', async (event) => {

--- a/src/api/tauri-events.ts
+++ b/src/api/tauri-events.ts
@@ -355,6 +355,19 @@ export function initializeTauriEventListeners() {
     eventQueue.addEvent(asEvent(event.payload, { type: 'free_dialogue', defaultDuration: 0 }))
   })
 
+  // 剧本事件进度：引擎每实际执行一个事件前广播（章节 key + 事件序号）。
+  // 必须入队（而非独立监听直接改 store），保证与其后的内容事件保序消费——
+  // 这样「玩家阅读位置」记录的是真正展示给玩家的那条内容，而不是引擎预跑到的位置。
+  listen('script:progress', (event) => {
+    const p = event.payload as { chapter?: string; seq?: number }
+    eventQueue.addEvent({
+      type: 'progress',
+      duration: 0,
+      chapter: p.chapter ?? '',
+      seq: typeof p.seq === 'number' ? p.seq : 0,
+    } as ScriptEventType)
+  })
+
   // === God Agent multi-dialogue event ===
 
   listen('character:switch', async (event) => {

--- a/src/components/game/standard/extra/ScriptCompleteDisplay.vue
+++ b/src/components/game/standard/extra/ScriptCompleteDisplay.vue
@@ -94,8 +94,10 @@ const completedScriptName = ref('')
 watch(
   () => gameStore.runningScript,
   (newVal, oldVal) => {
-    // 从有剧本变成无剧本时触发
-    if (!newVal && oldVal) {
+    // 仅当「剧本正常完成」（script:end completed=true，scriptEndCompleted 已置位）
+    // 且 runningScript 从有变无时触发——读档续跑失败、手动退出等非完成路径
+    // 不会误显示「本次剧本已完成」。
+    if (!newVal && oldVal && gameStore.scriptEndCompleted) {
       // 提取剧本名称，根据你的数据结构调整
       completedScriptName.value = oldVal.scriptName || 'Unknown Script'
 

--- a/src/components/settings/pages/SettingsSave.vue
+++ b/src/components/settings/pages/SettingsSave.vue
@@ -255,6 +255,14 @@ const handleCreateSave = async () => {
   }
   actionLoading.value = -1
   try {
+    // 手动存档前兜底上报玩家阅读位置（正常路径已随内容展示实时上报，
+    // 这里覆盖「刚读到一行就立刻进设置页存档」的竞态窗口）
+    if (gameStore.displayedSeq > 0) {
+      await invoke('update_player_read_position', {
+        chapter: gameStore.displayedChapter,
+        seq: gameStore.displayedSeq,
+      }).catch(() => {})
+    }
     await invoke<CreateSaveResponse>('create_save', {
       title: newSaveTitle.value.trim(),
       screenshotPath: await ensureScreenshot(),

--- a/src/components/settings/pages/SettingsSave.vue
+++ b/src/components/settings/pages/SettingsSave.vue
@@ -137,6 +137,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import { MenuPage, MenuItem } from '../../ui'
 import { Input } from '../../base'
 import { useGameStore } from '../../../stores/modules/game'
@@ -161,6 +162,7 @@ interface CreateSaveResponse {
 const gameStore = useGameStore()
 const uiStore = useUIStore()
 const dialogStore = useDialogStore()
+const router = useRouter()
 const { t } = useI18n()
 
 const saves = ref<SaveInfo[]>([])
@@ -278,6 +280,27 @@ const handleLoadSave = async (saveId: number) => {
   try {
     const gameInfo = await invoke<WebInitData>('load_save', { saveId })
     applyWebInitData(gameStore.$state, gameInfo)
+    // 读档成功后直接进入对话页（原来卡在设置页，官方 PR #555 的修复方向）
+    uiStore.showSettings = false
+    await router.push('/chat')
+    // 若存档处于剧本进行中，自动进入剧情模式并从存档点续跑剧本。
+    // 后端单实例保护：load_save 已中止旧任务，若其仍在收尾，start_script 会返回明确错误，
+    // 这里短暂重试直到成功启动（避免读档后剧本静默不跑）。
+    if (gameInfo.active_script) {
+      gameStore.enterStoryMode(gameInfo.active_script)
+      let started = false
+      for (let attempt = 0; attempt < 15; attempt++) {
+        try {
+          await invoke('start_script', { scriptName: gameInfo.active_script })
+          started = true
+          break
+        } catch (err) {
+          await new Promise((r) => setTimeout(r, 1000))
+          if (attempt >= 14) console.error('续跑剧本失败：多次尝试后仍无法启动', err)
+        }
+      }
+      console.log('[LoadSave] 读档续跑剧本:', gameInfo.active_script, '启动成功:', started)
+    }
     uiStore.showSuccess({ title: t('settings.save.msg.loadSuccessTitle'), message: t('settings.save.msg.loadSuccessMsg') })
   } catch (e: any) {
     console.error('读取存档失败:', e)

--- a/src/components/settings/pages/SettingsSave.vue
+++ b/src/components/settings/pages/SettingsSave.vue
@@ -307,14 +307,33 @@ const handleLoadSave = async (saveId: number) => {
     // 未完成（罕见）时短重试，避免长时间空白。
     if (gameInfo.active_script) {
       gameStore.enterStoryMode(gameInfo.active_script)
+      // 过渡态置为「等待内容」：eventQueue.clear() 会把 currentStatus 复位成 'input'，
+      // 若续跑的第一条内容事件（narration/player/input…）未及时到达，输入框会误现，
+      // 此时提交会报「当前没有等待输入的脚本事件」。先置 responding，等引擎事件按序覆盖。
+      gameStore.currentStatus = 'responding'
+      let started = false
       for (let attempt = 0; attempt < 5; attempt++) {
         try {
           await invoke('start_script', { scriptName: gameInfo.active_script })
+          started = true
           break
         } catch (err) {
           if (attempt < 4) await new Promise((r) => setTimeout(r, 500))
-          else console.error('续跑剧本失败：多次尝试后仍无法启动', err)
+          else {
+            console.error('续跑剧本失败：多次尝试后仍无法启动', err)
+            uiStore.showError({
+              title: t('settings.save.msg.loadFailTitle'),
+              message:
+                (typeof err === 'string' ? err : (err as any)?.message) ||
+                t('settings.save.msg.unknownError'),
+            })
+          }
         }
+      }
+      if (!started) {
+        // 续跑失败：退出剧本模式回到自由对话，避免停在"半剧本"假死界面
+        gameStore.exitStoryMode()
+        gameStore.currentStatus = 'input'
       }
     }
 

--- a/src/components/settings/pages/SettingsSave.vue
+++ b/src/components/settings/pages/SettingsSave.vue
@@ -145,6 +145,7 @@ import { applyWebInitData } from '../../../stores/modules/game/actions'
 import { useUIStore } from '../../../stores/modules/ui/ui'
 import { useDialogStore } from '../../../stores/modules/ui/dialog'
 import { invoke, convertFileSrc } from '@tauri-apps/api/core'
+import { eventQueue } from '@/core/events/event-queue'
 import type { SaveInfo } from '../../../types'
 import type { WebInitData } from '../../../api/services/game-info'
 import { Save as SaveIcon, PencilLine, LayoutList, Clock } from 'lucide-vue-next'
@@ -288,28 +289,38 @@ const handleLoadSave = async (saveId: number) => {
   try {
     const gameInfo = await invoke<WebInitData>('load_save', { saveId })
     applyWebInitData(gameStore.$state, gameInfo)
+    // 读档本身已成功：先给反馈，不因后续续跑启动（慢/重试）卡住 toast。
+    uiStore.showSuccess({ title: t('settings.save.msg.loadSuccessTitle'), message: t('settings.save.msg.loadSuccessMsg') })
+
+    // 关键：清空事件队列，丢弃旧剧本任务预跑遗留的事件（narration/ai:reply 等）。
+    // 读档前旧任务在后台预跑，其事件已进入队列；不清空会漏进新会话的历史/位置，
+    // 造成「历史出现超前内容」「读档后越读越靠后」「输入通道报错」。
+    // clear 会把 paused 置 true，稍后由本函数显式 resume（/chat 已挂载时不会重触发 MainChat 的 resume）。
+    eventQueue.clear()
+
     // 读档成功后直接进入对话页（原来卡在设置页，官方 PR #555 的修复方向）
     uiStore.showSettings = false
     await router.push('/chat')
+
     // 若存档处于剧本进行中，自动进入剧情模式并从存档点续跑剧本。
-    // 后端单实例保护：load_save 已中止旧任务，若其仍在收尾，start_script 会返回明确错误，
-    // 这里短暂重试直到成功启动（避免读档后剧本静默不跑）。
+    // load_save 已中止旧任务并复位 is_running，一次启动通常成功；仅旧任务收尾
+    // 未完成（罕见）时短重试，避免长时间空白。
     if (gameInfo.active_script) {
       gameStore.enterStoryMode(gameInfo.active_script)
-      let started = false
-      for (let attempt = 0; attempt < 15; attempt++) {
+      for (let attempt = 0; attempt < 5; attempt++) {
         try {
           await invoke('start_script', { scriptName: gameInfo.active_script })
-          started = true
           break
         } catch (err) {
-          await new Promise((r) => setTimeout(r, 1000))
-          if (attempt >= 14) console.error('续跑剧本失败：多次尝试后仍无法启动', err)
+          if (attempt < 4) await new Promise((r) => setTimeout(r, 500))
+          else console.error('续跑剧本失败：多次尝试后仍无法启动', err)
         }
       }
-      console.log('[LoadSave] 读档续跑剧本:', gameInfo.active_script, '启动成功:', started)
     }
-    uiStore.showSuccess({ title: t('settings.save.msg.loadSuccessTitle'), message: t('settings.save.msg.loadSuccessMsg') })
+
+    // 恢复事件队列消费（clear 把 paused 置 true；MainChat 若已挂载不会重触发 resume，
+    // 这里显式恢复，让续跑后的新剧本事件按序展示）。
+    eventQueue.resume()
   } catch (e: any) {
     console.error('读取存档失败:', e)
     uiStore.showError({

--- a/src/core/events/event-queue.ts
+++ b/src/core/events/event-queue.ts
@@ -123,6 +123,11 @@ export class EventQueue {
       this.currentResolve = null
     }
 
+    // 通知剧本引擎：当前事件已展示完毕、玩家已继续。引擎在旁白/主人公/立绘等
+    // 阅读型事件上等待此回执，从而让台词写入与玩家阅读同步（引擎与画面锁步，
+    // 避免预跑把超前剧情写进 line_list、存档捕获未读内容）。
+    invoke('script_event_continue').catch((e) => console.warn('script_event_continue 失败:', e))
+
     // 假如当前消息不是最后一个，但是队列事件已经没了
     if (!this.currentEvent?.isFinal && this.queue.length === 0) {
       needWait = true

--- a/src/core/events/event-queue.ts
+++ b/src/core/events/event-queue.ts
@@ -68,7 +68,10 @@ export class EventQueue {
     // 事件队列保序，progress 与其内容事件相邻，故此处读到的 pending 位置正对应当前内容。
     if (PLAYER_READ_EVENT_TYPES.has(event.type)) {
       const gameStore = useGameStore()
-      if (gameStore.pendingScriptSeq > 0) {
+      // 用 pendingChapter 非空表示「收到过 progress」，而非 seq > 0：
+      // 首个内容事件（如剧本第一行旁白）的事件序号就是 0，若按 seq>0 会漏报，
+      // 读档时 player_read 为空只能回退到引擎位置。
+      if (gameStore.pendingChapter) {
         gameStore.displayedChapter = gameStore.pendingChapter
         gameStore.displayedSeq = gameStore.pendingScriptSeq
         invoke('update_player_read_position', {

--- a/src/core/events/event-queue.ts
+++ b/src/core/events/event-queue.ts
@@ -1,6 +1,20 @@
 import type { ScriptEventType } from '../../types'
 import { eventProcessorManager } from './event-processor'
 import { useGameStore } from '../../stores/modules/game'
+import { invoke } from '@tauri-apps/api/core'
+
+// 玩家「真正读到」的内容事件类型：只有这些才推进玩家阅读位置。
+// 背景/音乐/特效等瞬时事件不代表阅读进度（引擎预跑它们时玩家还没看到），
+// 记录它们会让读档位置越过玩家实际读到的内容。
+const PLAYER_READ_EVENT_TYPES = new Set([
+  'narration',
+  'player',
+  'reply',
+  'free_dialogue',
+  'input',
+  'choice',
+  'present_pic',
+])
 
 export class EventQueue {
   private queue: ScriptEventType[] = []
@@ -49,6 +63,21 @@ export class EventQueue {
   }
 
   private async processSingleEvent(event: ScriptEventType): Promise<void> {
+    // 玩家阅读位置：内容事件展示时，用最近一次 script:progress 的（章节 + 序号）
+    // 作为「玩家已读到这」的位置，并上报后端暂存（手动/自动存档时据此写入存档）。
+    // 事件队列保序，progress 与其内容事件相邻，故此处读到的 pending 位置正对应当前内容。
+    if (PLAYER_READ_EVENT_TYPES.has(event.type)) {
+      const gameStore = useGameStore()
+      if (gameStore.pendingScriptSeq > 0) {
+        gameStore.displayedChapter = gameStore.pendingChapter
+        gameStore.displayedSeq = gameStore.pendingScriptSeq
+        invoke('update_player_read_position', {
+          chapter: gameStore.pendingChapter,
+          seq: gameStore.pendingScriptSeq,
+        }).catch((e) => console.warn('update_player_read_position 失败:', e))
+      }
+    }
+
     // 处理事件并等待完成
     await eventProcessorManager.processEvent(event)
 

--- a/src/core/events/processors/error-processor.ts
+++ b/src/core/events/processors/error-processor.ts
@@ -19,8 +19,12 @@ export default class ErrorProcessor implements IEventProcessor {
       errorCode: event.error_code || 'default_error',
     })
 
-    // 重置游戏状态
-    gameStore.currentStatus = 'input'
+    // 重置游戏状态。剧本模式下不拉回 input：LLM 失败后 ai_dialogue 会持续重试，
+    // 后面还有剧本事件按序覆盖状态；提前 input 会让读档/重试场景误现输入框。
+    // 自由对话模式保持原行为（回到可输入状态）。
+    if (!gameStore.runningScript) {
+      gameStore.currentStatus = 'input'
+    }
     gameStore.currentLine = ''
     console.log('游戏状态已重置为: input (由错误处理器触发)')
   }

--- a/src/core/events/processors/progress-processor.ts
+++ b/src/core/events/processors/progress-processor.ts
@@ -1,0 +1,20 @@
+import type { IEventProcessor } from '../event-processor'
+import type { ScriptProgressEvent } from '../../../types'
+import { useGameStore } from '../../../stores/modules/game'
+
+/**
+ * script:progress —— 引擎每实际执行一个事件前广播（章节 key + 事件序号）。
+ * 本处理器在事件队列里与其后的内容事件相邻、保序执行：先更新 pending 位置，
+ * 随后被展示的内容事件（narration/player/dialogue/…）即可据此记录玩家阅读位置。
+ */
+export default class ProgressProcessor implements IEventProcessor {
+  canHandle(eventType: string): boolean {
+    return eventType === 'progress'
+  }
+
+  async processEvent(event: ScriptProgressEvent): Promise<void> {
+    const gameStore = useGameStore()
+    gameStore.pendingChapter = event.chapter
+    gameStore.pendingScriptSeq = event.seq
+  }
+}

--- a/src/core/events/processors/retry-processor.ts
+++ b/src/core/events/processors/retry-processor.ts
@@ -1,0 +1,28 @@
+import type { IEventProcessor } from '../event-processor'
+import type { ScriptRetryEvent } from '../../../types'
+import { useGameStore } from '@/stores/modules/game'
+import { useUIStore } from '@/stores/modules/ui/ui'
+
+/**
+ * script:llm-retry —— AI 对话的 LLM 调用自动重试耗尽后，等待玩家点击「继续」重试。
+ *
+ * 进入「等待继续」状态（responding + 提示文本）：玩家点击继续走 GameDialog 的
+ * 继续按钮 → eventQueue.continue() → script_event_continue 回执给引擎，
+ * 引擎据此重新调用 LLM。不跳过对话、不退出剧本（剧本连续性优先）。
+ */
+export default class RetryProcessor implements IEventProcessor {
+  canHandle(eventType: string): boolean {
+    return eventType === 'retry'
+  }
+
+  async processEvent(event: ScriptRetryEvent): Promise<void> {
+    const gameStore = useGameStore()
+    const uiStore = useUIStore()
+
+    gameStore.currentStatus = 'responding'
+    uiStore.showCharacterLine = event.message || 'AI 响应失败，点击继续重试'
+    uiStore.showCharacterTitle = ''
+    uiStore.showCharacterSubtitle = ''
+    uiStore.showCharacterMotionText = ''
+  }
+}

--- a/src/core/events/processors/script-end-processor.ts
+++ b/src/core/events/processors/script-end-processor.ts
@@ -24,6 +24,9 @@ export default class ScriptEndProcessor implements IEventProcessor {
     }
 
     const gameStore = useGameStore()
+    // 标记「剧本正常完成」：ScriptCompleteDisplay 据此显示 Story Clear。
+    // 失败退出（completed=false）或其他退出路径不置位，避免误显示「本次剧本已完成」。
+    gameStore.scriptEndCompleted = completed
     gameStore.exitStoryMode()
     const uiStore = useUIStore()
     uiStore.showPlayerHintLine = ''

--- a/src/core/events/processors/thinking-processor.ts
+++ b/src/core/events/processors/thinking-processor.ts
@@ -15,8 +15,12 @@ export default class ThinkingProcessor implements IEventProcessor {
       gameStore.currentStatus = 'thinking'
       gameStore.thinkingLength = 0
     } else {
-      // AI 停止思考（通常是错误恢复），重置到可输入状态
-      gameStore.currentStatus = 'input'
+      // AI 停止思考。自由对话模式回到可输入状态；剧本模式下不拉回 'input'：
+      // 后面还有剧本事件（narration/player/input…）会按序覆盖状态，提前回到
+      // input 会让 AI 对话读档/续跑场景误现输入框（玩家名 + 输入框）。
+      if (!gameStore.runningScript) {
+        gameStore.currentStatus = 'input'
+      }
       gameStore.currentLine = ''
       gameStore.thinkingLength = 0
     }

--- a/src/stores/modules/game/actions.ts
+++ b/src/stores/modules/game/actions.ts
@@ -104,6 +104,10 @@ setGameMessages(this: GameState, messages: GameMessage[]) {
     this.pendingChapter = ''
     this.displayedSeq = 0
     this.displayedChapter = ''
+    // 通知后端中止剧本任务：AI 对话失败会持续重试，若不中止后台任务
+    // （is_running 仍 true）会导致无法再次启动剧本。正常结束/读档等场景
+    // 任务已停，此调用为空操作。fire-and-forget，不阻塞 UI。
+    invoke('stop_script').catch((e) => console.warn('stop_script 失败:', e))
   },
 
   // 设置当前场景（仅更新 store，不调用 API）

--- a/src/stores/modules/game/actions.ts
+++ b/src/stores/modules/game/actions.ts
@@ -266,6 +266,9 @@ export function convertInitLines(lines: GameLineInit[]): GameMessage[] {
     (line) =>
       line.attribute !== 'system' &&
       line.attribute !== 'tool' &&
+      // 「系统旁白」：入场问候/换装等系统注入的旁白（display_name 专用标记），
+      // 不作为对话历史展示；真实旁白（narration）display_name 为「旁白」，不受影响。
+      line.display_name !== '系统旁白' &&
       !isPlotPromptLine(line.content ?? ''),
   )
 

--- a/src/stores/modules/game/actions.ts
+++ b/src/stores/modules/game/actions.ts
@@ -84,6 +84,11 @@ setGameMessages(this: GameState, messages: GameMessage[]) {
         endLine: '',
       },
     }
+    // 复位玩家阅读位置：本次运行的阅读位置随 script:progress 重新上报
+    this.pendingScriptSeq = 0
+    this.pendingChapter = ''
+    this.displayedSeq = 0
+    this.displayedChapter = ''
     const uiStore = useUIStore()
     uiStore.bgMusicMode = 'loop-single'
   },
@@ -91,6 +96,12 @@ setGameMessages(this: GameState, messages: GameMessage[]) {
   /** 标记退出剧情模式，回到自由对话模式 */
   exitStoryMode(this: GameState) {
     this.runningScript = null
+    // 复位玩家阅读位置：自由对话期间不产生 script:progress，
+    // 不复位会让 free chat 消息误记到剧本位置
+    this.pendingScriptSeq = 0
+    this.pendingChapter = ''
+    this.displayedSeq = 0
+    this.displayedChapter = ''
   },
 
   // 设置当前场景（仅更新 store，不调用 API）

--- a/src/stores/modules/game/actions.ts
+++ b/src/stores/modules/game/actions.ts
@@ -89,6 +89,8 @@ setGameMessages(this: GameState, messages: GameMessage[]) {
     this.pendingChapter = ''
     this.displayedSeq = 0
     this.displayedChapter = ''
+    // 复位「剧本正常完成」标志：每次进入剧本，上一轮是否完成的记录作废
+    this.scriptEndCompleted = false
     const uiStore = useUIStore()
     uiStore.bgMusicMode = 'loop-single'
   },

--- a/src/stores/modules/game/actions.ts
+++ b/src/stores/modules/game/actions.ts
@@ -6,6 +6,7 @@ import { getRoleInfo } from '../../../api/services/character'
 import { useUIStore } from '../ui/ui'
 import { useSettingsStore } from '../settings'
 import type { SceneInfo } from '@/api/services/scene'
+import { cleanLineContent, isPlotPromptLine } from '../../../utils/scriptText'
 import { invoke } from '@tauri-apps/api/core'
 
 export const actions = {
@@ -248,10 +249,15 @@ export function applyWebInitData(state: GameState, gameInfo: WebInitData): void 
 
 /** 将 Rust GameLineInit 转换为前端 GameMessage 列表 */
 export function convertInitLines(lines: GameLineInit[]): GameMessage[] {
-  const filtered = lines.filter((line) => line.attribute !== 'system' && line.attribute !== 'tool')
+  const filtered = lines.filter(
+    (line) =>
+      line.attribute !== 'system' &&
+      line.attribute !== 'tool' &&
+      !isPlotPromptLine(line.content ?? ''),
+  )
 
   return filtered.map((line, index, array) => {
-    const filteredContent = line.content.replace(/\{[\s\S]*?\}/g, '').trim()
+    const filteredContent = cleanLineContent(line.content ?? '')
 
     const isLast = index === array.length - 1
     const nextLine = isLast ? null : array[index + 1]

--- a/src/stores/modules/game/state.ts
+++ b/src/stores/modules/game/state.ts
@@ -77,6 +77,15 @@ export interface GameState {
   currentScene: SceneInfo | null // 当前加载的场景
   command: string | null
 
+  /** 最近一次 script:progress 广播的事件序号（其后的内容事件即对应此序号，瞬态不持久化） */
+  pendingScriptSeq: number
+  /** 最近一次 script:progress 广播的章节 key（瞬态不持久化） */
+  pendingChapter: string
+  /** 玩家最近「已展示」的剧本事件序号：读档时上报给后端，作为玩家阅读位置（瞬态不持久化） */
+  displayedSeq: number
+  /** 玩家最近「已展示」的章节 key（瞬态不持久化） */
+  displayedChapter: string
+
   initialized: boolean
   latestScreenshot: string | null
   /** 正在进行的截图 Promise，供 save handler 等待 */
@@ -100,6 +109,11 @@ export const state: GameState = {
   dialogHistory: [],
   currentScene: null,
   command: null,
+
+  pendingScriptSeq: 0,
+  pendingChapter: '',
+  displayedSeq: 0,
+  displayedChapter: '',
 
   initialized: false,
   latestScreenshot: null,

--- a/src/stores/modules/game/state.ts
+++ b/src/stores/modules/game/state.ts
@@ -85,6 +85,9 @@ export interface GameState {
   displayedSeq: number
   /** 玩家最近「已展示」的章节 key（瞬态不持久化） */
   displayedChapter: string
+  /** 剧本是否正常完成（script:end 的 completed=true）：供「剧本已完成」提示判断。
+   *  读档续跑失败/手动退出等「非完成退出」不置位，避免误显示 Story Clear（瞬态不持久化） */
+  scriptEndCompleted: boolean
 
   initialized: boolean
   latestScreenshot: string | null
@@ -114,6 +117,7 @@ export const state: GameState = {
   pendingChapter: '',
   displayedSeq: 0,
   displayedChapter: '',
+  scriptEndCompleted: false,
 
   initialized: false,
   latestScreenshot: null,

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -148,6 +148,13 @@ export interface ScriptProgressEvent extends ScriptEvent {
   seq: number
 }
 
+/** LLM 生成失败、等待玩家点击「继续」重试（script:llm-retry）。 */
+export interface ScriptRetryEvent extends ScriptEvent {
+  type: 'retry'
+  /** 展示给玩家的提示文案 */
+  message?: string
+}
+
 export type ScriptEventType =
   | ScriptNarrationEvent
   | ScriptDialogueEvent
@@ -168,3 +175,4 @@ export type ScriptEventType =
   | ScriptPresentPicEvent
   | ScriptFreeDialogueEvent
   | ScriptProgressEvent
+  | ScriptRetryEvent

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -138,6 +138,16 @@ export interface ScriptStatusResetEvent extends ScriptEvent {
   status?: string
 }
 
+/** 剧本事件进度广播：引擎实际执行每个事件前推送（章节 key + 事件序号）。
+ *  前端在事件队列里与其后的内容事件相邻、保序消费，据此记录「玩家阅读位置」。 */
+export interface ScriptProgressEvent extends ScriptEvent {
+  type: 'progress'
+  /** 当前章节 key（YAML 文件名，如 "main" / "Intro/intro"） */
+  chapter: string
+  /** 事件在章节事件数组中的序号 */
+  seq: number
+}
+
 export type ScriptEventType =
   | ScriptNarrationEvent
   | ScriptDialogueEvent
@@ -157,3 +167,4 @@ export type ScriptEventType =
   | ScriptChoiceEvent
   | ScriptPresentPicEvent
   | ScriptFreeDialogueEvent
+  | ScriptProgressEvent

--- a/src/utils/function.ts
+++ b/src/utils/function.ts
@@ -1,19 +1,24 @@
 import type { GameLine } from '@/api/services/history'
 import type { GameMessage } from '@/stores/modules/game/state'
+import { cleanLineContent, isPlotPromptLine } from './scriptText'
 
 export const convertToGameMessages = (lines: GameLine[]): GameMessage[] => {
-  // 先过滤掉 SYSTEM 类型的消息（虽然后端已经过滤了，但再加一层保障）
-  const filteredLines = lines.filter((line) => line.attribute !== 'SYSTEM' && line.attribute !== 'system' && line.attribute !== 'tool' && line.attribute !== 'TOOL')
+  // 先过滤掉 SYSTEM / TOOL 类型的消息（虽然后端已经过滤了，但再加一层保障）
+  const filteredLines = lines.filter(
+    (line) =>
+      line.attribute !== 'SYSTEM' &&
+      line.attribute !== 'system' &&
+      line.attribute !== 'tool' &&
+      line.attribute !== 'TOOL' &&
+      !isPlotPromptLine(line.content ?? ''),
+  )
 
   return filteredLines.map((line, index, array) => {
-    const filteredContent = line.content
-      .replace(/\{[\s\S]*?\}/g, '') // 删除所有 {...} 内容（包括换行）
-      .trim()
+    const filteredContent = cleanLineContent(line.content ?? '')
 
     const isLastMessage = index === array.length - 1
     const nextLine = isLastMessage ? null : array[index + 1]
 
-    console.log('line.attribute', line.attribute)
     let isFinal = false
     if (line.attribute === 'assistant') {
       if (isLastMessage || nextLine?.attribute === 'user') {

--- a/src/utils/function.ts
+++ b/src/utils/function.ts
@@ -10,6 +10,8 @@ export const convertToGameMessages = (lines: GameLine[]): GameMessage[] => {
       line.attribute !== 'system' &&
       line.attribute !== 'tool' &&
       line.attribute !== 'TOOL' &&
+      // 「系统旁白」：入场问候/换装等系统注入旁白，不作为对话历史展示
+      line.display_name !== '系统旁白' &&
       !isPlotPromptLine(line.content ?? ''),
   )
 

--- a/src/utils/scriptText.ts
+++ b/src/utils/scriptText.ts
@@ -1,0 +1,24 @@
+/**
+ * 剧本台词正文清理工具（共享）。
+ *
+ * 剧本引擎把旁白整行存储为 `{旁白: ...}`（剧情演绎提示为 `{旁白: （接下来的剧情演绎提示：...）}`）。
+ * 直接 `replace(/\{[\s\S]*?\}/g, '')` 会把整行旁白连正文一起删掉，导致读档/历史里旁白显示为空白。
+ * 这里统一处理：整行旁白包裹时去掉外层保留正文，仅剥离内联 `{..}` 块；剧情演绎提示行整行过滤。
+ */
+
+/** 清理台词正文：整行 `{旁白: ...}` 包裹时去掉外层包裹保留正文；否则剥离内联 `{..}` 块。 */
+export function cleanLineContent(raw: string): string {
+  if (raw.startsWith('{旁白:') && raw.endsWith('}')) {
+    return raw.slice('{旁白:'.length, -1).trim()
+  }
+  return raw.replace(/\{[\s\S]*?\}/g, '').trim()
+}
+
+/** 是否为 AI 剧情演绎提示行（剧本内嵌 prompt，实玩时也不显示，读档历史保持一致） */
+export function isPlotPromptLine(raw: string): boolean {
+  if (raw.startsWith('{旁白:') && raw.endsWith('}')) {
+    const inner = raw.slice('{旁白:'.length, -1).trim()
+    return inner.startsWith('（接下来的剧情演绎提示')
+  }
+  return false
+}

--- a/src/utils/scriptText.ts
+++ b/src/utils/scriptText.ts
@@ -18,7 +18,13 @@ export function cleanLineContent(raw: string): string {
 export function isPlotPromptLine(raw: string): boolean {
   if (raw.startsWith('{旁白:') && raw.endsWith('}')) {
     const inner = raw.slice('{旁白:'.length, -1).trim()
-    return inner.startsWith('（接下来的剧情演绎提示')
+    // 剧本 ai_dialogue 的 prompt 包装成「（接下来的剧情演绎提示：…）」；
+    // 主动对话/日程提醒等系统注入写成「（系统提示：…）」。两类都是写给 LLM
+    // 的上下文 prompt，不该作为「对话历史」展示给玩家。
+    return (
+      inner.startsWith('（接下来的剧情演绎提示') ||
+      inner.startsWith('（系统提示')
+    )
   }
   return false
 }


### PR DESCRIPTION
## 概述

修复 issue #642：读取存档后剧本失效（被踢出剧本状态、转为自由模式）的问题。本 PR 实现剧本运行状态与玩家阅读位置的完整持久化，读档后按玩家阅读进度自动续跑剧本，并引入 LLM 失败重试机制保证剧本连续性。

## 修改范围（18 commits）

**剧本状态持久化与读档续跑**
- 存档时持久化运行中剧本（active_script）与玩家阅读位置（running_script / player_read）
- 读档后按玩家阅读位置/事件进度自动续跑：不跳剧情、不重放已读内容；读档清空事件队列，修复历史超前内容与位置错乱
- 前端展示内容时上报玩家阅读位置，读档回到真正读到的地方（支持事件序号 0）
- 剧本单实例原子守卫，忙时返回明确错误

**AI 对话容错与 LLM 重试**
- AI 对话 LLM 调用失败自动重试 3 次，之后广播 script:llm-retry，前端显示提示并等玩家点『继续』重试：不跳过对话、不退出剧本，保证剧本连续性
- 重试逻辑公共化（generate_with_retry，供 ai_dialogue / free_dialogue 复用）；free_dialogue 读档续轮：不重置轮次、不重复已聊内容、不重放整块
- 读档续跑时 AI 对话事件的恢复位置智能处理：仅在其回复已完整生成时跳过，未看完则重放，绝不跳剧情

**多人物与系统旁白**
- 读档预加载在场角色，多人物剧本 NPC 立绘/角色名即时可用
- 入场问候/换装等系统注入旁白不再进入对话历史（防提示词泄露；line_list 仍保留供 LLM 上下文）

## 进度

- [x] 剧本状态持久化：存档时保存运行中剧本与玩家阅读位置
- [x] 读档自动续跑：按玩家位置/事件进度恢复，不跳剧情、不重放
- [x] 事件队列与历史修正：读档清空事件队列，修复历史超前/位置错乱
- [x] 多人物支持：读档预加载在场角色（NPC 立绘/角色名即时可用）
- [x] 系统旁白处理：注入旁白不进对话历史（防提示词泄露）
- [x] LLM 失败重试：自动重试 3 次 + 前端重试按钮，不踢出剧本
- [x] free_dialogue 读档续轮：不重置轮次、不重复已聊内容
- [x] 剧本单实例原子守卫，忙时明确报错
- [ ] 多人物剧本完整测试
- [ ] 防止掉出剧本状态的 LLM 重试机制完整测试

## 关联

Closes #642
