### PR TITLE
fix: 修复 Codex 模型 API 内置联网返回 401

### DIFF
--- a/src-tauri/src/ai_service/tools/settings.rs
+++ b/src-tauri/src/ai_service/tools/settings.rs
@@ -75,15 +75,16 @@ pub const TOOL_GROUPS: &[(&str, &[&str])] = &[
 pub struct WebSearchSettings {
     /// 总开关：关闭时工具不下发给模型，执行也会被拒绝。
     pub enabled: bool,
-    /// 为 true 时使用「模型 API 内置联网」：复用聊天模型的 API（Moonshot/Kimi），
-    /// 由服务端执行 $web_search，无需单独的搜索 API Key；
-    /// 为 false 时使用独立搜索端点 + api_key。
+    /// 为 true 时使用「模型 API 内置联网」：Moonshot/Kimi 由服务端执行
+    /// $web_search，Codex 复用当前模型和 ChatGPT OAuth 调用 alpha/search；
+    /// 均无需单独的搜索 API Key。为 false 时使用独立搜索端点。
     pub use_builtin: bool,
     /// 独立端点模式的搜索服务提供商：
     /// "kimi"（Kimi Code 同款 /v1/search，body 为 text_query）
     /// "bocha"（BoCha 博查 https://api.bochaai.com/v1/web-search）
     /// "deepseek"（DeepSeek Responses API，服务端内置 web_search）
     /// "tavily"（Tavily https://api.tavily.com/search，body 为 query）
+    /// "codex"（ChatGPT 订阅 OAuth，Codex alpha/search，无需搜索 API Key）
     /// 仅在 use_builtin = false 时生效。
     pub provider: String,
     /// DeepSeek Responses API 使用的模型（仅 provider = "deepseek" 时生效）。

--- a/src-tauri/src/ai_service/tools/web_search.rs
+++ b/src-tauri/src/ai_service/tools/web_search.rs
@@ -1,13 +1,11 @@
 //! 网页搜索工具，两种后端模式：
 //!
-//! 1. 模型 API 内置联网（默认，`use_builtin = true`）：复用用户已配置的聊天模型
-//!    API（Moonshot/Kimi 的 OpenAI 兼容端点），声明 `$web_search` 内置工具，
-//!    由服务端执行搜索。协议（见 platform.moonshot.cn/docs/guide/use-web-search）：
-//!    模型返回 tool_calls 后，客户端把参数原样回传为 tool 消息，服务端继续生成最终答案。
-//!    无需单独的搜索 API Key。
-//! 2. 独立搜索端点（`use_builtin = false`）：直接 POST 搜索端点，
-//!    需要单独的 API Key。支持 Kimi /search、BoCha、DeepSeek Responses API
-//!    （服务端内置 `web_search`）与自定义兼容端点。
+//! 1. 模型 API 内置联网（默认，`use_builtin = true`）：复用用户已配置的聊天模型。
+//!    Moonshot/Kimi 声明 `$web_search` 内置工具并回显 tool_calls；Codex 复用当前
+//!    聊天模型与 ChatGPT OAuth 凭据调用 `alpha/search`。无需单独的搜索 API Key。
+//! 2. 独立搜索端点（`use_builtin = false`）：直接 POST 搜索端点。
+//!    支持 Kimi /search、BoCha、DeepSeek Responses API、Tavily、Codex 订阅搜索
+//!    与自定义兼容端点；除 Codex 外需要单独的 API Key。
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -195,7 +193,7 @@ impl WebSearchTool {
             "bocha" => self.execute_bocha_search(query, cfg).await,
             "deepseek" => self.execute_deepseek_search(query, cfg).await,
             "tavily" => self.execute_tavily_search(query, cfg).await,
-            "codex" => self.execute_codex_search(query, cfg).await,
+            "codex" => self.execute_codex_search(query, cfg, None).await,
             "custom" => self.execute_kimi_endpoint(query, cfg).await,
             _ => self.execute_kimi_endpoint(query, cfg).await,
         }
@@ -404,6 +402,7 @@ impl WebSearchTool {
         &self,
         query: &str,
         cfg: &WebSearchSettings,
+        current_chat_model: Option<&str>,
     ) -> Result<ToolResult, ToolError> {
         use crate::ai_service::llm::codex_auth;
         use crate::utils::proxy::build_proxied_client;
@@ -418,15 +417,12 @@ impl WebSearchTool {
             .map_err(|e| ToolError::Execution(format!("Codex 凭据读取失败: {e}")))?
             .ok_or_else(|| {
                 ToolError::Execution(
-                    "未登录 Codex：请先在「大模型管理」登录 ChatGPT 订阅，或改用其他搜索提供商".into(),
+                    "未登录 Codex：请先在「大模型管理」登录 ChatGPT 订阅，或改用其他搜索提供商"
+                        .into(),
                 )
             })?;
 
-        let model = if cfg.model.trim().is_empty() {
-            "gpt-5.6-sol"
-        } else {
-            cfg.model.trim()
-        };
+        let model = codex_search_model(cfg.model.as_str(), current_chat_model);
         let body = serde_json::json!({
             "id": uuid::Uuid::new_v4().to_string(),
             "model": model,
@@ -500,7 +496,12 @@ impl WebSearchTool {
             text.push_str("\n\n");
         }
         if !cfg.hide_search_results {
-            text.push_str(&Self::format_results(query, &results, cfg.max_results.max(1), false));
+            text.push_str(&Self::format_results(
+                query,
+                &results,
+                cfg.max_results.max(1),
+                false,
+            ));
         } else {
             text.push_str(
                 "以上是联网搜索到的信息。请把关键内容自然地融入你的回答，\
@@ -669,6 +670,13 @@ impl WebSearchTool {
                 "未找到可用的聊天模型配置，请先在「通用 → 文本」设置里配置 LLM".into(),
             )
         })?;
+        if provider.provider.eq_ignore_ascii_case("codex") {
+            // Codex 没有 Moonshot 的 $web_search 协议；复用当前聊天模型和
+            // 已登录的 ChatGPT 订阅凭据，改走 Codex alpha/search。
+            return self
+                .execute_codex_search(query, cfg, Some(provider.model.as_str()))
+                .await;
+        }
         if provider.provider.eq_ignore_ascii_case("kimicode") {
             // kimicode（Anthropic 协议）不支持 $web_search 内置工具，
             // 但 api.kimi.com/coding 提供独立的 /v1/search 端点（Kimi Code CLI 同款），
@@ -901,4 +909,45 @@ impl Tool for WebSearchTool {
 
 fn bounded_query(query: &str) -> String {
     query.chars().take(MAX_QUERY_CHARS).collect()
+}
+
+/// Codex 内置联网优先跟随当前聊天模型；独立 Codex 搜索则允许手工配置，
+/// 但不能把与 DeepSeek 搜索共用字段的默认值误发给 Codex。
+fn codex_search_model(configured: &str, current_chat_model: Option<&str>) -> String {
+    if let Some(model) = current_chat_model
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+    {
+        return model.to_string();
+    }
+
+    let configured = configured.trim();
+    if configured.is_empty() || configured.to_ascii_lowercase().starts_with("deepseek") {
+        "gpt-5.6-sol".to_string()
+    } else {
+        configured.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::codex_search_model;
+
+    #[test]
+    fn codex_builtin_search_uses_current_chat_model() {
+        assert_eq!(
+            codex_search_model("deepseek-v4-flash", Some("gpt-5.4")),
+            "gpt-5.4"
+        );
+    }
+
+    #[test]
+    fn codex_endpoint_does_not_reuse_deepseek_default_model() {
+        assert_eq!(codex_search_model("deepseek-v4-flash", None), "gpt-5.6-sol");
+    }
+
+    #[test]
+    fn codex_endpoint_keeps_an_explicit_codex_model() {
+        assert_eq!(codex_search_model("gpt-5.6-terra", None), "gpt-5.6-terra");
+    }
 }

--- a/src/api/services/tool-settings.ts
+++ b/src/api/services/tool-settings.ts
@@ -5,9 +5,9 @@ import { i18n } from '@/locales'
 /** 网页搜索工具配置（与后端 WebSearchSettings 对应，字段保持 snake_case）。 */
 export interface WebSearchSettings {
   enabled: boolean
-  /** true = 模型 API 内置联网（免 Key）；false = 独立搜索端点 + api_key */
+  /** true = 复用当前 Kimi/Moonshot/Codex 聊天模型联网；false = 独立搜索端点 */
   use_builtin: boolean
-  /** 独立端点模式的搜索提供商："kimi" | "bocha" | "deepseek"  | "tavily" | "custom"（仅 custom 用 base_url） */
+  /** 独立端点模式的搜索提供商："kimi" | "bocha" | "deepseek" | "tavily" | "codex" | "custom"（仅 custom 用 base_url） */
   provider: string
   /** DeepSeek Responses API 使用的模型（仅 provider = "deepseek" 时生效） */
   model: string

--- a/src/locales/en/ui.ts
+++ b/src/locales/en/ui.ts
@@ -198,7 +198,7 @@ export default {
     enableWebSearch: "Enable the web search tool (let them look things up online)",
     useBuiltin: "Use model API built-in search (no API Key needed)",
     hideSearchResults: "Hide search results (no sources or URLs shown in their replies)",
-    builtinHint: "Search runs server-side on your current chat model API (must be Kimi/Moonshot) — it just uses your existing chat key, no separate signup needed",
+    builtinHint: "Search reuses the current chat model: Kimi/Moonshot use server-side built-in search, while Codex uses your signed-in ChatGPT subscription—no separate search key needed",
     apiKey: "API Key",
     provider: "Search Provider",
     providerCustom: "Custom Endpoint",

--- a/src/locales/ja/ui.ts
+++ b/src/locales/ja/ui.ts
@@ -197,7 +197,7 @@ export default {
     enableWebSearch: 'ウェブ検索ツールを有効化（あの子がネットで調べられるようになるよ）',
     useBuiltin: 'モデル API の内蔵検索を使用（API Key 不要）',
     hideSearchResults: '検索結果を隠す（あの子の回答にソースや URL を表示しない）',
-    builtinHint: '検索は現在のチャットモデル API（Kimi/Moonshot が必要）のサーバー側で実行されるよ。今のチャット Key だけで使えるから、別途申請は不要だよ',
+    builtinHint: '検索は現在のチャットモデルを再利用するよ。Kimi/Moonshot はサーバー内蔵検索、Codex はログイン済みの ChatGPT サブスクリプションを使うため、検索用 Key は別途不要だよ',
     apiKey: 'API Key',
     provider: '検索プロバイダー',
     providerCustom: 'カスタム端点',

--- a/src/locales/zh-CN/ui.ts
+++ b/src/locales/zh-CN/ui.ts
@@ -197,7 +197,7 @@ export default {
     enableWebSearch: '启用网页搜索工具（让ta可以联网查资料）',
     useBuiltin: '使用模型 API 内置联网（免 API Key）',
     hideSearchResults: '隐藏搜索结果（ta 回答时不显示来源和网址）',
-    builtinHint: '搜索由当前聊天模型 API（需为 Kimi/Moonshot）在服务端执行，用现有的聊天 Key 即可，无需单独申请',
+    builtinHint: '搜索会复用当前聊天模型：Kimi/Moonshot 使用服务端内置联网，Codex 使用已登录的 ChatGPT 订阅，无需单独申请搜索 Key',
     apiKey: 'API Key',
     provider: '搜索提供商',
     providerCustom: '自定义端点',

--- a/src/locales/zh-HK/ui.ts
+++ b/src/locales/zh-HK/ui.ts
@@ -198,7 +198,7 @@ export default {
     "enableWebSearch": "啟用網頁搜尋工具（等ta可以上網查資料）",
     "useBuiltin": "使用模型 API 內建聯網（免 API Key）",
     "hideSearchResults": "隱藏搜尋結果（ta 回答嗰陣唔會顯示來源同網址）",
-    "builtinHint": "搜尋由目前嘅聊天模型 API（需要係 Kimi/Moonshot）喺服務端執行，用現有嘅聊天 Key 就得，唔使單獨申請",
+    "builtinHint": "搜尋會沿用目前嘅聊天模型：Kimi/Moonshot 使用服務端內置聯網，Codex 使用已登入嘅 ChatGPT 訂閱，毋須另外申請搜尋 Key",
     "apiKey": "API Key",
     "provider": "搜尋供應商",
     "providerCustom": "自訂端點",


### PR DESCRIPTION
## 问题

当前聊天提供商选择 Codex 且开启“模型 API 内置联网”时，`execute_builtin` 只识别 KimiCode，Codex 会错误落入 Moonshot `/chat/completions` 路径，并以空 API Key 请求，测试搜索返回 HTTP 401。

另外，独立 Codex 搜索与 DeepSeek 共用 `model` 字段，旧配置默认值 `deepseek-v4-flash` 可能被误发到 Codex `alpha/search`。

## 修复

- 内置联网检测到当前聊天提供商为 Codex 时，复用当前 Codex 模型和已登录的 ChatGPT OAuth 凭据，调用现有 `alpha/search` 实现。
- 独立 Codex 搜索不再把 DeepSeek 默认模型误发给 Codex，缺省回退 `gpt-5.6-sol`。
- 更新中/港/英/日四语言提示，明确内置联网支持 Kimi/Moonshot/Codex。
- 补充 3 个 Codex 搜索模型选择回归测试。

## 验证

- `cargo test --manifest-path src-tauri/Cargo.toml codex_ --lib`：3 passed
- `pnpm run build`：通过
- 修改 Rust 文件 `rustfmt --check`：通过
- `git diff --check`：通过