### PR TITLE
fix: 修复 Kimi-Code 流式响应按分块解码导致中文乱码

### DIFF
--- a/src-tauri/src/ai_service/llm/providers/kimi_code.rs
+++ b/src-tauri/src/ai_service/llm/providers/kimi_code.rs
@@ -533,7 +533,9 @@ impl KimiCodeProvider {
 
         let byte_stream = resp.bytes_stream();
         let stream = async_stream::try_stream! {
-            let mut pending = String::new();
+            // 按字节累积：SSE 事件分隔符是 ASCII，按字节切分再整段解码，
+            // 才能保证跨分块的多字节字符不被拆坏（详见 find_subslice 处注释）。
+            let mut pending: Vec<u8> = Vec::new();
             let mut thinking_buffer = String::new();
             let mut text_buffer = String::new();
             let mut last_flush_len: usize = 0;
@@ -548,13 +550,18 @@ impl KimiCodeProvider {
             let mut bs = byte_stream;
             while let Some(item) = bs.next().await {
                 let chunk = item.map_err(|e| anyhow!("Kimi-Code 流式读取失败: {e}"))?;
-                pending.push_str(&String::from_utf8_lossy(&chunk));
+                pending.extend_from_slice(&chunk);
 
                 loop {
-                    let sep = pending.find("\n\n").or_else(|| pending.find("\r\n\r\n"));
-                    let Some(pos) = sep else { break };
-                    let seplen = if pending[pos..].starts_with("\n\n") { 2 } else { 4 };
-                    let event = pending[..pos].to_string();
+                    let (pos, seplen) = match find_subslice(&pending, b"\n\n") {
+                        Some(pos) => (pos, 2),
+                        None => match find_subslice(&pending, b"\r\n\r\n") {
+                            Some(pos) => (pos, 4),
+                            None => break,
+                        },
+                    };
+                    // pos 落在 ASCII 分隔符上，一定是字符边界，整段解码安全。
+                    let event = String::from_utf8_lossy(&pending[..pos]).into_owned();
                     pending.drain(..pos + seplen);
 
                     for raw_line in event.lines() {
@@ -715,6 +722,20 @@ impl KimiCodeProvider {
 
         Ok(Box::pin(stream))
     }
+}
+
+/// 在字节序列中查找子序列首次出现的位置。
+///
+/// 用于在未解码的 SSE 缓冲区里定位事件分隔符。之所以必须在字节层面定位，
+/// 是因为 `bytes_stream()` 的分块边界落在任意字节偏移上：若对每个分块单独调用
+/// `String::from_utf8_lossy`，跨分块的多字节字符（中文占 3 字节）会被拆成两截，
+/// 前后各自变成 U+FFFD，字符不可恢复。而 U+FFFD 在 JSON 字符串里是合法字符，
+/// 后续 `serde_json::from_str` 不会报错，损坏会静默流向界面、历史记录与 TTS。
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|window| window == needle)
 }
 
 /// 把流式累积的工具块组装成 ToolCall 列表（按块 index 升序）。


### PR DESCRIPTION
## 修复说明

修复 Kimi-Code provider 流式响应的解码问题。

`stream_impl` 对 `bytes_stream()` 的**每一个分块**单独调用 `String::from_utf8_lossy`，而分块边界落在任意字节偏移上。当一个多字节字符（中文占 3 字节）跨越两个分块时，它的前后两截会各自被替换成 U+FFFD，字符不可恢复。

由于 U+FFFD 在 JSON 字符串中是合法字符，后续 `serde_json::from_str` 不会报错，损坏会**静默**流向界面、聊天历史、后续轮次的上下文以及 TTS。表现为回复里偶发的「�」，且历史记录里会一直留着。

原有的 `pending` 缓冲区只解决了 **SSE 事件**被分块截断的问题（跨块拼接事件），但解码发生在拼接**之前**，所以对**字符**被截断无效。

## 修复的问题

- [ ] 解决了崩溃问题
- [x] 修复了功能异常
- [x] 修复了显示问题
- [ ] 修复了性能问题
- [ ] 其他

## 相关 Issue

无对应 Issue。

## 修复方法

把 `pending` 从 `String` 改为 `Vec<u8>`，在**字节层面**定位 SSE 事件分隔符，只对切出来的完整事件调用一次 `String::from_utf8_lossy`：

- 事件分隔符 `\n\n` / `\r\n\r\n` 全是 ASCII，因此切点必然落在 UTF-8 字符边界上，整段解码是安全的。
- 跨分块的多字节字符会留在 `pending` 里等待后续分块补齐，不再被提前解码破坏。
- 新增私有辅助函数 `find_subslice`，用于在字节切片里定位子序列。

事件切分与分隔符长度判定的逻辑与原实现保持一致（优先匹配 `\n\n`，否则 `\r\n\r\n`），不改变任何对外行为，仅修正解码所在的层级。

## 检查清单

- [ ] 代码已经本地测试

当前环境未安装 Rust 工具链（无 `cargo` / `rustc`），因此 `cargo check` / `cargo clippy` 未在本地执行。改动仅限单个 `try_stream!` 块内的缓冲区类型 + 一个新增私有函数，`pending` 的全部 6 处使用已逐一核对为 `Vec<u8>` 语义（`Vec::new` / `extend_from_slice` / 切片索引 / `drain`）。烦请 reviewer 在本地编译确认。

## 截图/示例

分块边界导致损坏的例子（`界` 的 3 个字节被拆成 2 + 1）：

```text
chunk N   : ...{"type":"content_block_delta","delta":{"text":"你好世\xe7\x95
chunk N+1 : \x8c"}}\n\n
```

- 修复前：`你好世��` —— 两个替换字符，`界` 永久丢失，且写入历史记录
- 修复后：`你好世界`
