### PR TITLE
[Perf]优化设置页面背景模糊的性能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,7 +188,9 @@ data/plugins/*
 .claude
 CLAUDE.md
 AGENTS.md
+.agents/
+CONTEXT.md
+docs/adr
 
 # 本地 APK build 路径
 prev-build-*/
-

--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -19,6 +19,7 @@ pub mod script;
 pub mod script_editor;
 pub mod settings;
 pub mod tool_settings;
+pub mod settings_snapshot;
 pub mod workshop;
 
 use std::path::PathBuf;

--- a/src-tauri/src/api/settings_snapshot.rs
+++ b/src-tauri/src/api/settings_snapshot.rs
@@ -1,0 +1,104 @@
+use tauri::{AppHandle, Manager};
+
+/// 捕获设置背景快照（Windows 专用）。
+///
+/// 与 `save::capture_main_window_screenshot` 共用 HWND 截屏链路，但写入独立前缀
+/// `lingchat_settings_bg_<pid>_<ts>_<rand>.png`，与存档截图 `lingchat_screenshot_*`
+/// 彻底隔离，避免互相覆盖/误删。
+#[cfg(target_os = "windows")]
+#[tauri::command]
+pub async fn capture_settings_snapshot(app: AppHandle) -> Result<String, String> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or_else(|| "main window not found".to_string())?;
+
+    let hwnd = window
+        .hwnd()
+        .map_err(|e| format!("获取窗口句柄失败: {}", e))?;
+
+    let id = hwnd.0 as usize as u32;
+    let image = tauri_plugin_screenshots::windows::capture_own_window(id)?;
+
+    let pid = std::process::id();
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    // 加 4 位随机避免同一毫秒并发碰撞
+    let rand: u16 = {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut h = DefaultHasher::new();
+        std::thread::current().id().hash(&mut h);
+        ts.hash(&mut h);
+        (h.finish() & 0xFFFF) as u16
+    };
+
+    let temp_dir = std::env::temp_dir();
+    let temp_path = temp_dir.join(format!(
+        "lingchat_settings_bg_{}_{}_{}.png",
+        pid, ts, rand
+    ));
+    image
+        .save(&temp_path)
+        .map_err(|e| format!("保存设置快照失败: {}", e))?;
+
+    tracing::info!(
+        "[capture_settings_snapshot] Captured → {}",
+        temp_path.display()
+    );
+    Ok(temp_path.to_string_lossy().to_string())
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tauri::command]
+pub async fn capture_settings_snapshot(_app: AppHandle) -> Result<String, String> {
+    Err("capture_settings_snapshot is only available on Windows".to_string())
+}
+
+/// 清理设置快照临时文件。
+///
+/// 仅允许删除文件名含 `lingchat_settings_bg_` 且位于系统临时目录下的文件，
+/// 避免误删任意路径。
+#[tauri::command]
+pub async fn cleanup_settings_snapshot(path: String) -> Result<(), String> {
+    let p = std::path::Path::new(&path);
+
+    // 文件名必须含前缀，否则拒绝
+    let file_name = p
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("");
+    if !file_name.contains("lingchat_settings_bg_") {
+        return Err(format!("拒绝删除非设置快照文件: {}", path));
+    }
+
+    // 必须位于 temp_dir 内（或其子目录），防止路径穿越
+    let temp_dir = std::env::temp_dir();
+    // 规范化比较：若 canonicalize 失败则用前缀字符串比较兜底
+    let allowed = match (p.canonicalize(), temp_dir.canonicalize()) {
+        (Ok(cp), Ok(ct)) => cp.starts_with(&ct),
+        _ => {
+            // 回退：检查路径字符串是否以 temp_dir 开头
+            let s = p.to_string_lossy();
+            let t = temp_dir.to_string_lossy();
+            s.starts_with(t.as_ref())
+        }
+    };
+    // 额外允许：未落盘的路径（文件不存在）也视为成功，直接返回
+    if !allowed {
+        // 若文件不存在，也不宜报错；但若路径不在 temp 内则拒绝
+        if p.exists() {
+            return Err(format!("拒绝删除非临时目录文件: {}", path));
+        } else {
+            // 文件已不存在，视为已清理
+            return Ok(());
+        }
+    }
+
+    if p.exists() {
+        std::fs::remove_file(p).map_err(|e| format!("删除设置快照失败: {}: {}", path, e))?;
+        tracing::info!("[cleanup_settings_snapshot] Removed → {}", path);
+    }
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -701,6 +701,8 @@ pub fn run() {
             api::save::update_save_title,
             api::save::save_screenshot,
             api::save::capture_main_window_screenshot,
+            api::settings_snapshot::capture_settings_snapshot,
+            api::settings_snapshot::cleanup_settings_snapshot,
             api::script::list_scripts,
             api::script::list_standalone_scripts,
             api::script::start_script,

--- a/src/components/game/standard/animations/ParallaxAnimation.ts
+++ b/src/components/game/standard/animations/ParallaxAnimation.ts
@@ -47,12 +47,14 @@ const DEFAULT_PARALLAX_CONFIG: ParallaxConfig = {
 export function useParallaxAnimation(
   elements: ParallaxElements,
   config: Partial<ParallaxConfig> = {},
+  enabledRef?: Ref<boolean>,
 ) {
   // 合并默认配置
   const PARALLAX_CONFIG: ParallaxConfig = {
     ...DEFAULT_PARALLAX_CONFIG,
     ...config,
   }
+  const isEnabled = () => (enabledRef ? enabledRef.value : true)
 
   // 视差动画状态
   let targetOffsetX = 0
@@ -140,8 +142,8 @@ export function useParallaxAnimation(
    * - 页面不可见时暂停
    */
   function parallaxLoop() {
-    // 页面可见性检查
-    if (!isPageVisible) {
+    // 暂停态或页面不可见时停止
+    if (!isEnabled() || !isPageVisible) {
       isParallaxRunning = false
       parallaxRafId = null
       return
@@ -178,6 +180,7 @@ export function useParallaxAnimation(
    * 启动视差动画（如果尚未运行）
    */
   function startParallaxIfNeeded() {
+    if (!isEnabled()) return
     if (!isParallaxRunning && isPageVisible) {
       isParallaxRunning = true
       parallaxLoop()
@@ -200,6 +203,7 @@ export function useParallaxAnimation(
    * 节流的鼠标移动处理
    */
   function handleMouseMove(e: MouseEvent) {
+    if (!isEnabled()) return
     // 节流处理
     const now = performance.now()
     if (now - lastMouseMoveTime < PARALLAX_CONFIG.THROTTLE_DELAY) {
@@ -215,6 +219,7 @@ export function useParallaxAnimation(
   }
 
   function handleMouseLeave() {
+    if (!isEnabled()) return
     targetOffsetX = 0
     targetOffsetY = 0
     startParallaxIfNeeded()

--- a/src/components/settings/SettingsPanel.vue
+++ b/src/components/settings/SettingsPanel.vue
@@ -2,28 +2,34 @@
   <!-- Windows 静态快照背景：blur 在图片自身，不再用 backdrop-filter 持续消耗 GPU -->
   <div
     v-if="isWindowsMode && shouldShowOverlay"
-    class="snapshot-bg-wrap"
+    class="fixed inset-0 z-[999] overflow-hidden transition-opacity duration-300"
     :style="{ opacity: overlayOpacity }"
   >
     <img
       v-show="snapshotSrc && !snapshotFailed"
       ref="snapshotImgRef"
       :src="snapshotSrc ?? undefined"
-      class="snapshot-bg"
-      :class="{ 'is-ready': imgReady }"
+      class="w-full h-full object-cover blur-[8px] brightness-[0.85] scale-[1.02] block transition-opacity duration-300"
+      :class="imgReady ? 'opacity-100' : 'opacity-0'"
       draggable="false"
       alt=""
       @load="onSnapshotLoad"
       @error="onSnapshotError"
     />
-    <div class="snapshot-dim" :class="{ 'snapshot-dim--fallback': snapshotFailed }"></div>
+    <div
+      class="absolute inset-0 transition-colors duration-300"
+      :class="snapshotFailed ? 'bg-black/72' : 'bg-black/35'"
+    ></div>
   </div>
   <div
     v-else-if="shouldShowOverlay"
-    class="blur-overlay"
+    class="fixed inset-0 bg-black/70 backdrop-blur-[8px] z-[999] transition-opacity duration-300"
     :style="{ opacity: overlayOpacity }"
   ></div>
-  <div class="settings-panel flex flex-col h-full" v-show="uiStore.showSettings">
+  <div
+    class="fixed inset-0 z-[1000] bg-transparent text-[var(--text-primary,#fff)] flex flex-col h-full"
+    v-show="uiStore.showSettings"
+  >
     <div class="shrink-0 w-full">
       <SettingsNav ref="settingsNavRef" @remove-more-menu-from-a="onAddFromA" />
     </div>
@@ -290,66 +296,6 @@ defineExpose({
 </script>
 
 <style scoped>
-.blur-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  z-index: 999;
-  transition: opacity 0.3s ease;
-  opacity: 0;
-}
-
-.snapshot-bg-wrap {
-  position: fixed;
-  inset: 0;
-  z-index: 999;
-  overflow: hidden;
-  transition: opacity 0.3s ease;
-  opacity: 0;
-}
-
-.snapshot-bg {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  filter: blur(8px) brightness(0.85);
-  transform: scale(1.02);
-  display: block;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.snapshot-bg.is-ready {
-  opacity: 1;
-}
-
-.snapshot-dim {
-  position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.35);
-  transition: background 0.3s ease;
-}
-
-.snapshot-dim--fallback {
-  background: rgba(0, 0, 0, 0.72);
-}
-
-.settings-panel {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1000;
-  background: transparent;
-  color: var(--text-primary, #fff);
-}
-
 .slide-left-enter-active,
 .slide-left-leave-active,
 .slide-right-enter-active,

--- a/src/components/settings/SettingsPanel.vue
+++ b/src/components/settings/SettingsPanel.vue
@@ -1,5 +1,24 @@
 <template>
-  <div class="blur-overlay" v-if="shouldShowOverlay" :style="{ opacity: overlayOpacity }"></div>
+  <!-- Windows 静态快照背景：blur 在图片自身，不再用 backdrop-filter 持续消耗 GPU -->
+  <div
+    v-if="isWindowsMode && shouldShowOverlay"
+    class="snapshot-bg-wrap"
+    :style="{ opacity: overlayOpacity }"
+  >
+    <img
+      v-if="snapshotSrc && !snapshotFailed"
+      :src="snapshotSrc"
+      class="snapshot-bg"
+      draggable="false"
+      alt=""
+    />
+    <div class="snapshot-dim" :class="{ 'snapshot-dim--fallback': snapshotFailed }"></div>
+  </div>
+  <div
+    v-else-if="shouldShowOverlay"
+    class="blur-overlay"
+    :style="{ opacity: overlayOpacity }"
+  ></div>
   <div class="settings-panel flex flex-col h-full" v-show="uiStore.showSettings">
     <div class="shrink-0 w-full">
       <SettingsNav ref="settingsNavRef" @remove-more-menu-from-a="onAddFromA" />
@@ -44,32 +63,50 @@ import {
 import SettingsNav from './SettingsNav.vue'
 import { useUIStore } from '../../stores/modules/ui/ui'
 import { ref, watch, computed, type Component } from 'vue'
+import { isWindows } from '@/utils/platform'
+import { useSettingsSnapshot } from '@/composables/useSettingsSnapshot'
 
 const uiStore = useUIStore()
+const { snapshotSrc, snapshotFailed } = useSettingsSnapshot()
+const isWindowsMode = computed(() => isWindows())
 
 // 获取 A 组件和 B 组件的 Ref 实例
 const settingsNavRef = ref<InstanceType<typeof SettingsNav> | null>(null)
 const settingsAdvanceRef = ref<InstanceType<typeof SettingsAdvance> | null>(null)
 
-// 添加延迟状态
+// 添加延迟状态（带 session 守卫，避免快速开关时旧定时器影响新会话）
 const shouldShowOverlay = ref(false)
 const overlayOpacity = ref(0)
+let overlaySession = 0
+let showTimer: ReturnType<typeof setTimeout> | null = null
+let hideTimer: ReturnType<typeof setTimeout> | null = null
 
 watch(
   () => uiStore.showSettings,
   (newVal) => {
+    const mySession = ++overlaySession
+    if (showTimer) {
+      clearTimeout(showTimer)
+      showTimer = null
+    }
+    if (hideTimer) {
+      clearTimeout(hideTimer)
+      hideTimer = null
+    }
     if (newVal) {
       // 显示时：立即显示元素，然后延迟改变透明度
       shouldShowOverlay.value = true
-      setTimeout(() => {
+      showTimer = setTimeout(() => {
+        if (mySession !== overlaySession) return
         overlayOpacity.value = 1
       }, 10) // 使用很小的延迟确保浏览器有机会渲染
     } else {
       // 隐藏时：先改变透明度，然后延迟隐藏元素
       overlayOpacity.value = 0
-      setTimeout(() => {
+      hideTimer = setTimeout(() => {
+        if (mySession !== overlaySession) return
         shouldShowOverlay.value = false
-      }, 100) // 匹配你的动画持续时间
+      }, 300) // 与 CSS transition 0.3s 对齐，避免旧 hide 覆盖新 show
     }
   },
   { immediate: true },
@@ -212,6 +249,34 @@ defineExpose({
   z-index: 999;
   transition: opacity 0.3s ease;
   opacity: 0;
+}
+
+.snapshot-bg-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  overflow: hidden;
+  transition: opacity 0.3s ease;
+  opacity: 0;
+}
+
+.snapshot-bg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(8px) brightness(0.85);
+  transform: scale(1.02);
+  display: block;
+}
+
+.snapshot-dim {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.snapshot-dim--fallback {
+  background: rgba(0, 0, 0, 0.72);
 }
 
 .settings-panel {

--- a/src/components/settings/SettingsPanel.vue
+++ b/src/components/settings/SettingsPanel.vue
@@ -6,11 +6,15 @@
     :style="{ opacity: overlayOpacity }"
   >
     <img
-      v-if="snapshotSrc && !snapshotFailed"
-      :src="snapshotSrc"
+      v-show="snapshotSrc && !snapshotFailed"
+      ref="snapshotImgRef"
+      :src="snapshotSrc ?? undefined"
       class="snapshot-bg"
+      :class="{ 'is-ready': imgReady }"
       draggable="false"
       alt=""
+      @load="onSnapshotLoad"
+      @error="onSnapshotError"
     />
     <div class="snapshot-dim" :class="{ 'snapshot-dim--fallback': snapshotFailed }"></div>
   </div>
@@ -62,13 +66,54 @@ import {
 } from './pages'
 import SettingsNav from './SettingsNav.vue'
 import { useUIStore } from '../../stores/modules/ui/ui'
-import { ref, watch, computed, type Component } from 'vue'
+import { ref, watch, computed, nextTick, type Component } from 'vue'
 import { isWindows } from '@/utils/platform'
 import { useSettingsSnapshot } from '@/composables/useSettingsSnapshot'
 
 const uiStore = useUIStore()
 const { snapshotSrc, snapshotFailed } = useSettingsSnapshot()
 const isWindowsMode = computed(() => isWindows())
+
+// 快照图就绪再淡入：避免 file:// 解码未完成时的闪白/半帧
+const imgReady = ref(false)
+const snapshotImgRef = ref<HTMLImageElement | null>(null)
+
+function onSnapshotLoad() {
+  imgReady.value = true
+}
+
+function onSnapshotError() {
+  imgReady.value = false
+  // 图片解码失败则走兜底深色遮罩
+  snapshotFailed.value = true
+}
+
+watch(snapshotSrc, (newVal) => {
+  if (!newVal || snapshotFailed.value) {
+    imgReady.value = false
+    return
+  }
+  imgReady.value = false
+  // 已缓存图片可能同步完成，nextTick 检查 complete 兜底
+  nextTick(() => {
+    const el = snapshotImgRef.value
+    if (el && el.complete && el.naturalWidth > 0) {
+      imgReady.value = true
+    }
+  })
+})
+
+watch(snapshotFailed, (failed) => {
+  if (failed) imgReady.value = false
+  else if (snapshotSrc.value) {
+    // 从失败恢复且已有图时，重新检查就绪
+    imgReady.value = false
+    nextTick(() => {
+      const el = snapshotImgRef.value
+      if (el && el.complete && el.naturalWidth > 0) imgReady.value = true
+    })
+  }
+})
 
 // 获取 A 组件和 B 组件的 Ref 实例
 const settingsNavRef = ref<InstanceType<typeof SettingsNav> | null>(null)
@@ -110,6 +155,14 @@ watch(
     }
   },
   { immediate: true },
+)
+
+// 关闭遮罩时重置就绪态，供下次打开复用（随外层 opacity 一起淡出，无需内层反向动画）
+watch(
+  () => shouldShowOverlay.value,
+  (show) => {
+    if (!show) imgReady.value = false
+  },
 )
 
 // ========== 手机端左右滑动切换标签 ==========
@@ -267,12 +320,19 @@ defineExpose({
   filter: blur(8px) brightness(0.85);
   transform: scale(1.02);
   display: block;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.snapshot-bg.is-ready {
+  opacity: 1;
 }
 
 .snapshot-dim {
   position: absolute;
   inset: 0;
   background: rgba(0, 0, 0, 0.35);
+  transition: background 0.3s ease;
 }
 
 .snapshot-dim--fallback {

--- a/src/components/views/MainChat.vue
+++ b/src/components/views/MainChat.vue
@@ -10,10 +10,7 @@
       @audio-ended="handleAudioFinished"
       @audio-started="handleAudioStarted"
     />
-    <GameDialog
-      ref="gameDialogRef"
-      @player-continued="manualTriggerContinue"
-    />
+    <GameDialog ref="gameDialogRef" @player-continued="manualTriggerContinue" />
 
     <!-- 原有的菜单按钮 -->
     <div id="menu-panel">
@@ -25,7 +22,7 @@
         :active="uiStore.autoMode"
         v-show="uiStore.showSettings !== true"
       >
-        <h3 class="hidden xl:block">{{ $t('views.mainChat.auto') }}</h3>
+        <h3 class="hidden xl:block">{{ $t("views.mainChat.auto") }}</h3>
       </Button>
       <!-- 桌宠模式依赖 Windows 透明置顶窗口与 hit-test（lib.rs 为 cfg(windows)），Android 不可用 -->
       <Button
@@ -35,10 +32,10 @@
         @click="goToPetMode"
         v-show="uiStore.showSettings !== true"
       >
-        <h3 class="hidden xl:block">{{ $t('views.mainChat.pet') }}</h3>
+        <h3 class="hidden xl:block">{{ $t("views.mainChat.pet") }}</h3>
       </Button>
       <Button type="nav" icon="text" @click="openSettings" v-show="uiStore.showSettings !== true">
-        <h3 class="hidden xl:block">{{ $t('views.mainChat.menu') }}</h3>
+        <h3 class="hidden xl:block">{{ $t("views.mainChat.menu") }}</h3>
       </Button>
     </div>
     <GameExtraUI />
@@ -52,218 +49,244 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
-import FreeModeTools from '@/components/tools/FreeModeTools.vue'
-import ToolActivityStatus from '@/components/tools/ToolActivityStatus.vue'
-import { useUIStore } from '../../stores/modules/ui/ui'
-import { useGameStore } from '../../stores/modules/game'
-import { GameBackground, GameRolesStage } from '../game/standard'
-import { GameDialog } from '../game/standard'
-import { Button } from '../base'
-import LoadingTransition from './LoadingTransition.vue'
-import { eventQueue } from '@/core/events/event-queue'
+  import FreeModeTools from "@/components/tools/FreeModeTools.vue";
+  import ToolActivityStatus from "@/components/tools/ToolActivityStatus.vue";
+  import { eventQueue } from "@/core/events/event-queue";
+  import { onMounted, ref, watch } from "vue";
+  import { useRouter } from "vue-router";
+  import { useGameStore } from "../../stores/modules/game";
+  import { useUIStore } from "../../stores/modules/ui/ui";
+  import { Button } from "../base";
+  import { GameBackground, GameDialog, GameRolesStage } from "../game/standard";
+  import LoadingTransition from "./LoadingTransition.vue";
 
-import GameExtraUI from '../game/standard/GameExtraUI.vue'
-import ImageSourcePicker from '@/components/ui/ImageSourcePicker.vue'
-import { isAndroid } from '@/utils/platform'
-import FullAccessWarning from '@/components/tools/FullAccessWarning.vue'
+  import FullAccessWarning from "@/components/tools/FullAccessWarning.vue";
+  import ImageSourcePicker from "@/components/ui/ImageSourcePicker.vue";
+  import { useSettingsSnapshot } from "@/composables/useSettingsSnapshot";
+  import { isAndroid, isWindows } from "@/utils/platform";
+  import GameExtraUI from "../game/standard/GameExtraUI.vue";
 
-const LOADING_STORAGE_KEY = 'lingchat_loading_shown'
+  const LOADING_STORAGE_KEY = "lingchat_loading_shown";
 
-// 会话级标记：同一页面 session 内只播放一次加载动画。
-// 仅靠 localStorage 会在路由卸载/重挂时回显（如桌宠切回聊天），
-// 用模块级变量兜底，确保一次启动只播放一次。
-let loadingShownThisSession = false
+  // 会话级标记：同一页面 session 内只播放一次加载动画。
+  // 仅靠 localStorage 会在路由卸载/重挂时回显（如桌宠切回聊天），
+  // 用模块级变量兜底，确保一次启动只播放一次。
+  let loadingShownThisSession = false;
 
-const router = useRouter()
-const uiStore = useUIStore()
-const gameStore = useGameStore()
+  const router = useRouter();
+  const uiStore = useUIStore();
+  const gameStore = useGameStore();
 
-// 首次加载过渡状态：仅当本次 session 未播放过且 localStorage 未标记时播放
-const showLoading = ref(!loadingShownThisSession && !localStorage.getItem(LOADING_STORAGE_KEY))
+  // 首次加载过渡状态：仅当本次 session 未播放过且 localStorage 未标记时播放
+  const showLoading = ref(!loadingShownThisSession && !localStorage.getItem(LOADING_STORAGE_KEY));
 
-function onLoadingComplete() {
-  loadingShownThisSession = true
-  showLoading.value = false
-  localStorage.setItem(LOADING_STORAGE_KEY, '1')
-  // 加载动画结束，恢复事件队列消费
-  eventQueue.resume()
-}
-
-const goToPetMode = () => {
-  router.push('/pet')
-}
-
-const gameDialogRef = ref<InstanceType<typeof GameDialog> | null>(null)
-
-const openSettings = () => {
-  // 后台截图（不阻塞 UI），设置面板立即打开
-  gameStore.captureScreenshot()
-  uiStore.toggleSettings(true)
-  uiStore.setSettingsTab('text')
-}
-
-const switchAutoMode = () => {
-  uiStore.autoMode = !uiStore.autoMode
-}
-
-const runInitialization = async () => {
-  try {
-    await gameStore.initializeGame()
-  } catch (error) {
-    console.error('[MainChat] 初始化游戏失败:', error)
-    uiStore.showWarning({ title: '初始化失败', message: '请尝试重新进入自由对话' })
+  function onLoadingComplete() {
+    loadingShownThisSession = true;
+    showLoading.value = false;
+    localStorage.setItem(LOADING_STORAGE_KEY, "1");
+    // 加载动画结束，恢复事件队列消费
+    eventQueue.resume();
   }
-}
 
-// 初始化游戏信息
-onMounted(() => {
-  // 每次进入自由对话都恢复事件队列——编辑器试玩结束后 clear() 会把 paused 置 true，
-  // 而 resume 只在首次加载的 LoadingTransition 里被调用，返回时走不到那里。
-  // 但首次加载时不能在这里恢复：AI 开场白的打字机/音效必须等 LoadingTransition
-  // 动画结束（onLoadingComplete 里 resume），否则会在开场动画遮罩后面提前播。
-  if (!showLoading.value) {
-    eventQueue.resume()
-  }
-  if (!gameStore.initialized) {
-    runInitialization()
-  }
-})
+  const goToPetMode = () => {
+    router.push("/pet");
+  };
 
-/* 自动模式（AUTO）逻辑：事件驱动，非轮询
- * 当且仅当以下全部满足时，延迟 1 秒自动推进下一句：
- * 1. 自动模式开启
- * 2. 当前处于 responding 状态
- * 3. 当前台词打字机已结束
- * 4. 当前台词语音已播放完毕
- * 用户手动推进时取消当前调度。
- */
-const AUTO_ADVANCE_DELAY_MS = 1000
+  const gameDialogRef = ref<InstanceType<typeof GameDialog> | null>(null);
+  const settingsSnapshot = useSettingsSnapshot();
+  let settingsSnapshotSession: number | null = null;
 
-const typingFinished = ref(true)
-const audioFinished = ref(true)
-let autoAdvanceTimer: ReturnType<typeof setTimeout> | null = null
-
-const cancelAutoAdvance = () => {
-  if (autoAdvanceTimer) {
-    clearTimeout(autoAdvanceTimer)
-    autoAdvanceTimer = null
-  }
-}
-
-const scheduleAutoAdvance = () => {
-  cancelAutoAdvance()
-
-  if (!uiStore.autoMode) return
-  if (gameStore.currentStatus !== 'responding') return
-  if (!typingFinished.value || !audioFinished.value) return
-
-  autoAdvanceTimer = setTimeout(() => {
-    autoAdvanceTimer = null
-    if (!uiStore.autoMode || gameStore.currentStatus !== 'responding') return
-    if (!typingFinished.value || !audioFinished.value) return
-
-    const needWait = gameDialogRef.value?.continueDialog(false) ?? true
-    if (!needWait) {
-      // 推进后重置状态，等待下一条台词的打字/语音事件
-      typingFinished.value = true
-      audioFinished.value = true
+  const openSettings = async () => {
+    // 存档截图（原逻辑，保留用于存档预览）
+    gameStore.captureScreenshot();
+    // Windows 静态背景快照
+    if (isWindows()) {
+      settingsSnapshot
+        .capture()
+        .then((result) => {
+          if (result) settingsSnapshotSession = settingsSnapshot.snapshotSessionId.value || null;
+        })
+        .catch((e) => console.warn("[MainChat] settings snapshot failed:", e));
     }
-  }, AUTO_ADVANCE_DELAY_MS)
-}
+    uiStore.toggleSettings(true);
+    uiStore.setSettingsTab("text");
+  };
 
-// 音频开始播放
-const handleAudioStarted = () => {
-  audioFinished.value = false
-  cancelAutoAdvance()
-}
-
-// 音频播放结束
-const handleAudioFinished = () => {
-  audioFinished.value = true
-  scheduleAutoAdvance()
-}
-
-// 用户手动推进
-const manualTriggerContinue = () => {
-  cancelAutoAdvance()
-}
-
-// 监听自动模式开关
-watch(
-  () => uiStore.autoMode,
-  (enabled) => {
-    if (enabled) scheduleAutoAdvance()
-    else cancelAutoAdvance()
-  },
-)
-
-// 监听游戏状态：进入 responding 时重置状态并等待事件
-watch(
-  () => gameStore.currentStatus,
-  (status) => {
-    if (status === 'responding') {
-      typingFinished.value = !(gameDialogRef.value?.isTyping ?? false)
-      audioFinished.value = true // 新台词初始无音频
-      scheduleAutoAdvance()
-    } else {
-      cancelAutoAdvance()
+  // 关闭设置后释放 Windows 静态背景临时资源
+  watch(
+    () => uiStore.showSettings,
+    (show) => {
+      if (!show && isWindows() && settingsSnapshotSession !== null) {
+        const sid = settingsSnapshotSession;
+        settingsSnapshotSession = null;
+        settingsSnapshot.release(sid).catch(() => {});
+      } else if (!show && isWindows() && settingsSnapshot.snapshotSrc.value) {
+        // 兜底：MainMenu 未释放时由游戏侧释放
+        settingsSnapshot.release().catch(() => {});
+      }
     }
-  },
-)
+  );
 
-// 监听打字状态：结束立即尝试推进，开始则取消
-watch(
-  () => gameDialogRef.value?.isTyping,
-  (typing) => {
-    if (typing) {
-      typingFinished.value = false
-      cancelAutoAdvance()
-    } else {
-      typingFinished.value = true
-      scheduleAutoAdvance()
+  const switchAutoMode = () => {
+    uiStore.autoMode = !uiStore.autoMode;
+  };
+
+  const runInitialization = async () => {
+    try {
+      await gameStore.initializeGame();
+    } catch (error) {
+      console.error("[MainChat] 初始化游戏失败:", error);
+      uiStore.showWarning({ title: "初始化失败", message: "请尝试重新进入自由对话" });
     }
-  },
-)
+  };
+
+  // 初始化游戏信息
+  onMounted(() => {
+    // 每次进入自由对话都恢复事件队列——编辑器试玩结束后 clear() 会把 paused 置 true，
+    // 而 resume 只在首次加载的 LoadingTransition 里被调用，返回时走不到那里。
+    // 但首次加载时不能在这里恢复：AI 开场白的打字机/音效必须等 LoadingTransition
+    // 动画结束（onLoadingComplete 里 resume），否则会在开场动画遮罩后面提前播。
+    if (!showLoading.value) {
+      eventQueue.resume();
+    }
+    if (!gameStore.initialized) {
+      runInitialization();
+    }
+  });
+
+  /* 自动模式（AUTO）逻辑：事件驱动，非轮询
+   * 当且仅当以下全部满足时，延迟 1 秒自动推进下一句：
+   * 1. 自动模式开启
+   * 2. 当前处于 responding 状态
+   * 3. 当前台词打字机已结束
+   * 4. 当前台词语音已播放完毕
+   * 用户手动推进时取消当前调度。
+   */
+  const AUTO_ADVANCE_DELAY_MS = 1000;
+
+  const typingFinished = ref(true);
+  const audioFinished = ref(true);
+  let autoAdvanceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const cancelAutoAdvance = () => {
+    if (autoAdvanceTimer) {
+      clearTimeout(autoAdvanceTimer);
+      autoAdvanceTimer = null;
+    }
+  };
+
+  const scheduleAutoAdvance = () => {
+    cancelAutoAdvance();
+
+    if (!uiStore.autoMode) return;
+    if (gameStore.currentStatus !== "responding") return;
+    if (!typingFinished.value || !audioFinished.value) return;
+
+    autoAdvanceTimer = setTimeout(() => {
+      autoAdvanceTimer = null;
+      if (!uiStore.autoMode || gameStore.currentStatus !== "responding") return;
+      if (!typingFinished.value || !audioFinished.value) return;
+
+      const needWait = gameDialogRef.value?.continueDialog(false) ?? true;
+      if (!needWait) {
+        // 推进后重置状态，等待下一条台词的打字/语音事件
+        typingFinished.value = true;
+        audioFinished.value = true;
+      }
+    }, AUTO_ADVANCE_DELAY_MS);
+  };
+
+  // 音频开始播放
+  const handleAudioStarted = () => {
+    audioFinished.value = false;
+    cancelAutoAdvance();
+  };
+
+  // 音频播放结束
+  const handleAudioFinished = () => {
+    audioFinished.value = true;
+    scheduleAutoAdvance();
+  };
+
+  // 用户手动推进
+  const manualTriggerContinue = () => {
+    cancelAutoAdvance();
+  };
+
+  // 监听自动模式开关
+  watch(
+    () => uiStore.autoMode,
+    (enabled) => {
+      if (enabled) scheduleAutoAdvance();
+      else cancelAutoAdvance();
+    }
+  );
+
+  // 监听游戏状态：进入 responding 时重置状态并等待事件
+  watch(
+    () => gameStore.currentStatus,
+    (status) => {
+      if (status === "responding") {
+        typingFinished.value = !(gameDialogRef.value?.isTyping ?? false);
+        audioFinished.value = true; // 新台词初始无音频
+        scheduleAutoAdvance();
+      } else {
+        cancelAutoAdvance();
+      }
+    }
+  );
+
+  // 监听打字状态：结束立即尝试推进，开始则取消
+  watch(
+    () => gameDialogRef.value?.isTyping,
+    (typing) => {
+      if (typing) {
+        typingFinished.value = false;
+        cancelAutoAdvance();
+      } else {
+        typingFinished.value = true;
+        scheduleAutoAdvance();
+      }
+    }
+  );
 </script>
 
 <style>
-.main-box {
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: center;
-  overflow: hidden;
-}
+  .main-box {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
+    overflow: hidden;
+  }
 
-#menu-panel {
-  display: flex;
-  position: fixed;
-  top: calc(15px + var(--safe-area-inset-top));
-  right: 20px;
-  z-index: 1000;
-}
-.scene-controls {
-  position: fixed;
-  bottom: 80px; /* 根据聊天输入框高度调整 */
-  left: 20px;
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  background: rgba(0, 0, 0, 0.5);
-  padding: 8px 12px;
-  border-radius: 20px;
-  backdrop-filter: blur(5px);
-  z-index: 100;
-}
+  #menu-panel {
+    display: flex;
+    position: fixed;
+    top: calc(15px + var(--safe-area-inset-top));
+    right: 20px;
+    z-index: 1000;
+  }
+  .scene-controls {
+    position: fixed;
+    bottom: 80px; /* 根据聊天输入框高度调整 */
+    left: 20px;
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.5);
+    padding: 8px 12px;
+    border-radius: 20px;
+    backdrop-filter: blur(5px);
+    z-index: 100;
+  }
 
-.scene-indicator {
-  color: #fff;
-  font-size: 14px;
-  margin-left: 8px;
-}
+  .scene-indicator {
+    color: #fff;
+    font-size: 14px;
+    margin-left: 8px;
+  }
 </style>

--- a/src/components/views/MainMenu.vue
+++ b/src/components/views/MainMenu.vue
@@ -1,27 +1,18 @@
 <template>
-  <div
-    class="main-menu-page"
-    :class="{ 'main-menu-page--panel-active': currentPage !== 'mainMenu' }"
-  >
+  <div class="main-menu-page" :class="panelClass">
     <MainChat v-if="currentPage === 'gameMainView'" />
     <Settings v-else-if="currentPage === 'settings'" />
     <Save v-else-if="currentPage === 'save'" />
 
     <!-- 背景层（最底层） -->
-    <div
-      class="video-background"
-      ref="bgRef"
-    ></div>
+    <div class="video-background" ref="bgRef"></div>
 
-    <!-- 流星层（SVG动画） -->
-    <MeteorAnimation
-      :meteors-enabled="meteorsEnabled"
-      :meteor-fps="meteorFps"
-    />
+    <!-- 流星层（SVG动画）— 临时暂停不污染持久偏好 -->
+    <MeteorAnimation :meteors-enabled="effectiveMeteorsEnabled" :meteor-fps="meteorFps" />
 
     <!-- 星星粒子层（位于背景和人物之间） -->
     <StarAnimation
-      :stars-enabled="starsEnabled"
+      :stars-enabled="effectiveStarsEnabled"
       :stars-layer-ref="starsLayerRef"
       :stars-fps="starsFps"
     />
@@ -88,238 +79,329 @@
 </template>
 
 <script setup lang="ts">
-import { StartLogo, StartPage } from './menu/base'
-import { WorkshopOptions, GameModeOptions, MainMenuOptions, ScriptModeOptions } from './menu/page'
-import { computed, onMounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
-import MainChat from './MainChat.vue'
-import { SettingsPanel as Settings } from '../settings/'
-import { useUIStore } from '../../stores/modules/ui/ui'
-import { useSettingsStore } from '../../stores/modules/settings'
-import { getScriptList, type ScriptSummary } from '@/api/services/script-info'
-import { invoke } from '@tauri-apps/api/core'
-import { useGameStore } from '../../stores/modules/game'
-import { applyWebInitData } from '../../stores/modules/game/actions'
-import type { WebInitData } from '@/api/services/game-info'
-import MeteorAnimation from '../game/standard/animations/MeteorAnimation.vue'
-import StarAnimation from '../game/standard/animations/StarAnimation.vue'
-import { useParallaxAnimation } from '../game/standard/animations/ParallaxAnimation'
-import { useI18n } from 'vue-i18n'
+  import type { WebInitData } from "@/api/services/game-info";
+  import { getScriptList, type ScriptSummary } from "@/api/services/script-info";
+  import { useSettingsSnapshot } from "@/composables/useSettingsSnapshot";
+  import { isWindows } from "@/utils/platform";
+  import { invoke } from "@tauri-apps/api/core";
+  import { computed, nextTick, onMounted, ref, watch } from "vue";
+  import { useI18n } from "vue-i18n";
+  import { useRouter } from "vue-router";
+  import { useGameStore } from "../../stores/modules/game";
+  import { applyWebInitData } from "../../stores/modules/game/actions";
+  import { useSettingsStore } from "../../stores/modules/settings";
+  import { useUIStore } from "../../stores/modules/ui/ui";
+  import MeteorAnimation from "../game/standard/animations/MeteorAnimation.vue";
+  import { useParallaxAnimation } from "../game/standard/animations/ParallaxAnimation";
+  import StarAnimation from "../game/standard/animations/StarAnimation.vue";
+  import { SettingsPanel as Settings } from "../settings/";
+  import MainChat from "./MainChat.vue";
+  import { StartLogo, StartPage } from "./menu/base";
+  import {
+    GameModeOptions,
+    MainMenuOptions,
+    ScriptModeOptions,
+    WorkshopOptions,
+  } from "./menu/page";
 
-const { t } = useI18n()
-const router = useRouter()
-const uiStore = useUIStore()
-const settingsStore = useSettingsStore()
+  const { t } = useI18n();
+  const router = useRouter();
+  const uiStore = useUIStore();
+  const settingsStore = useSettingsStore();
 
-// 页面与菜单状态
-const currentPage = ref('mainMenu')
-const menuState = ref<'main' | 'gameMode' | 'scriptMode' | 'workshop'>('main')
-const scripts = ref<ScriptSummary[]>([])
-const loadingScripts = ref(false)
-const starsEnabled = computed(() => settingsStore.mainMenuStarsEnabled)
-const meteorsEnabled = computed(() => settingsStore.mainMenuMeteorsEnabled)
-const meteorFps = computed(() => settingsStore.meteorFps)
-const starsFps = computed(() => settingsStore.starsFps)
+  // 页面与菜单状态
+  const currentPage = ref("mainMenu");
+  const menuState = ref<"main" | "gameMode" | "scriptMode" | "workshop">("main");
+  const scripts = ref<ScriptSummary[]>([]);
+  const loadingScripts = ref(false);
+  const starsEnabled = computed(() => settingsStore.mainMenuStarsEnabled);
+  const meteorsEnabled = computed(() => settingsStore.mainMenuMeteorsEnabled);
+  const meteorFps = computed(() => settingsStore.meteorFps);
+  const starsFps = computed(() => settingsStore.starsFps);
 
-// DOM Refs
-const containerRef = ref<HTMLElement | null>(null)
-const bgRef = ref<HTMLElement | null>(null)
-const charRef = ref<HTMLElement | null>(null)
-const starsLayerRef = ref<HTMLElement | null>(null)
+  // 临时暂停（内存态，不写入持久化）— 仅 Windows 快照期间生效
+  const isWindowsMode = computed(() => isWindows());
+  const transientSuspend = ref(false);
+  const effectiveStarsEnabled = computed(() => starsEnabled.value && !transientSuspend.value);
+  const effectiveMeteorsEnabled = computed(() => meteorsEnabled.value && !transientSuspend.value);
+  const parallaxEnabled = computed(() => !transientSuspend.value);
+  const panelClass = computed(() => {
+    if (currentPage.value === "mainMenu") return {};
+    // Windows 用静态快照背景时，不再用 backdrop-filter 实时模糊
+    if (isWindowsMode.value) return { "main-menu-page--snapshot-active": true };
+    return { "main-menu-page--panel-active": true };
+  });
+  const settingsSnapshot = useSettingsSnapshot();
+  let settingsSnapshotSession: number | null = null;
 
-const Save = Settings
+  // DOM Refs
+  const containerRef = ref<HTMLElement | null>(null);
+  const bgRef = ref<HTMLElement | null>(null);
+  const charRef = ref<HTMLElement | null>(null);
+  const starsLayerRef = ref<HTMLElement | null>(null);
 
-/* ================== 菜单逻辑 ================== */
-function showGameModeMenu() {
-  menuState.value = 'gameMode'
-}
-function handleOpenCredits() {
-  router.push('/credit')
-}
-function backToMainMenu() {
-  menuState.value = 'main'
-}
-function showScriptModeMenu() {
-  menuState.value = 'scriptMode'
-}
-function showWorkshopMenu() {
-  menuState.value = 'workshop'
-}
-function goToGithub() {
-  window.open('https://github.com/SlimeBoyOwO/LingChat', '_blank')
-}
+  const Save = Settings;
 
-const handleContinueGame = async () => {
-  try {
-    const { saves } = await invoke<{ saves: Array<{ id: number }>; total: number }>('list_saves', {
-      page: 1,
-      pageSize: 1,
-    })
-    if (!saves || saves.length === 0) {
-      uiStore.showWarning({
-        title: t('views.mainMenu.noSaveTitle'),
-        message: t('views.mainMenu.noSaveMessage'),
-      })
-      return
+  /* ================== 菜单逻辑 ================== */
+  function showGameModeMenu() {
+    menuState.value = "gameMode";
+  }
+  function handleOpenCredits() {
+    router.push("/credit");
+  }
+  function backToMainMenu() {
+    menuState.value = "main";
+  }
+  function showScriptModeMenu() {
+    menuState.value = "scriptMode";
+  }
+  function showWorkshopMenu() {
+    menuState.value = "workshop";
+  }
+  function goToGithub() {
+    window.open("https://github.com/SlimeBoyOwO/LingChat", "_blank");
+  }
+
+  const handleContinueGame = async () => {
+    try {
+      const { saves } = await invoke<{ saves: Array<{ id: number }>; total: number }>(
+        "list_saves",
+        {
+          page: 1,
+          pageSize: 1,
+        }
+      );
+      if (!saves || saves.length === 0) {
+        uiStore.showWarning({
+          title: t("views.mainMenu.noSaveTitle"),
+          message: t("views.mainMenu.noSaveMessage"),
+        });
+        return;
+      }
+      const gameInfo = await invoke<WebInitData>("load_save", { saveId: saves[0].id });
+      const gameStore = useGameStore();
+      applyWebInitData(gameStore.$state, gameInfo);
+      router.push("/chat");
+    } catch (error) {
+      console.error("继续游戏失败:", error);
+      uiStore.showError({
+        title: t("views.mainMenu.continueFailTitle"),
+        message: t("views.mainMenu.continueFailMessage"),
+      });
     }
-    const gameInfo = await invoke<WebInitData>('load_save', { saveId: saves[0].id })
-    const gameStore = useGameStore()
-    applyWebInitData(gameStore.$state, gameInfo)
-    router.push('/chat')
-  } catch (error) {
-    console.error('继续游戏失败:', error)
-    uiStore.showError({
-      title: t('views.mainMenu.continueFailTitle'),
-      message: t('views.mainMenu.continueFailMessage'),
-    })
-  }
-}
+  };
 
-function handleOpenSettings(tab?: string) {
-  uiStore.toggleSettings(true)
-  if (tab === 'save') {
-    currentPage.value = 'save'
-    uiStore.setSettingsTab('save')
-  } else {
-    currentPage.value = 'settings'
+  async function hideMenuForSnapshot(): Promise<void> {
+    const raw = containerRef.value as unknown as HTMLElement | { $el?: HTMLElement } | null;
+    const el = (raw as { $el?: HTMLElement })?.$el ?? (raw as HTMLElement | null);
+    if (!el || !(el instanceof HTMLElement)) return;
+    el.style.visibility = "hidden";
+    await nextTick();
+    // 双 rAF 确保重绘完成再截
+    await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
   }
-}
 
-watch(
-  () => uiStore.showSettings,
-  (newVal) => {
-    if (!newVal && (currentPage.value === 'settings' || currentPage.value === 'save')) {
-      currentPage.value = 'mainMenu'
-      menuState.value = 'main'
+  function restoreMenuVisibility() {
+    const raw = containerRef.value as unknown as HTMLElement | { $el?: HTMLElement } | null;
+    const el = (raw as { $el?: HTMLElement })?.$el ?? (raw as HTMLElement | null);
+    if (el && el instanceof HTMLElement) el.style.visibility = "";
+  }
+
+  async function handleOpenSettings(tab?: string) {
+    // Windows：非阻塞快照 — 先隐藏菜单抢拍，再立即打开设置，背景就绪后自动替换
+    if (isWindowsMode.value) {
+      (async () => {
+        await hideMenuForSnapshot();
+        let capturePromise: Promise<string | null> | null = null;
+        try {
+          capturePromise = settingsSnapshot.capture();
+          restoreMenuVisibility();
+          const result = await capturePromise;
+          if (result) {
+            settingsSnapshotSession = settingsSnapshot.snapshotSessionId.value || null;
+          }
+        } catch (e) {
+          console.warn("[MainMenu] snapshot capture error:", e);
+          restoreMenuVisibility();
+        }
+        if (capturePromise) {
+          capturePromise.catch(() => restoreMenuVisibility());
+        }
+        // 截图完成后暂停动画
+        // 需守卫：若用户已快速关闭设置，则不再暂停
+        if (uiStore.showSettings && currentPage.value !== "mainMenu") {
+          transientSuspend.value = true;
+        }
+      })();
     }
-  },
-)
-
-/* ================== 视差动画 Hook ================== */
-const { handleMouseMove, handleMouseLeave } = useParallaxAnimation({
-  charRef,
-  bgRef,
-  starsLayerRef,
-})
-
-// 抽取接口请求逻辑，不阻塞动画初始化
-async function fetchScripts() {
-  loadingScripts.value = true
-  try {
-    scripts.value = await getScriptList()
-  } catch (e) {
-    uiStore.showError({
-      errorCode: 'script_list_failed',
-      message: t('views.mainMenu.scriptListFailed'),
-    })
-    scripts.value = []
-  } finally {
-    loadingScripts.value = false
-  }
-}
-
-onMounted(() => {
-  const initializeMenu = async () => {
-    // 性能提示只显示一次
-    const PERFORMANCE_TIP_KEY = 'mainMenuPerformanceTipShown'
-    if (
-      (starsEnabled.value || meteorsEnabled.value) &&
-      !localStorage.getItem(PERFORMANCE_TIP_KEY)
-    ) {
-      localStorage.setItem(PERFORMANCE_TIP_KEY, 'true')
-      uiStore.showInfo({
-        title: 'Tip',
-        message: t('views.mainMenu.perfTip'),
-        duration: 5000,
-      })
+    uiStore.toggleSettings(true);
+    if (tab === "save") {
+      currentPage.value = "save";
+      uiStore.setSettingsTab("save");
+    } else {
+      currentPage.value = "settings";
     }
-
-    fetchScripts()
   }
 
-  initializeMenu()
-})
+  watch(
+    () => uiStore.showSettings,
+    (newVal) => {
+      if (!newVal && (currentPage.value === "settings" || currentPage.value === "save")) {
+        currentPage.value = "mainMenu";
+        menuState.value = "main";
+        // 恢复动画（按最新持久值）
+        if (transientSuspend.value) transientSuspend.value = false;
+        // 释放静态背景临时资源（session守卫）
+        if (isWindowsMode.value && settingsSnapshotSession !== null) {
+          const sid = settingsSnapshotSession;
+          settingsSnapshotSession = null;
+          settingsSnapshot.release(sid).catch(() => {});
+        } else if (isWindowsMode.value) {
+          settingsSnapshot.release().catch(() => {});
+        }
+      }
+    }
+  );
+
+  /* ================== 视差动画 Hook ================== */
+  const { handleMouseMove, handleMouseLeave } = useParallaxAnimation(
+    {
+      charRef,
+      bgRef,
+      starsLayerRef,
+    },
+    {},
+    parallaxEnabled
+  );
+
+  // 抽取接口请求逻辑，不阻塞动画初始化
+  async function fetchScripts() {
+    loadingScripts.value = true;
+    try {
+      scripts.value = await getScriptList();
+    } catch (e) {
+      uiStore.showError({
+        errorCode: "script_list_failed",
+        message: t("views.mainMenu.scriptListFailed"),
+      });
+      scripts.value = [];
+    } finally {
+      loadingScripts.value = false;
+    }
+  }
+
+  onMounted(() => {
+    const initializeMenu = async () => {
+      // 性能提示只显示一次
+      const PERFORMANCE_TIP_KEY = "mainMenuPerformanceTipShown";
+      if (
+        (starsEnabled.value || meteorsEnabled.value) &&
+        !localStorage.getItem(PERFORMANCE_TIP_KEY)
+      ) {
+        localStorage.setItem(PERFORMANCE_TIP_KEY, "true");
+        uiStore.showInfo({
+          title: "Tip",
+          message: t("views.mainMenu.perfTip"),
+          duration: 5000,
+        });
+      }
+
+      fetchScripts();
+    };
+
+    initializeMenu();
+  });
 </script>
 
 <style scoped>
-@font-face {
-  font-family: 'Maoken Assorted Sans';
-  src: url('/fonts/MaokenAssortedSans.woff2') format('woff2');
-  font-weight: normal;
-  font-style: normal;
-  font-display: swap;
-}
+  @font-face {
+    font-family: "Maoken Assorted Sans";
+    src: url("/fonts/MaokenAssortedSans.woff2") format("woff2");
+    font-weight: normal;
+    font-style: normal;
+    font-display: swap;
+  }
 
-.main-menu-page {
-  width: 100%;
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-}
+  .main-menu-page {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    overflow: hidden;
+  }
 
-.main-menu-page--panel-active::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  backdrop-filter: blur(12px) brightness(0.9);
-  z-index: 10;
-  pointer-events: none;
-}
+  .main-menu-page--panel-active::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    backdrop-filter: blur(12px) brightness(0.9);
+    z-index: 10;
+    pointer-events: none;
+  }
 
-/* 菜单容器 */
+  .main-menu-page--snapshot-active::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    backdrop-filter: none;
+    background: none;
+    z-index: 10;
+    pointer-events: none;
+  }
 
-/* 页面切换动画 */
-.slide-left-enter-active,
-.slide-left-leave-active,
-.slide-right-enter-active,
-.slide-right-leave-active {
-  transition: all 0.4s cubic-bezier(0.7, 0, 0.2, 1);
-}
+  /* 菜单容器 */
 
-/* Remove leaving elements from flex flow immediately to prevent layout jump */
-.slide-left-leave-active,
-.slide-right-leave-active {
-  position: absolute;
-}
+  /* 页面切换动画 */
+  .slide-left-enter-active,
+  .slide-left-leave-active,
+  .slide-right-enter-active,
+  .slide-right-leave-active {
+    transition: all 0.4s cubic-bezier(0.7, 0, 0.2, 1);
+  }
 
-.slide-left-enter-from,
-.slide-left-leave-to {
-  transform: translateX(-120%);
-  opacity: 0;
-}
+  /* Remove leaving elements from flex flow immediately to prevent layout jump */
+  .slide-left-leave-active,
+  .slide-right-leave-active {
+    position: absolute;
+  }
 
-.slide-right-enter-from,
-.slide-right-leave-to {
-  transform: translateX(120%);
-  opacity: 0;
-}
+  .slide-left-enter-from,
+  .slide-left-leave-to {
+    transform: translateX(-120%);
+    opacity: 0;
+  }
 
-/* ========== 背景层 ========== */
-.video-background {
-  position: absolute;
-  top: 0;
-  left: -10%;
-  width: 120%;
-  height: 100%;
-  background-image: url('../../assets/images/background2.png');
-  background-size: cover;
-  background-position: center;
-  z-index: -2;
-  /* 移除 transition */
-  will-change: transform;
-}
+  .slide-right-enter-from,
+  .slide-right-leave-to {
+    transform: translateX(120%);
+    opacity: 0;
+  }
 
-/* ========== 人物图层 ========== */
-.character-image {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  max-width: 100%;
-  max-height: 100%;
-  z-index: 3;
-  pointer-events: none;
-  /* 移除 transition */
-  will-change: transform;
-}
+  /* ========== 背景层 ========== */
+  .video-background {
+    position: absolute;
+    top: 0;
+    left: -10%;
+    width: 120%;
+    height: 100%;
+    background-image: url("../../assets/images/background2.png");
+    background-size: cover;
+    background-position: center;
+    z-index: -2;
+    /* 移除 transition */
+    will-change: transform;
+  }
+
+  /* ========== 人物图层 ========== */
+  .character-image {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    max-width: 100%;
+    max-height: 100%;
+    z-index: 3;
+    pointer-events: none;
+    /* 移除 transition */
+    will-change: transform;
+  }
 </style>

--- a/src/components/views/MainMenu.vue
+++ b/src/components/views/MainMenu.vue
@@ -1,11 +1,14 @@
 <template>
-  <div class="main-menu-page" :class="panelClass">
+  <div class="w-full h-full relative overflow-hidden" :class="panelClass">
     <MainChat v-if="currentPage === 'gameMainView'" />
     <Settings v-else-if="currentPage === 'settings'" />
     <Save v-else-if="currentPage === 'save'" />
 
     <!-- 背景层（最底层） -->
-    <div class="video-background" ref="bgRef"></div>
+    <div
+      class="absolute top-0 left-[-10%] w-[120%] h-full bg-cover bg-center bg-[url('../../assets/images/background2.png')] z-[-2] will-change-transform"
+      ref="bgRef"
+    ></div>
 
     <!-- 流星层（SVG动画）— 临时暂停不污染持久偏好 -->
     <MeteorAnimation :meteors-enabled="effectiveMeteorsEnabled" :meteor-fps="meteorFps" />
@@ -19,7 +22,7 @@
 
     <!-- 人物图层（位于星星之上，菜单之下） -->
     <img
-      class="character-image"
+      class="absolute top-1/2 left-1/2 transform-[translate(-50%,-50%)] max-w-full max-h-full z-[3] pointer-events-none will-change-transform"
       ref="charRef"
       src="../../assets/images/alona.png"
       :alt="$t('views.mainMenu.characterAlt')"
@@ -126,10 +129,10 @@
   const effectiveMeteorsEnabled = computed(() => meteorsEnabled.value && !transientSuspend.value);
   const parallaxEnabled = computed(() => !transientSuspend.value);
   const panelClass = computed(() => {
-    if (currentPage.value === "mainMenu") return {};
-    // Windows 用静态快照背景时，不再用 backdrop-filter 实时模糊
-    if (isWindowsMode.value) return { "main-menu-page--snapshot-active": true };
-    return { "main-menu-page--panel-active": true };
+    if (currentPage.value === "mainMenu") return "";
+    // Windows 快照态：不做实时模糊，静态快照已在 SettingsPanel 内
+    if (isWindowsMode.value) return "";
+    return "before:content-[''] before:absolute before:inset-0 before:backdrop-blur-[12px] before:backdrop-brightness-90 before:z-10 before:pointer-events-none";
   });
   const settingsSnapshot = useSettingsSnapshot();
   let settingsSnapshotSession: number | null = null;
@@ -322,32 +325,6 @@
     font-display: swap;
   }
 
-  .main-menu-page {
-    width: 100%;
-    height: 100%;
-    position: relative;
-    overflow: hidden;
-  }
-
-  .main-menu-page--panel-active::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    backdrop-filter: blur(12px) brightness(0.9);
-    z-index: 10;
-    pointer-events: none;
-  }
-
-  .main-menu-page--snapshot-active::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    backdrop-filter: none;
-    background: none;
-    z-index: 10;
-    pointer-events: none;
-  }
-
   /* 菜单容器 */
 
   /* 页面切换动画 */
@@ -374,34 +351,5 @@
   .slide-right-leave-to {
     transform: translateX(120%);
     opacity: 0;
-  }
-
-  /* ========== 背景层 ========== */
-  .video-background {
-    position: absolute;
-    top: 0;
-    left: -10%;
-    width: 120%;
-    height: 100%;
-    background-image: url("../../assets/images/background2.png");
-    background-size: cover;
-    background-position: center;
-    z-index: -2;
-    /* 移除 transition */
-    will-change: transform;
-  }
-
-  /* ========== 人物图层 ========== */
-  .character-image {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    max-width: 100%;
-    max-height: 100%;
-    z-index: 3;
-    pointer-events: none;
-    /* 移除 transition */
-    will-change: transform;
   }
 </style>

--- a/src/composables/useSettingsSnapshot.ts
+++ b/src/composables/useSettingsSnapshot.ts
@@ -1,0 +1,150 @@
+import { isWindows } from "@/utils/platform";
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
+import { ref } from "vue";
+
+const CAPTURE_TIMEOUT_MS = 800;
+
+const snapshotSrc = ref<string | null>(null);
+const snapshotPath = ref<string | null>(null);
+const snapshotFailed = ref(false);
+const snapshotSessionId = ref(0);
+
+let currentSessionId = 0;
+let capturePending: Promise<string | null> | null = null;
+
+function isSupported(): boolean {
+  return isWindows();
+}
+
+async function capture(): Promise<string | null> {
+  if (!isSupported()) {
+    // 非 Windows：不使用快照，保持原实时模糊
+    return null;
+  }
+
+  const myId = ++currentSessionId;
+  snapshotSessionId.value = myId;
+  snapshotFailed.value = false;
+
+  // 清理上一会话的临时资源（懒清理，避免异常积累）
+  const prevPath = snapshotPath.value;
+  const prevSrc = snapshotSrc.value;
+  // 先清空显示，避免旧图闪烁；但保留 prevPath 以便后台删除
+  snapshotSrc.value = null;
+  snapshotPath.value = null;
+
+  if (prevPath) {
+    // 异步删除，不阻塞
+    invoke("cleanup_settings_snapshot", { path: prevPath }).catch(() => {});
+  }
+  // revoke 兜底（若之前是 blob 则无；convertFileSrc 为 file:// 无需 revoke）
+  // 保留以防未来改为 objectURL
+  // if (prevSrc && prevSrc.startsWith('blob:')) URL.revokeObjectURL(prevSrc)
+
+  const doCapture = async (): Promise<string | null> => {
+    try {
+      const path = await invoke<string>("capture_settings_snapshot");
+      if (!path) return null;
+      return path;
+    } catch (e) {
+      console.warn("[SettingsSnapshot] capture failed:", e);
+      return null;
+    }
+  };
+
+  const timeout = new Promise<null>((resolve) =>
+    setTimeout(() => resolve(null), CAPTURE_TIMEOUT_MS)
+  );
+
+  const p = Promise.race([doCapture(), timeout]) as Promise<string | null>;
+  capturePending = p;
+
+  let resultPath: string | null = null;
+  try {
+    resultPath = await p;
+  } finally {
+    if (capturePending === p) capturePending = null;
+  }
+
+  // session 已过期 → 丢弃结果并清理新产生的临时文件
+  if (myId !== currentSessionId) {
+    if (resultPath) {
+      invoke("cleanup_settings_snapshot", { path: resultPath }).catch(() => {});
+    }
+    return null;
+  }
+
+  if (!resultPath) {
+    snapshotFailed.value = true;
+    snapshotPath.value = null;
+    snapshotSrc.value = null;
+    return null;
+  }
+
+  // 成功：转换为可加载的 file:// URL
+  try {
+    const src = convertFileSrc(resultPath) + `?v=${myId}`;
+    snapshotPath.value = resultPath;
+    snapshotSrc.value = src;
+    snapshotFailed.value = false;
+    return resultPath;
+  } catch (e) {
+    console.warn("[SettingsSnapshot] convertFileSrc failed:", e);
+    snapshotFailed.value = true;
+    // 清理已落盘但无法展示的文件
+    invoke("cleanup_settings_snapshot", { path: resultPath }).catch(() => {});
+    return null;
+  }
+}
+
+/**
+ * 释放指定会话的快照资源。
+ * 若 myId 与当前会话不匹配则不清理显示（防止旧清理影响新会话）。
+ */
+async function release(myId?: number): Promise<void> {
+  const targetId = myId ?? snapshotSessionId.value;
+  const path = snapshotPath.value;
+  const currentId = snapshotSessionId.value;
+
+  // 若指定 myId 且与当前不一致，说明是旧会话的延迟清理：仅删文件，不清显示
+  if (myId !== undefined && myId !== currentId) {
+    // 无法确定旧 path，使用传入的 path 已在 capture 的丢弃分支处理
+    return;
+  }
+
+  // 清理显示
+  snapshotSrc.value = null;
+  snapshotFailed.value = false;
+  // 保留 snapshotPath 一份用于删除，清空后异步删
+  const toDelete = path ?? snapshotPath.value;
+  snapshotPath.value = null;
+  snapshotSessionId.value = 0;
+
+  if (toDelete) {
+    try {
+      await invoke("cleanup_settings_snapshot", { path: toDelete });
+    } catch (e) {
+      console.warn("[SettingsSnapshot] cleanup failed:", e);
+    }
+  }
+}
+
+function clearForNewSession() {
+  // 供 SettingsPanel 在打开新会话时重置失败态（由 capture 内部已处理）
+}
+
+export function useSettingsSnapshot() {
+  return {
+    snapshotSrc,
+    snapshotPath,
+    snapshotFailed,
+    snapshotSessionId,
+    isSupported,
+    capture,
+    release,
+    clearForNewSession,
+    get currentSessionId() {
+      return currentSessionId;
+    },
+  };
+}


### PR DESCRIPTION
Fixes SlimeBoyOwO#694

将设置页面背景的实时模糊改为一次性模糊快照：

1. 收到打开设置页面的事件后，捕获主页面当前帧；
2. 立即显示设置页面及半透明过渡遮罩，同时暂停底层动画；
3. 在后台异步生成模糊快照；
4. 快照生成完成后，平滑替换过渡遮罩；
5. 关闭设置页面时移除快照并恢复动画；
6. 如果截图或模糊处理失败，则回退到半透明遮罩或现有方案，避免阻塞设置页面打开。


这样可以保留进入设置瞬间的视觉效果，在与实时模糊观感几乎无异的同时，避免设置页面停留期间持续执行全屏实时模糊和无意义的后台动画，降低 GPU 占用。


仅优化windows端，android保持原实现