### PR TITLE
Fix:修复HDR显示发灰发暗and设置面滑动动画异常

### DIFF
--- a/src-tauri/src/api/settings.rs
+++ b/src-tauri/src/api/settings.rs
@@ -258,3 +258,21 @@ pub async fn list_llm_models(
         .await
         .map_err(|error| error.to_string())
 }
+
+/// 设置「HDR 模式」开关（仅 Windows）。
+///
+/// 持久化到 settings.json 的 `display.hdr_mode_enabled`，下次启动时由
+/// `lib.rs::read_hdr_mode_enabled` 读取，决定是否强制 WebView2 色彩配置：
+/// - 开启 → 不强制（WebView2 自动色彩管理，正确适配 HDR）
+/// - 关闭 → 强制 `--force-color-profile=scrgb-linear`（现状）
+#[cfg(target_os = "windows")]
+#[tauri::command]
+pub fn set_hdr_mode(app: AppHandle, enabled: bool) -> Result<(), String> {
+    let store = crate::config::settings_store(&app).map_err(|e| e.to_string())?;
+    store.set(
+        crate::config::keys::HDR_MODE_ENABLED.to_string(),
+        serde_json::Value::Bool(enabled),
+    );
+    store.save().map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/src-tauri/src/config/keys.rs
+++ b/src-tauri/src/config/keys.rs
@@ -123,3 +123,7 @@ pub const LOG_GENAI_DEBUG: &str = "log.genai_debug";
 // ========== 本地 TTS 推理设备 ==========
 /// 本地 TTS 推理硬件设备："cpu" | "gpu" | "npu" | "device:<id>"（Windows DirectML）
 pub const LOCAL_TTS_DEVICE: &str = "features.local_tts_device";
+
+// ========== 显示（HDR 模式，仅 Windows） ==========
+/// 是否启用 HDR 模式：开启时不强制 WebView2 色彩配置（自动适配 HDR），关闭时强制线性 sRGB。
+pub const HDR_MODE_ENABLED: &str = "display.hdr_mode_enabled";

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -201,6 +201,33 @@ impl std::ops::Deref for AppState {
     }
 }
 
+/// 读取 settings.json 中的「HDR 模式」开关（仅 Windows）。
+///
+/// 必须在 WebView2 环境创建（`Builder::build()`）之前调用——此时 `AppHandle` 尚不存在，
+/// 只能直接解析 store 文件。store 位于 `%APPDATA%\<identifier>\settings.json`
+/// （tauri-plugin-store 的 flat 点号键）。文件缺失/解析失败一律视为「未开启」。
+#[cfg(target_os = "windows")]
+fn read_hdr_mode_enabled(identifier: &str) -> bool {
+    use serde_json::Value;
+
+    let Some(appdata) = std::env::var("APPDATA").ok() else {
+        return false;
+    };
+    let path = std::path::Path::new(&appdata)
+        .join(identifier)
+        .join(crate::config::STORE_FILE);
+
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(json) = serde_json::from_str::<Value>(&content) else {
+        return false;
+    };
+    json.get(crate::config::keys::HDR_MODE_ENABLED)
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // 配置日志过滤器（genai 调试日志由 log.genai_debug 设置在 setup 阶段动态控制）。
@@ -221,13 +248,24 @@ pub fn run() {
         .with(filter)
         .init();
 
-    // 设置 WebView2 颜色配置文件（强制使用线性 sRGB）
-    #[allow(deprecated)]
-    unsafe {
-        std::env::set_var(
-            "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS",
-            "--force-color-profile=scrgb-linear",
-        );
+    // 提前构建 Tauri 上下文（读取 bundle identifier，供 Windows HDR 开关定位 settings.json）
+    let context = tauri::generate_context!();
+
+    // Windows：设置 WebView2 颜色配置文件（强制使用线性 sRGB）。
+    // 用户开启「HDR 模式」时跳过强制，改用 WebView2 自动色彩管理，
+    // 避免 HDR 显示器下整体发灰/发暗。环境变量须在 WebView2 环境创建
+    // （Builder::build() 之前）设置，因此在此处直接解析 settings.json。
+    #[cfg(target_os = "windows")]
+    {
+        if !read_hdr_mode_enabled(&context.config().identifier) {
+            #[allow(deprecated)]
+            unsafe {
+                std::env::set_var(
+                    "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS",
+                    "--force-color-profile=scrgb-linear",
+                );
+            }
+        }
     }
 
     // 构建 Tauri 应用
@@ -604,6 +642,8 @@ pub fn run() {
             api::settings::list_llm_providers,
             api::settings::save_llm_provider,
             api::settings::delete_llm_provider,
+            #[cfg(target_os = "windows")]
+            api::settings::set_hdr_mode,
             api::settings::set_llm_role,
             api::settings::switch_llm,
             api::settings::test_llm_provider,
@@ -776,7 +816,7 @@ pub fn run() {
             ai_service::tts::local::tts_local_set_device,
             exit_app,
         ])
-        .run(tauri::generate_context!())
+        .run(context)
         .expect("error while running tauri application");
 }
 

--- a/src/api/services/config.ts
+++ b/src/api/services/config.ts
@@ -20,6 +20,14 @@ export async function saveEnvConfig(
   return invoke('save_settings', { values })
 }
 
+/**
+ * 设置 HDR 模式开关（仅 Windows）。
+ * 持久化到后端 settings.json，启动时由 Rust 侧读取并决定 WebView2 色彩配置，重启后生效。
+ */
+export async function setHdrMode(enabled: boolean): Promise<void> {
+  return invoke('set_hdr_mode', { enabled })
+}
+
 export const getEnvConfigByKey = async (key: string): Promise<ConfigItem> => {
   try {
     const data = await invoke('get_setting_by_key', { key })

--- a/src/components/settings/SettingsPanel.vue
+++ b/src/components/settings/SettingsPanel.vue
@@ -112,6 +112,20 @@ const currentTabComponent = computed(() => tabComponents[uiStore.currentSettings
 // 转场方向：左滑下一项 → slide-left（新页从右进）；右滑上一项 → slide-right
 const transitionName = ref<'slide-left' | 'slide-right'>('slide-left')
 
+// 依据 TABS 顺序决定滑动方向：目标索引更大 → 下一项（slide-left）；更小 → 上一项（slide-right）。
+// watch 默认 flush: 'pre'，在重渲染前更新 transitionName，Transition 开始动画时能取到正确方向。
+watch(
+  () => uiStore.currentSettingsTab,
+  (newTab, oldTab) => {
+    if (!oldTab || oldTab === newTab) return
+    const newIdx = (TABS as readonly string[]).indexOf(newTab)
+    const oldIdx = (TABS as readonly string[]).indexOf(oldTab)
+    // 目标/来源不在滑动顺序里（理论不应发生）→ 保持原方向
+    if (newIdx === -1 || oldIdx === -1) return
+    transitionName.value = newIdx > oldIdx ? 'slide-left' : 'slide-right'
+  },
+)
+
 const contentRef = ref<HTMLElement | null>(null)
 let touchStartX = 0
 let touchStartY = 0

--- a/src/components/settings/pages/SettingsBackground.vue
+++ b/src/components/settings/pages/SettingsBackground.vue
@@ -193,6 +193,35 @@
       </div>
     </MenuItem>
 
+    <!-- HDR 模式（仅 Windows：WebView2 强制色彩配置在 HDR 下会发灰/发暗） -->
+    <MenuItem
+      v-if="isWindows()"
+      :title="$t('settings.background.hdr.title')"
+      size="large"
+    >
+      <template #header>
+        <Settings :size="20" />
+      </template>
+      <div class="flex flex-col gap-3">
+        <Toggle
+          :checked="hdrModeEnabled"
+          @change="settingsStore.setHdrModeEnabled($event)"
+        >
+          {{ $t('settings.background.hdr.enable') }}
+        </Toggle>
+        <p class="text-xs text-yellow-400/70">
+          {{ $t('settings.background.hdr.restartHint') }}
+        </p>
+        <button
+          class="self-start px-4 py-2 bg-amber-500/20 text-amber-300 border border-amber-500/30 rounded-lg text-sm font-medium transition-colors hover:bg-amber-500/30 disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="!hdrChanged"
+          @click="restartApp"
+        >
+          {{ $t('settings.background.hdr.restartBtn') }}
+        </button>
+      </div>
+    </MenuItem>
+
     <MenuItem :title="$t('settings.background.animation.settingsTitle')" size="large">
       <template #header>
         <Sparkles :size="20" />
@@ -369,7 +398,8 @@ import { useGameStore } from '../../../stores/modules/game'
 import { useUIStore } from '../../../stores/modules/ui/ui'
 import { useDialogStore } from '../../../stores/modules/ui/dialog'
 import { useSettingsStore } from '../../../stores/modules/settings'
-import { isAndroid } from '@/utils/platform'
+import { isAndroid, isWindows } from '@/utils/platform'
+import { relaunch } from '@tauri-apps/plugin-process'
 import {
   listScenes,
   createScene,
@@ -415,6 +445,23 @@ const mainMenuMeteorsEnabled = computed(() => settingsStore.mainMenuMeteorsEnabl
 const globalMouseTrailEnabled = computed(() => settingsStore.globalMouseTrailEnabled)
 const clickAnimationEnabled = computed(() => settingsStore.clickAnimationEnabled)
 const sceneAwarenessEnabled = computed(() => settingsStore.sceneAwarenessEnabled)
+const hdrModeEnabled = computed(() => settingsStore.hdrModeEnabled)
+
+// 记录进入设置页时的初始值；开关改变后「立即重启」按钮才可用，改回原值则恢复置灰
+const initialHdrMode = ref(settingsStore.hdrModeEnabled)
+const hdrChanged = computed(() => settingsStore.hdrModeEnabled !== initialHdrMode.value)
+
+// 立即重启应用（HDR 模式等设置需重启后生效）
+async function restartApp() {
+  const ok = await dialogStore.confirm(t('settings.background.hdr.restartConfirm'))
+  if (!ok) return
+  try {
+    await relaunch()
+  } catch (e) {
+    console.error('重启失败:', e)
+    dialogStore.alert(t('settings.background.hdr.restartFailed'))
+  }
+}
 const meteorFps = computed({
   get: () => settingsStore.meteorFps,
   set: (value: number) => {

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -600,6 +600,14 @@ export default {
       meteorFps: "Meteor FPS",
       starsFps: "Star FPS",
     },
+    hdr: {
+      title: "HDR Display",
+      enable: "Enable HDR mode",
+      restartHint: "Restart the app for changes to take effect",
+      restartBtn: "Restart Now",
+      restartConfirm: "HDR mode takes effect after a restart. Restart the app now?",
+      restartFailed: "Restart failed. Please restart the app manually",
+    },
     perf: {
       title: "Performance Check",
       detecting: "Checking hardware performance…",

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -598,6 +598,14 @@ export default {
       meteorFps: '流星フレームレート (FPS)',
       starsFps: '星フレームレート (FPS)',
     },
+    hdr: {
+      title: 'HDR 表示',
+      enable: 'HDR モードを有効化',
+      restartHint: '変更はアプリの再起動後に反映されます',
+      restartBtn: '今すぐ再起動',
+      restartConfirm: 'HDR モードは再起動後に反映されます。今すぐアプリを再起動しますか？',
+      restartFailed: '再起動に失敗しました。手動で再起動してください',
+    },
     perf: {
       title: '性能チェック',
       detecting: 'ハードウェア性能をチェック中…',

--- a/src/locales/zh-CN/settings.ts
+++ b/src/locales/zh-CN/settings.ts
@@ -599,6 +599,14 @@ export default {
       meteorFps: '流星帧率 (FPS)',
       starsFps: '星星帧率 (FPS)',
     },
+    hdr: {
+      title: 'HDR 显示',
+      enable: '启用 HDR 模式',
+      restartHint: '更改后需重启应用生效',
+      restartBtn: '立即重启应用',
+      restartConfirm: 'HDR 模式设置将在重启后生效，确定立即重启应用吗？',
+      restartFailed: '重启失败，请手动重启应用',
+    },
     perf: {
       title: '性能检测',
       detecting: '正在检测硬件性能 …',

--- a/src/locales/zh-HK/settings.ts
+++ b/src/locales/zh-HK/settings.ts
@@ -599,6 +599,14 @@ export default {
       "meteorFps": "流星幀率 (FPS)",
       "starsFps": "星星幀率 (FPS)"
     },
+    "hdr": {
+      "title": "HDR 顯示",
+      "enable": "啟用 HDR 模式",
+      "restartHint": "更改後需重啟應用先會生效",
+      "restartBtn": "即刻重啟應用",
+      "restartConfirm": "HDR 模式設定喺重啟後先會生效，確定即刻重啟應用？",
+      "restartFailed": "重啟失敗，請手動重啟應用"
+    },
     "perf": {
       "title": "性能檢測",
       "detecting": "檢測緊硬件性能 …",

--- a/src/stores/modules/settings/index.ts
+++ b/src/stores/modules/settings/index.ts
@@ -4,6 +4,7 @@
  */
 import { setCurrentBackground } from '@/api/services/background'
 import { setSceneAwareness } from '@/api/services/scene'
+import { setHdrMode } from '@/api/services/config'
 import { defineStore } from 'pinia'
 import type { ShortcutAction, ShortcutBinding } from '@/utils/shortcuts'
 import { DEFAULT_SHORTCUTS, sanitizeShortcuts } from '@/utils/shortcuts'
@@ -39,6 +40,7 @@ export const DEFAULT_SETTINGS = {
     meteorFps: 30, // 流星动画帧率
     starsFps: 30, // 星星动画帧率
     sceneAwarenessEnabled: true, // 场景感知开关
+    hdrModeEnabled: false, // HDR 模式开关（仅 Windows）
     locale: 'zh-CN', // 界面显示语言（i18n，'zh-CN' / 'ja'）
     // 对话框外观（自定义）
     dialogBackgroundImage: '', // 自定义背景图 base64/dataURL；空字符串=无图
@@ -90,6 +92,7 @@ export interface DisplaySettings {
   meteorFps: number
   starsFps: number
     sceneAwarenessEnabled: boolean
+    hdrModeEnabled: boolean
     locale: string
     // 对话框外观
     dialogBackgroundImage: string
@@ -157,6 +160,8 @@ export const useSettingsStore = defineStore('settings', {
     meteorFps: (state) => state.display.meteorFps,
     starsFps: (state) => state.display.starsFps,
     sceneAwarenessEnabled: (state) => state.display.sceneAwarenessEnabled,
+    // HDR 模式开关（仅 Windows）
+    hdrModeEnabled: (state) => state.display.hdrModeEnabled,
     // 界面显示语言（i18n）
     uiLocale: (state) => state.display.locale,
     // 对话框外观
@@ -332,6 +337,12 @@ export const useSettingsStore = defineStore('settings', {
     setSceneAwarenessEnabled(enabled: boolean) {
       this.display.sceneAwarenessEnabled = enabled
       setSceneAwareness(enabled)
+    },
+
+    // 设置 HDR 模式开关（仅 Windows；同步到后端，重启后生效）
+    setHdrModeEnabled(enabled: boolean) {
+      this.display.hdrModeEnabled = enabled
+      setHdrMode(enabled)
     },
 
     // 设置界面显示语言（i18n）


### PR DESCRIPTION
本 PR 包含两个修复：

1. **Windows HDR 模式下界面发灰/发暗** — 通过新增「HDR 模式」用户开关解决
2. **设置面板 Tab 切换动画方向固定** — 恢复按导航顺序左右滑动

---

## 修复 1：Windows HDR 模式下界面发灰 / 发暗

### 问题现象

Windows 开启 HDR 后，整个应用（尤其是对话窗口）出现发灰、发暗，色彩观感明显异常。

### 根因

`src-tauri/src/lib.rs` 在应用启动时**无条件**设置了环境变量：

```
WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--force-color-profile=scrgb-linear"
```

这是 Chromium/WebView2 的强制色彩配置标志，会让渲染器把整个页面当作**线性 scRGB** 色彩空间处理，忽略显示器/系统的实际色彩配置与 HDR 色调映射（tone mapping）。Windows 开启 HDR 后，显示器进入 HDR 模式，而强制线性值与 HDR 呈现链路不匹配，SDR 内容被错误呈现 → 发灰/发暗。这与前端代码无关，纯属 WebView2 渲染层问题。

### 修复方案与技术路线

采用「**用户手动开关 + 启动时条件化色彩配置**」方案：

1. **前端开关**（`SettingsBackground.vue`）：新增「HDR 显示」设置项，`Toggle` 开关「启用 HDR 模式」。
   - 仅 Windows 显示（`v-if="isWindows()"`），macOS/Linux/Android 完全不涉及。
2. **前后端持久化链路**：
   - `setHdrMode`（`api/services/config.ts`）→ `invoke('set_hdr_mode')` → Rust 命令 `set_hdr_mode`（`#[cfg(target_os = "windows")]`）
   - 写入 `settings.json` 键 `display.hdr_mode_enabled`（`config::keys::HDR_MODE_ENABLED`），并同步 Pinia `settingsStore.hdrModeEnabled`。
3. **启动时读取**（`lib.rs`）：关键点——该环境变量必须在 **WebView2 环境创建（`Builder::build()`）之前**设置，此时 `AppHandle` 尚不存在，因此：
   - 把 `tauri::generate_context!()` 提前到 `run()` 顶部以读取 bundle identifier；
   - 新增 `read_hdr_mode_enabled(identifier)`，直接解析 `%APPDATA%\<identifier>\settings.json`；
   - 仅在 **HDR 模式未开启** 时强制 `scrgb-linear`；开启时跳过强制，让 WebView2 走自动色彩管理，正确适配 HDR。
4. **重启生效 + 立即重启按钮**：环境变量只能在环境创建前决定，故改设置需重启。提供「立即重启」按钮（`@tauri-apps/plugin-process` 的 `relaunch()`，权限 `process:allow-restart` 已具备），带确认框；按钮在选项未改变时置灰（`hdrChanged` computed 对比初始快照）。
5. **i18n**：zh-CN / en / ja / zh-HK 四语种文案补齐。

### 涉及文件

- `src-tauri/src/lib.rs`（条件化 env var + 启动读取 helper + 注册命令）
- `src-tauri/src/config/keys.rs`（新增键常量）
- `src-tauri/src/api/settings.rs`（新增 `set_hdr_mode` 命令）
- `src/api/services/config.ts`（新增 `setHdrMode`）
- `src/stores/modules/settings/index.ts`（`hdrModeEnabled` 字段/getter/action）
- `src/components/settings/pages/SettingsBackground.vue`（HDR 开关 + 重启按钮）
- `src/locales/{zh-CN,en,ja,zh-HK}/settings.ts`

### 平台限定

该功能**仅 Windows**：

- 命令与注册均 `#[cfg(target_os = "windows")]`；
- 前端开关 `v-if="isWindows()"`；
- macOS/Linux/Android 不设置该环境变量、无开关、命令不存在，**行为零变化**（该标志本就只在 WebView2 上生效，其他平台 webview 自动处理色彩）。

---

## 修复 2：设置面板 Tab 切换动画方向固定

### 问题现象

设置面板切换导航 Tab 时，动画**一律向同一方向滑动**；而预期是：切到更靠后的 Tab 向左滑、切回更靠前的 Tab 向右滑。

### 根因

`SettingsPanel.vue` 中：

```ts
const transitionName = ref<'slide-left' | 'slide-right'>('slide-left')
```

`transitionName` **只被声明、从未被更新**（全项目无任何赋值点），导致 `<Transition :name="transitionName">` 永远使用 `slide-left` 一个方向。注释里「下一项→左滑、上一项→右滑」的设计意图没有对应实现。

### 修复方案与技术路线

在 `SettingsPanel.vue` 增加一个 `watch`，依据 `TABS`（与 `SettingsNav.vue` 导航顺序一致的数组）比较**新旧 Tab 索引**决定方向：

```ts
watch(
  () => uiStore.currentSettingsTab,
  (newTab, oldTab) => {
    if (!oldTab || oldTab === newTab) return
    const newIdx = (TABS as readonly string[]).indexOf(newTab)
    const oldIdx = (TABS as readonly string[]).indexOf(oldTab)
    if (newIdx === -1 || oldIdx === -1) return
    transitionName.value = newIdx > oldIdx ? 'slide-left' : 'slide-right'
  },
)
```

- `watch` 默认 `flush: 'pre'`，在组件重渲染前更新 `transitionName`，`<Transition>` 开始动画时能取到正确方向；
- 该逻辑同时覆盖两条路径：导航点击（`SettingsNav`）与手机端左右滑动（`onTouchEnd`），二者都走 `uiStore.setSettingsTab()`，会触发同一 watch。

### 涉及文件

- `src/components/settings/SettingsPanel.vue`

---

## 验证

- `cargo check`（src-tauri）通过
- `vue-tsc --noEmit --skipLibCheck` 通过（exit 0）
