### PR TITLE
fix: 「已配置的模型」编辑/测试面板压缩左侧列表，导致用途标签覆盖模型名，改为移至模型名下方

### DIFF
--- a/src/components/settings/pages/SettingsLlmProviders.vue
+++ b/src/components/settings/pages/SettingsLlmProviders.vue
@@ -62,30 +62,37 @@
               }}</span>
             </div>
             <div class="text-sm text-white/40 truncate">{{ p.model || $t('settings.llmProviders.list.modelNotSet') }}</div>
-          </div>
-
-          <!-- Role badges -->
-          <div class="flex gap-1.5 shrink-0">
-            <span
-              v-if="store.chatProviderId === p.id"
-              class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-300 border border-green-500/30"
-              >{{ $t('settings.llmProviders.role.chat') }}</span
+            <!-- Role badges -->
+            <div
+              v-if="
+                store.chatProviderId === p.id ||
+                store.translateProviderId === p.id ||
+                store.godAgentProviderId === p.id ||
+                store.visionProviderId === p.id
+              "
+              class="flex flex-wrap gap-1.5 mt-1.5"
             >
-            <span
-              v-if="store.translateProviderId === p.id"
-              class="text-xs px-2 py-0.5 rounded-full bg-blue-500/20 text-blue-300 border border-blue-500/30"
-              >{{ $t('settings.llmProviders.role.translate') }}</span
-            >
-            <span
-              v-if="store.godAgentProviderId === p.id"
-              class="text-xs px-2 py-0.5 rounded-full bg-purple-500/20 text-purple-300 border border-purple-500/30"
-              >Agent</span
-            >
-            <span
-              v-if="store.visionProviderId === p.id"
-              class="text-xs px-2 py-0.5 rounded-full bg-orange-500/20 text-orange-300 border border-orange-500/30"
-              >{{ $t('settings.llmProviders.role.vision') }}</span
-            >
+              <span
+                v-if="store.chatProviderId === p.id"
+                class="text-xs px-2 py-0.5 rounded-full bg-green-500/20 text-green-300 border border-green-500/30"
+                >{{ $t('settings.llmProviders.role.chat') }}</span
+              >
+              <span
+                v-if="store.translateProviderId === p.id"
+                class="text-xs px-2 py-0.5 rounded-full bg-blue-500/20 text-blue-300 border border-blue-500/30"
+                >{{ $t('settings.llmProviders.role.translate') }}</span
+              >
+              <span
+                v-if="store.godAgentProviderId === p.id"
+                class="text-xs px-2 py-0.5 rounded-full bg-purple-500/20 text-purple-300 border border-purple-500/30"
+                >Agent</span
+              >
+              <span
+                v-if="store.visionProviderId === p.id"
+                class="text-xs px-2 py-0.5 rounded-full bg-orange-500/20 text-orange-300 border border-orange-500/30"
+                >{{ $t('settings.llmProviders.role.vision') }}</span
+              >
+            </div>
           </div>
 
           <!-- Actions -->


### PR DESCRIPTION
修复 #672

## 问题

「已配置的模型」列表卡片中，「对话 / 翻译 / 上帝(Agent) / 视觉」用途标签原本与模型信息、操作按钮在同一行显示。当某个模型同时被配置为这四种用途，并打开右侧的编辑/测试面板时，面板占用一半宽度压缩左侧列表，四个用途标签把左侧模型名称挤压覆盖，只能看到 "q..." 之类的截断内容。

该问题在窗口**非最大化**（正常窗口尺寸）时出现；窗口最大化时列表空间足够，不易复现。

## 修改内容

将用途标签从卡片行内移至模型名称下方显示：

- 标签容器移入左侧信息区（`flex-1 min-w-0`）内部、模型名 `div` 下方
- 容器改为 `flex flex-wrap`，空间不足时自动换行，不再挤压模型名
- 容器增加条件渲染，模型没有任何用途时不渲染，避免多余空白间距

## 修改文件

- `src/components/settings/pages/SettingsLlmProviders.vue`（仅模板结构调整，无逻辑改动）

## 截图

修改前（模型名被用途标签覆盖）：

<!-- 截图1 -->

修改后（标签移至模型名下方，模型名完整可见）：

<!-- 截图2 -->
