### PR TITLE
refactor: 拆分 LLM 提供商预设到独立文件

### DIFF
--- a/docs/llm-provider-presets.md
+++ b/docs/llm-provider-presets.md
@@ -1,0 +1,68 @@
+# LLM 提供商预设（开发者修改指南）
+
+## 概述
+
+「预设」是 LLM 提供商表单里的**快速配置**按钮：点击某个预设，会自动把表单的
+名称 / 提供商 / 模型 / API 地址填充为对应配置，方便用户快速接入常用服务商。
+
+预设**不再写死在前端组件里**，而是统一放在独立文件：
+
+- 数据定义：`src/constants/llm-presets.ts`
+- 使用位置：`src/components/settings/pages/SettingsLlmProviders.vue`（遍历渲染预设按钮）
+
+## 如何新增 / 修改 / 删除预设
+
+只需编辑 `src/constants/llm-presets.ts` 中的 `llmPresets` 数组，前端会自动生效，**无需改动组件代码**。
+
+每个预设是一个对象：
+
+```ts
+{
+  key: '唯一标识',          // 用作按钮 key，需保持唯一
+  label: '按钮显示名',      // 例如 'DeepSeek V4 Flash'
+  provider: 'openai',       // 提供商类型，需与后端 provider 解析逻辑一致
+  model: '模型名',          // 默认模型名，可留空字符串
+  base_url: 'https://api.example.com/v1',  // API 地址
+}
+```
+
+### 新增
+
+在 `llmPresets` 数组末尾追加一个对象即可，例如：
+
+```ts
+{
+  key: 'my-provider',
+  label: '我的服务商',
+  provider: 'openai',
+  model: 'my-model',
+  base_url: 'https://api.my-provider.com/v1',
+},
+```
+
+### 修改
+
+直接改对应对象的 `label` / `provider` / `model` / `base_url` 字段。
+
+### 删除
+
+移除对应的对象（同时保证 `key` 在剩余预设中仍唯一）。
+
+## 字段约定
+
+| 字段 | 说明 |
+|------|------|
+| `key` | 唯一标识（按钮 key），建议小写连字符风格，如 `deepseek-v4-flash` |
+| `label` | 按钮显示名（可含中文，会直接展示给用户） |
+| `provider` | 提供商类型。`openai` 兼容协议用 `openai`；LM Studio 等本地推理用 `lmstudio`。需与后端解析逻辑匹配，否则连接会失败 |
+| `model` | 默认模型名。本地推理（如 Ollama / LM Studio）可留空，让用户自行填写 |
+| `base_url` | API 地址。注意：纯前端预设，URL 不会加密存储，请勿写入私有密钥 |
+
+## 注意事项
+
+- **`provider` 必须与后端支持的类型一致**：改错会导致「连接测试」/实际请求失败。
+- **`key` 必须唯一**：重复会导致按钮渲染异常。
+- 预设只是**填充表单**，不会自动保存或测试连接；用户仍需点击「保存」。
+- 若需支持新的 `provider` 类型（除 openai / lmstudio 外），需要同时在 Rust 侧
+  `src-tauri/src/ai_service/llm/provider_config.rs`（`build_llm_client_from_provider`）
+  增加对应分支，否则前端填了也连不上。

--- a/src/components/settings/pages/SettingsLlmProviders.vue
+++ b/src/components/settings/pages/SettingsLlmProviders.vue
@@ -670,71 +670,11 @@ import {
   type LlmProviderConfig,
 } from '@/api/services/llm-providers'
 import { useI18n } from 'vue-i18n'
+import { llmPresets as presets, type LlmPreset } from '@/constants/llm-presets'
 
 const store = useLlmProvidersStore()
 const uiStore = useUIStore()
 const { t } = useI18n()
-
-// ---- 预设 ----
-interface LlmPreset {
-  key: string
-  label: string
-  provider: string
-  model: string
-  base_url: string
-}
-
-const presets: LlmPreset[] = [
-  {
-    key: 'deepseek-v4-flash',
-    label: 'DeepSeek V4 Flash',
-    provider: 'openai',
-    model: 'deepseek-v4-flash',
-    base_url: 'https://api.deepseek.com',
-  },
-  {
-    key: 'deepseek-v4-pro',
-    label: 'DeepSeek V4 Pro',
-    provider: 'openai',
-    model: 'deepseek-v4-pro',
-    base_url: 'https://api.deepseek.com',
-  },
-  {
-    key: 'qwen-max',
-    label: '通义千问 Max',
-    provider: 'openai',
-    model: 'qwen3.7-max',
-    base_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
-  },
-  {
-    key: 'qwen-plus',
-    label: '通义千问 Plus',
-    provider: 'openai',
-    model: 'qwen3.7-plus',
-    base_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
-  },
-  {
-    key: 'kimi',
-    label: 'Kimi K2.6',
-    provider: 'openai',
-    model: 'kimi-k2.6',
-    base_url: 'https://api.moonshot.cn/v1',
-  },
-  {
-    key: 'ollama',
-    label: 'Ollama',
-    provider: 'openai',
-    model: '',
-    base_url: 'http://localhost:11434/v1',
-  },
-  {
-    key: 'lmstudio',
-    label: 'LM Studio',
-    provider: 'lmstudio',
-    model: '',
-    base_url: 'http://localhost:1234/v1',
-  },
-]
 
 function applyPreset(preset: LlmPreset) {
   editing.label = preset.label

--- a/src/constants/llm-presets.ts
+++ b/src/constants/llm-presets.ts
@@ -1,0 +1,74 @@
+/**
+ * LLM 提供商预设（快速配置）。
+ *
+ * 新增/修改预设只需编辑本文件 —— 前端 `SettingsLlmProviders.vue` 会遍历本数组自动渲染
+ * 出预设按钮，点击即可把表单字段填充为对应配置，无需改动组件代码。
+ *
+ * 开发者修改指南见：docs/llm-provider-presets.md
+ *
+ * 字段说明：
+ * - key:      唯一标识（用作按钮的 key，需保持唯一）
+ * - label:    按钮显示名
+ * - provider: 提供商类型（如 openai / lmstudio，需与后端 provider 解析逻辑一致）
+ * - model:    默认模型名（可为空字符串，用户后续可改）
+ * - base_url: API 地址
+ */
+export interface LlmPreset {
+  key: string
+  label: string
+  provider: string
+  model: string
+  base_url: string
+}
+
+export const llmPresets: LlmPreset[] = [
+  {
+    key: 'deepseek-v4-flash',
+    label: 'DeepSeek V4 Flash',
+    provider: 'openai',
+    model: 'deepseek-v4-flash',
+    base_url: 'https://api.deepseek.com',
+  },
+  {
+    key: 'deepseek-v4-pro',
+    label: 'DeepSeek V4 Pro',
+    provider: 'openai',
+    model: 'deepseek-v4-pro',
+    base_url: 'https://api.deepseek.com',
+  },
+  {
+    key: 'qwen-max',
+    label: '通义千问 Max',
+    provider: 'openai',
+    model: 'qwen3.7-max',
+    base_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+  },
+  {
+    key: 'qwen-plus',
+    label: '通义千问 Plus',
+    provider: 'openai',
+    model: 'qwen3.7-plus',
+    base_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+  },
+  {
+    key: 'kimi',
+    label: 'Kimi K2.6',
+    provider: 'openai',
+    model: 'kimi-k2.6',
+    base_url: 'https://api.moonshot.cn/v1',
+  },
+  {
+    key: 'ollama',
+    label: 'Ollama',
+    provider: 'openai',
+    model: '',
+    base_url: 'http://localhost:11434/v1',
+  },
+  {
+    key: 'lmstudio',
+    label: 'LM Studio',
+    provider: 'lmstudio',
+    model: '',
+    base_url: 'http://localhost:1234/v1',
+  },
+]


### PR DESCRIPTION
# PR 描述：拆分 LLM 提供商预设到独立文件

## 概述

将 LLM 提供商「预设」（快速配置按钮）从 `SettingsLlmProviders.vue` 中拆出，统一放到独立文件，
并新增开发者修改指南，方便开发者随时增删改预设，无需改动组件代码。

---

## 动机

此前 7 个预设直接写死在 `src/components/settings/pages/SettingsLlmProviders.vue` 里：
- 组件文件大、预设与 UI 逻辑耦合，想加/改一个预设必须进组件改代码；
- 缺少字段说明，开发者容易改错（如 `provider` 类型与后端不一致）。

拆分后，预设成为独立配置数据，维护成本显著降低。

## 改动内容

### 1. 新增 `src/constants/llm-presets.ts`（预设数据）

- 导出 `LlmPreset` 接口（`key` / `label` / `provider` / `model` / `base_url`）；
- 导出 `llmPresets` 数组（原 7 个预设原样迁移，行为不变）；
- 文件头部附字段说明注释，并指向开发者指南。

### 2. 新增 `docs/llm-provider-presets.md`（开发者修改指南）

- 说明预设是什么、数据定义位置、使用位置；
- 如何新增 / 修改 / 删除预设（附代码示例）；
- 字段约定表；
- 注意事项（`provider` 需与后端一致、`key` 需唯一、新 provider 需同步改 Rust 侧等）。

### 3. 改造 `src/components/settings/pages/SettingsLlmProviders.vue`

- 删除内联的 `interface LlmPreset` + `const presets` 定义（约 -61 行）；
- 改为导入引用：

```ts
import { llmPresets as presets, type LlmPreset } from '@/constants/llm-presets'
```

- 模板 `v-for="preset in presets"`、`applyPreset(preset: LlmPreset)` 等**无需改动**（名称与类型保持一致）。

## 技术说明

- 采用**别名导入** `llmPresets as presets`，让组件内既有引用（模板 + `applyPreset`）完全不变，最小化改动面；
- 纯数据迁移，**零运行行为变化**——预设按钮渲染、点击填充逻辑原样保留；
- 预设只负责填充表单，不涉及保存/连接测试，与原有逻辑一致。

## 涉及文件

- `src/constants/llm-presets.ts`（新增）
- `docs/llm-provider-presets.md`（新增）
- `src/components/settings/pages/SettingsLlmProviders.vue`（修改，-61/+1）

## 验证

- `vue-tsc --noEmit --skipLibCheck` 通过（exit 0）；
- 类型检查确认导入别名、`LlmPreset` 类型引用无误。

## 建议手动回归

1. 打开「设置 → 大模型管理（LLM Providers）」→ 编辑任一提供商；
2. 确认 7 个预设按钮（DeepSeek / 通义千问 / Kimi / Ollama / LM Studio）正常显示；
3. 点击各预设，表单字段（名称/提供商/模型/API 地址）正确填充；
4. 保存后连接测试正常（与拆分前行为一致）。

## 后续扩展指引

新增预设只需编辑 `src/constants/llm-presets.ts` 的 `llmPresets` 数组；
如需支持新的 `provider` 类型，需同步在 Rust 侧
`src-tauri/src/ai_service/llm/provider_config.rs` 的 `build_llm_client_from_provider` 增加对应分支。
