### PR TITLE
fix: validate LAN sync manifest paths

### DIFF
--- a/src-tauri/src/lan_sync/manifest.rs
+++ b/src-tauri/src/lan_sync/manifest.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io;
-use std::path::Path;
+use std::path::{Component, Path};
 use std::time::UNIX_EPOCH;
 
 use sha2::{Digest, Sha256};
@@ -150,7 +150,7 @@ fn compute_sha256(path: &Path) -> io::Result<String> {
 pub fn diff_manifests(
     local: &CompleteManifest,
     remote: &CompleteManifest,
-) -> (Vec<super::messages::SyncFileOp>, Vec<String>) {
+) -> Result<(Vec<super::messages::SyncFileOp>, Vec<String>), String> {
     let mut to_transfer = Vec::new();
     let mut to_delete = Vec::new();
 
@@ -168,6 +168,10 @@ pub fn diff_manifests(
         .chain(remote.runtime_files.iter())
         .map(|(k, v)| (k.as_str(), v))
         .collect();
+
+    for path in local_all.keys().chain(remote_all.keys()) {
+        validate_manifest_path(path)?;
+    }
 
     // 找出远端有而本地没有、或远端更新的文件
     for (path, remote_entry) in &remote_all {
@@ -212,5 +216,57 @@ pub fn diff_manifests(
         }
     }
 
-    (to_transfer, to_delete)
+    Ok((to_transfer, to_delete))
+}
+
+/// Validate paths received from another device before they can reach filesystem operations.
+pub fn validate_manifest_path(path: &str) -> Result<(), String> {
+    if path.is_empty() || path.contains('\\') {
+        return Err(format!("远端清单包含非法路径: {path:?}"));
+    }
+
+    let path = Path::new(path);
+    if path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::Prefix(_)
+                    | Component::RootDir
+                    | Component::CurDir
+                    | Component::ParentDir
+            )
+        })
+    {
+        return Err(format!("远端清单包含非法路径: {path:?}"));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_manifest_path;
+
+    #[test]
+    fn accepts_normal_relative_manifest_paths() {
+        assert!(validate_manifest_path("game_data/characters/alice/settings.yml").is_ok());
+    }
+
+    #[test]
+    fn rejects_paths_that_can_escape_the_data_directory() {
+        for path in [
+            "",
+            ".",
+            "../outside.txt",
+            "game_data/../../outside.txt",
+            "/tmp/outside.txt",
+            r"C:\outside.txt",
+            r"game_data\..\outside.txt",
+        ] {
+            assert!(
+                validate_manifest_path(path).is_err(),
+                "path should be rejected: {path:?}"
+            );
+        }
+    }
 }

--- a/src-tauri/src/lan_sync/sync_engine.rs
+++ b/src-tauri/src/lan_sync/sync_engine.rs
@@ -36,7 +36,7 @@ pub async fn plan_push(identity: &DeviceIdentity, peer: &PeerInfo) -> Result<Syn
     let remote_manifest = client::fetch_remote_manifest(peer).await?;
 
     let (files_to_transfer, files_to_delete) =
-        sync_manifest::diff_manifests(&remote_manifest, &local_manifest);
+        sync_manifest::diff_manifests(&remote_manifest, &local_manifest)?;
 
     let total_bytes: u64 = files_to_transfer.iter().map(|f| f.size).sum();
 
@@ -60,7 +60,7 @@ pub async fn plan_pull(identity: &DeviceIdentity, peer: &PeerInfo) -> Result<Syn
             .map_err(|e| format!("扫描本地文件失败: {e}"))?;
 
     let (files_to_transfer, files_to_delete) =
-        sync_manifest::diff_manifests(&local_manifest, &remote_manifest);
+        sync_manifest::diff_manifests(&local_manifest, &remote_manifest)?;
 
     let total_bytes: u64 = files_to_transfer.iter().map(|f| f.size).sum();
 
@@ -226,6 +226,13 @@ pub async fn execute_pull(
     app: &AppHandle,
     cancel: &AtomicBool,
 ) -> Result<SyncResult, String> {
+    for op in &plan.files_to_transfer {
+        sync_manifest::validate_manifest_path(&op.path)?;
+    }
+    for path in &plan.files_to_delete {
+        sync_manifest::validate_manifest_path(path)?;
+    }
+
     let data_dir = data_dir();
     let total = plan.files_to_transfer.len() as u64 + plan.files_to_delete.len() as u64;
     let mut current: u64 = 0;


### PR DESCRIPTION
## 修复说明

修复 LAN 同步直接信任远端 manifest 路径的问题。恶意或异常对端可返回绝对路径或包含 `..` 的路径，使 Pull 将文件写到 `data/` 目录之外。

## 修复的问题

- [ ] 解决了崩溃问题
- [x] 修复了功能异常
- [ ] 修复了显示问题
- [ ] 修复了性能问题
- [x] 其他：修复 LAN 同步路径穿越风险

## 相关 Issue

无对应 Issue。

## 修复方法

- 在生成同步计划时校验双方 manifest 中的全部路径。
- 拒绝空路径、绝对路径、`.`、`..`、Windows 盘符和反斜杠路径。
- 在执行 Pull 前再次校验计划，避免旧计划或被篡改的计划绕过检查。
- 添加正常相对路径和多种目录穿越形式的单元测试。

## 检查清单

- [ ] 代码已经本地测试

本地已通过 `git diff --check`。当前环境未安装 Rust 工具链，新增的 Rust 单元测试未在本机执行。

## 截图/示例

不适用，本次修改不涉及界面。