### PR TITLE
fix: make automatic memory compression effective and race-safe

### DIFF
--- a/src-tauri/src/ai_service/game_system/game_status.rs
+++ b/src-tauri/src/ai_service/game_system/game_status.rs
@@ -101,6 +101,7 @@ impl GameStatus {
 
     /// 追加台词，记录当前在场者为感知列表，并刷新相关角色的记忆。
     pub async fn add_line(&mut self, db: &DatabaseConnection, line: LineBase) -> Result<()> {
+        self.role_manager.invalidate_memory_history();
         let perceived: Vec<i32> = self.present_role_ids.iter().copied().collect();
         let game_line = GameLine::from_base(line, perceived);
         self.line_list.push(game_line);

--- a/src-tauri/src/ai_service/game_system/persistent_memory_system.rs
+++ b/src-tauri/src/ai_service/game_system/persistent_memory_system.rs
@@ -135,6 +135,10 @@ pub struct PersistentMemorySystem {
     memory_bank: Arc<Mutex<GameMemoryBank>>,
     is_updating: Arc<AtomicBool>,
     has_pending: Arc<AtomicBool>,
+    /// 每次历史刷新都会递增；后台任务提交前必须仍匹配，避免撤回/读档后写入旧摘要。
+    history_revision: Arc<AtomicU64>,
+    /// 把历史失效与后台成功/失败提交放进同一同步边界，封闭最终 revision 检查的 TOCTOU。
+    commit_gate: Arc<std::sync::Mutex<()>>,
 
     /// 最近一次压缩失败的时间戳（unix 毫秒），0 = 无失败。用于重试冷却。
     last_failure_at_ms: Arc<AtomicU64>,
@@ -149,6 +153,64 @@ pub struct PersistentMemorySystem {
     section_limits: MemorySectionLimits,
 
     section_prompts: HashMap<String, String>,
+}
+
+/// 无论后台任务成功、显式失败还是 panic 展开，都解除 updating 锁。
+struct UpdatingGuard(Arc<AtomicBool>);
+
+impl Drop for UpdatingGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+fn record_failure_if_current(
+    commit_gate: &std::sync::Mutex<()>,
+    history_revision: &AtomicU64,
+    expected_revision: u64,
+    last_failure_at_ms: &AtomicU64,
+    fail_count: &AtomicU32,
+) -> bool {
+    let _gate = commit_gate
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if history_revision.load(Ordering::Acquire) != expected_revision {
+        return false;
+    }
+    last_failure_at_ms.store(current_time_ms(), Ordering::Release);
+    fail_count.fetch_add(1, Ordering::AcqRel);
+    true
+}
+
+#[allow(clippy::too_many_arguments)]
+fn commit_update_if_current(
+    commit_gate: &std::sync::Mutex<()>,
+    history_revision: &AtomicU64,
+    expected_revision: u64,
+    bank: &mut GameMemoryBank,
+    sections: [String; 4],
+    target_idx: i64,
+    last_failure_at_ms: &AtomicU64,
+    fail_count: &AtomicU32,
+    has_pending: &AtomicBool,
+) -> bool {
+    let _gate = commit_gate
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if history_revision.load(Ordering::Acquire) != expected_revision {
+        return false;
+    }
+    let [short_term, long_term, user_info, promises] = sections;
+    bank.data.short_term = short_term;
+    bank.data.long_term = long_term;
+    bank.data.user_info = user_info;
+    bank.data.promises = promises;
+    bank.meta.last_processed_global_idx = target_idx;
+    bank.meta.updated_at = now_str();
+    last_failure_at_ms.store(0, Ordering::Release);
+    fail_count.store(0, Ordering::Release);
+    has_pending.store(true, Ordering::Release);
+    true
 }
 
 impl PersistentMemorySystem {
@@ -169,6 +231,8 @@ impl PersistentMemorySystem {
             memory_bank: Arc::new(Mutex::new(initial_bank.clone())),
             is_updating: Arc::new(AtomicBool::new(false)),
             has_pending: Arc::new(AtomicBool::new(false)),
+            history_revision: Arc::new(AtomicU64::new(0)),
+            commit_gate: Arc::new(std::sync::Mutex::new(())),
             last_failure_at_ms: Arc::new(AtomicU64::new(0)),
             fail_count: Arc::new(AtomicU32::new(0)),
             enabled,
@@ -185,11 +249,49 @@ impl PersistentMemorySystem {
         self.enabled
     }
 
+    /// 在台词历史发生追加、撤回、清空或读档时使进行中的后台摘要立即过期。
+    pub fn invalidate_history(&self) {
+        let _gate = self
+            .commit_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.history_revision.fetch_add(1, Ordering::AcqRel);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn history_revision_for_test(&self) -> u64 {
+        self.history_revision.load(Ordering::Acquire)
+    }
+
     /// 返回给调用方用于裁剪 line_list 的起点索引。
-    pub async fn get_slice_start_index(&self) -> usize {
+    ///
+    /// `recent_window` 的单位与触发阈值一致，都是“该角色可见、非 system 的台词”，
+    /// 而不是全局原始行数；0 表示压缩点之前一条也不保留。
+    pub async fn get_slice_start_index(&self, all_lines: &[GameLine]) -> usize {
         let bank = self.memory_bank.lock().await;
-        let idx = bank.meta.last_processed_global_idx;
-        (idx - self.recent_window as i64).max(0) as usize
+        let processed = bank
+            .meta
+            .last_processed_global_idx
+            .max(0)
+            .min(all_lines.len() as i64) as usize;
+        drop(bank);
+
+        if processed == 0 || self.recent_window == 0 {
+            return processed;
+        }
+
+        let mut start = processed;
+        let mut remaining = self.recent_window;
+        while start > 0 {
+            start -= 1;
+            if line_visible_to_role(&all_lines[start], self.role_id) {
+                remaining -= 1;
+                if remaining == 0 {
+                    break;
+                }
+            }
+        }
+        start
     }
 
     /// 长期记忆 / 用户画像 / 约定 文本（适合合并到 system 消息）。
@@ -214,7 +316,7 @@ impl PersistentMemorySystem {
     pub async fn get_short_term_user_text(&self) -> String {
         let bank = self.memory_bank.lock().await;
         let short = truncate_to_chars(bank.data.short_term.trim(), self.section_limits.short_term);
-        if short.is_empty() {
+        if short.is_empty() || short == "暂无近期对话摘要。" {
             String::new()
         } else {
             format!("【近期回顾】{}\n\n", short)
@@ -237,6 +339,7 @@ impl PersistentMemorySystem {
     /// 从 DB 加载后重置内部缓存（丢弃任何待处理的过期更新）。
     /// 同时清失败状态：指针仍停在 DB 中的旧位置，重试从新会话重新计时。
     pub async fn reset_from(&self, bank: &GameMemoryBank) {
+        self.invalidate_history();
         self.has_pending.store(false, Ordering::Release);
         self.last_failure_at_ms.store(0, Ordering::Release);
         self.fail_count.store(0, Ordering::Release);
@@ -252,6 +355,7 @@ impl PersistentMemorySystem {
         if !self.enabled {
             return;
         }
+        let history_revision = self.history_revision.load(Ordering::Acquire);
         if self.is_updating.load(Ordering::Acquire) {
             return;
         }
@@ -270,7 +374,7 @@ impl PersistentMemorySystem {
         // 读取并校验指针。越界（清空对话/读档后 line_list 变短）时**写回**重置，
         // 否则指针残留旧值，get_slice_start_index 会一直返回过期大索引，
         // 导致上下文窗口无限膨胀且每轮都从 index 0 重建整段上下文。
-        let last_idx = {
+        let (last_idx, pointer_corrected) = {
             let mut bank_guard = match self.memory_bank.try_lock() {
                 Ok(g) => g,
                 Err(_) => return, // 后台任务正在写，跳过
@@ -278,11 +382,15 @@ impl PersistentMemorySystem {
             let idx = bank_guard.meta.last_processed_global_idx;
             if idx < 0 || idx as usize > current_total {
                 bank_guard.meta.last_processed_global_idx = 0;
-                0
+                bank_guard.meta.updated_at = now_str();
+                (0, true)
             } else {
-                idx as usize
+                (idx as usize, false)
             }
         };
+        if pointer_corrected {
+            self.has_pending.store(true, Ordering::Release);
+        }
 
         let new_lines = &all_lines[last_idx..current_total];
         let (chat_text, visible_count) = self.build_chat_text_and_count(new_lines);
@@ -297,6 +405,7 @@ impl PersistentMemorySystem {
             if let Ok(mut bank) = self.memory_bank.try_lock() {
                 bank.meta.last_processed_global_idx = target_idx;
                 bank.meta.updated_at = now_str();
+                self.has_pending.store(true, Ordering::Release);
             }
             return;
         }
@@ -308,18 +417,31 @@ impl PersistentMemorySystem {
             self.update_interval,
         );
 
-        self.is_updating.store(true, Ordering::Release);
-        self.spawn_background_update(chat_text, target_idx);
+        if self
+            .is_updating
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        self.spawn_background_update(chat_text, target_idx, history_revision);
     }
 
     // ── 内部方法 ──
 
-    fn spawn_background_update(&self, chat_text: String, target_idx: i64) {
+    fn spawn_background_update(
+        &self,
+        chat_text: String,
+        target_idx: i64,
+        expected_history_revision: u64,
+    ) {
         let llm_slot = self.llm.clone();
         let mb = self.memory_bank.clone();
         let prompts = self.section_prompts.clone();
         let is_updating = self.is_updating.clone();
         let has_pending = self.has_pending.clone();
+        let history_revision = self.history_revision.clone();
+        let commit_gate = self.commit_gate.clone();
         let last_failure_at_ms = self.last_failure_at_ms.clone();
         let fail_count = self.fail_count.clone();
         let role_id = self.role_id;
@@ -327,11 +449,21 @@ impl PersistentMemorySystem {
         let limits = self.section_limits;
 
         tokio::spawn(async move {
-            // 记录一次失败并复位 is_updating。失败不推进指针 → 下轮对话重试同一批。
+            let _updating_guard = UpdatingGuard(is_updating.clone());
+            // 仅当前历史版本的失败才进入冷却；过期任务不能污染新会话的重试状态。
             let record_failure = || {
-                last_failure_at_ms.store(current_time_ms(), Ordering::Release);
-                fail_count.fetch_add(1, Ordering::AcqRel);
-                is_updating.store(false, Ordering::Release);
+                if !record_failure_if_current(
+                    &commit_gate,
+                    &history_revision,
+                    expected_history_revision,
+                    &last_failure_at_ms,
+                    &fail_count,
+                ) {
+                    tracing::info!(
+                        "MemoryBank: role_id={} 过期压缩请求失败，忽略其冷却状态",
+                        role_id
+                    );
+                }
             };
 
             // 从槽位读取当前 LLM 客户端快照（支持热切换后使用新模型）
@@ -409,22 +541,37 @@ impl PersistentMemorySystem {
                 return;
             }
 
-            // 全部成功：写回 + 推进指针 + 清失败状态
-            let [st, lt, ui, pr] = results;
-            {
-                let mut bank = mb.lock().await;
-                bank.data.short_term = st.unwrap();
-                bank.data.long_term = lt.unwrap();
-                bank.data.user_info = ui.unwrap();
-                bank.data.promises = pr.unwrap();
-                bank.meta.last_processed_global_idx = target_idx;
-                bank.meta.updated_at = now_str();
+            // 压缩期间若历史被追加、撤回、清空或读档，本批输入已经过期，绝不能写回。
+            if history_revision.load(Ordering::Acquire) != expected_history_revision {
+                tracing::info!(
+                    "MemoryBank: role_id={} 历史版本已变化，丢弃过期压缩结果（指针不移动）",
+                    role_id
+                );
+                return;
             }
 
-            last_failure_at_ms.store(0, Ordering::Release);
-            fail_count.store(0, Ordering::Release);
-            is_updating.store(false, Ordering::Release);
-            has_pending.store(true, Ordering::Release);
+            // 全部成功：在同一个提交门内复核版本、写回、推进指针并清失败状态。
+            let [st, lt, ui, pr] = results;
+            let sections = [st.unwrap(), lt.unwrap(), ui.unwrap(), pr.unwrap()];
+            let mut bank = mb.lock().await;
+            if !commit_update_if_current(
+                &commit_gate,
+                &history_revision,
+                expected_history_revision,
+                &mut bank,
+                sections,
+                target_idx,
+                &last_failure_at_ms,
+                &fail_count,
+                &has_pending,
+            ) {
+                tracing::info!(
+                    "MemoryBank: role_id={} 提交前历史版本已变化，丢弃过期压缩结果",
+                    role_id
+                );
+                return;
+            }
+            drop(bank);
             tracing::info!(
                 "MemoryBank: role_id={} 记忆库更新完成! 指针已移动至 {}",
                 role_id,
@@ -485,20 +632,11 @@ impl PersistentMemorySystem {
     /// 1. 统计非 system 且该角色可见的台词数（visible_count）
     /// 2. 用 MemoryBuilder 构建该角色视角的 LLM 消息，转为纯文本
     fn build_chat_text_and_count(&self, lines: &[GameLine]) -> (String, usize) {
-        use crate::db::entities::line::LineAttribute;
-
         // 统计可见非 system 台词
-        let mut visible_count: usize = 0;
-        for line in lines {
-            if matches!(line.attribute(), LineAttribute::System) {
-                continue;
-            }
-            let visible = line.sender_role_id() == Some(self.role_id)
-                || line.perceived_role_ids.contains(&self.role_id);
-            if visible && !line.content().trim().is_empty() {
-                visible_count += 1;
-            }
-        }
+        let visible_count = lines
+            .iter()
+            .filter(|line| line_visible_to_role(line, self.role_id))
+            .count();
 
         if visible_count == 0 {
             return (String::new(), 0);
@@ -531,10 +669,192 @@ impl PersistentMemorySystem {
     }
 }
 
+fn line_visible_to_role(line: &GameLine, role_id: i32) -> bool {
+    use crate::db::entities::line::LineAttribute;
+
+    !matches!(line.attribute(), LineAttribute::System)
+        && !line.content().trim().is_empty()
+        && (line.sender_role_id() == Some(role_id)
+            || line.perceived_role_ids.contains(&role_id))
+}
+
 fn now_str() -> String {
     chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
 }
 
 fn current_time_ms() -> u64 {
     chrono::Utc::now().timestamp_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ai_service::types::{LineAttributeExt, LineBase};
+    use crate::db::entities::line::LineAttribute;
+    use tokio::sync::RwLock;
+
+    fn line(attribute: LineAttribute, sender: Option<i32>, perceived: Vec<i32>) -> GameLine {
+        GameLine::from_base(
+            LineBase {
+                content: "line".to_string(),
+                attribute: LineAttributeExt(attribute),
+                sender_role_id: sender,
+                ..Default::default()
+            },
+            perceived,
+        )
+    }
+
+    fn system(recent_window: usize, processed: i64) -> PersistentMemorySystem {
+        let mut bank = GameMemoryBank::default();
+        bank.meta.last_processed_global_idx = processed;
+        let llm: LlmSlot = Arc::new(RwLock::new(None));
+        PersistentMemorySystem::new(
+            7,
+            &bank,
+            llm,
+            true,
+            250,
+            recent_window,
+            MemorySectionLimits::default(),
+            "AI",
+        )
+    }
+
+    #[tokio::test]
+    async fn recent_window_counts_only_role_visible_non_system_lines() {
+        let lines = vec![
+            line(LineAttribute::System, Some(7), vec![7]),
+            line(LineAttribute::Assistant, Some(7), vec![]),
+            line(LineAttribute::Assistant, Some(8), vec![8]),
+            line(LineAttribute::User, Some(0), vec![7]),
+            line(LineAttribute::Assistant, Some(8), vec![8]),
+            line(LineAttribute::User, Some(0), vec![7]),
+        ];
+        let memory = system(2, 5);
+        assert_eq!(memory.get_slice_start_index(&lines).await, 1);
+    }
+
+    #[tokio::test]
+    async fn recent_window_falls_back_to_zero_when_visible_history_is_short() {
+        let mut empty = line(LineAttribute::User, Some(0), vec![7]);
+        empty.base.content = "   ".to_string();
+        let lines = vec![
+            line(LineAttribute::System, Some(7), vec![7]),
+            empty,
+            line(LineAttribute::Assistant, Some(7), vec![]),
+            line(LineAttribute::User, Some(0), vec![7]), // unprocessed boundary line
+        ];
+        let memory = system(5, 3);
+        assert_eq!(memory.get_slice_start_index(&lines).await, 0);
+    }
+
+    #[tokio::test]
+    async fn default_short_term_placeholder_is_not_injected() {
+        let memory = system(30, 0);
+        assert_eq!(memory.get_short_term_user_text().await, "");
+    }
+
+    #[tokio::test]
+    async fn zero_recent_window_starts_exactly_at_processed_boundary() {
+        let lines = vec![
+            line(LineAttribute::System, Some(7), vec![7]),
+            line(LineAttribute::Assistant, Some(7), vec![]),
+            line(LineAttribute::User, Some(0), vec![7]),
+        ];
+        let memory = system(0, lines.len() as i64);
+        assert_eq!(memory.get_slice_start_index(&lines).await, lines.len());
+    }
+
+    #[test]
+    fn invalidating_history_while_updating_advances_the_revision() {
+        let memory = system(30, 0);
+        memory.is_updating.store(true, Ordering::Release);
+        memory.invalidate_history();
+        memory.check_and_trigger_auto_update(&[]);
+        assert_eq!(memory.history_revision.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn correcting_an_out_of_range_pointer_marks_it_pending() {
+        let memory = system(30, 999);
+        memory.check_and_trigger_auto_update(&[]);
+        assert!(memory.has_pending.load(Ordering::Acquire));
+        let bank = memory.memory_bank.try_lock().expect("memory bank unlocked");
+        assert_eq!(bank.meta.last_processed_global_idx, 0);
+    }
+
+    #[test]
+    fn stale_results_cannot_commit_or_pollute_failure_cooldown() {
+        let gate = std::sync::Mutex::new(());
+        let revision = AtomicU64::new(2);
+        let last_failure = AtomicU64::new(0);
+        let failures = AtomicU32::new(0);
+        let pending = AtomicBool::new(false);
+        let mut bank = GameMemoryBank::default();
+        let original = bank.clone();
+
+        assert!(!record_failure_if_current(
+            &gate,
+            &revision,
+            1,
+            &last_failure,
+            &failures,
+        ));
+        assert_eq!(last_failure.load(Ordering::Acquire), 0);
+        assert_eq!(failures.load(Ordering::Acquire), 0);
+
+        assert!(!commit_update_if_current(
+            &gate,
+            &revision,
+            1,
+            &mut bank,
+            ["st".into(), "lt".into(), "ui".into(), "pr".into()],
+            99,
+            &last_failure,
+            &failures,
+            &pending,
+        ));
+        assert_eq!(bank, original);
+        assert!(!pending.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn current_result_commits_all_sections_and_pointer_atomically() {
+        let gate = std::sync::Mutex::new(());
+        let revision = AtomicU64::new(3);
+        let last_failure = AtomicU64::new(42);
+        let failures = AtomicU32::new(2);
+        let pending = AtomicBool::new(false);
+        let mut bank = GameMemoryBank::default();
+
+        assert!(commit_update_if_current(
+            &gate,
+            &revision,
+            3,
+            &mut bank,
+            ["st".into(), "lt".into(), "ui".into(), "pr".into()],
+            12,
+            &last_failure,
+            &failures,
+            &pending,
+        ));
+        assert_eq!(bank.data.short_term, "st");
+        assert_eq!(bank.data.long_term, "lt");
+        assert_eq!(bank.data.user_info, "ui");
+        assert_eq!(bank.data.promises, "pr");
+        assert_eq!(bank.meta.last_processed_global_idx, 12);
+        assert_eq!(last_failure.load(Ordering::Acquire), 0);
+        assert_eq!(failures.load(Ordering::Acquire), 0);
+        assert!(pending.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn updating_guard_always_releases_the_flag() {
+        let flag = Arc::new(AtomicBool::new(true));
+        {
+            let _guard = UpdatingGuard(flag.clone());
+        }
+        assert!(!flag.load(Ordering::Acquire));
+    }
 }

--- a/src-tauri/src/ai_service/game_system/role_manager.rs
+++ b/src-tauri/src/ai_service/game_system/role_manager.rs
@@ -316,7 +316,7 @@ impl GameRoleManager {
                             s.sync_to_role(role);
                         }
                         s.check_and_trigger_auto_update(source_lines);
-                        let start = s.get_slice_start_index().await;
+                        let start = s.get_slice_start_index(source_lines).await;
                         let sys_text = s.get_system_memory_text().await;
                         let short = s.get_short_term_user_text().await;
                         (true, start, sys_text, short)
@@ -327,7 +327,7 @@ impl GameRoleManager {
             };
 
             // 阶段 3: 裁剪 + 构建角色记忆
-            let sliced: Vec<GameLine> = if slice_start > 0 && slice_start < source_lines.len() {
+            let sliced: Vec<GameLine> = if slice_start > 0 && slice_start <= source_lines.len() {
                 source_lines[slice_start..].to_vec()
             } else {
                 source_lines.to_vec()
@@ -365,6 +365,13 @@ impl GameRoleManager {
     }
 
     // ── MemoryBank 集成方法 ──
+
+    /// 台词历史即将重建；让所有进行中的摘要任务在提交时自动作废。
+    pub fn invalidate_memory_history(&self) {
+        for system in self.memory_bank_systems.values() {
+            system.invalidate_history();
+        }
+    }
 
     /// 惰性构造角色的 `PersistentMemorySystem`。
     ///
@@ -597,13 +604,13 @@ impl GameRoleManager {
     /// 将 MemoryBank 文本合并到 LLM 消息中。
     ///
     /// - `system_addendum`：合并到第一条 system 消息末尾
-    /// - `short_term_prefix`：保留参数（Python 版对应的 user 前缀合并已注释，此处同步）
+    /// - `short_term_prefix`：前置到第一条 user 消息；没有 user 时在 system 后插入
     ///
     /// 另会合并连续出现的多条 system 消息为一条。
     fn merge_memory_bank_into_context(
         memory: Vec<LlmMessage>,
         system_addendum: &str,
-        _short_term_prefix: &str,
+        short_term_prefix: &str,
     ) -> Vec<LlmMessage> {
         let mut out = memory;
 
@@ -619,6 +626,21 @@ impl GameRoleManager {
                 }
             } else {
                 out.push(LlmMessage::system(system_addendum));
+            }
+        }
+
+        if !short_term_prefix.trim().is_empty() {
+            let insert_at = out
+                .iter()
+                .position(|message| message.role != "system")
+                .unwrap_or(out.len());
+            if out.get(insert_at).is_some_and(|message| message.role == "user") {
+                let first_user = &mut out[insert_at];
+                if !first_user.content.contains(short_term_prefix) {
+                    first_user.content = format!("{}{}", short_term_prefix, first_user.content);
+                }
+            } else {
+                out.insert(insert_at, LlmMessage::user(short_term_prefix));
             }
         }
 
@@ -647,6 +669,99 @@ impl GameRoleManager {
     /// 提供给 memory_builder 之外的工具：把 `memory` 合并成 `[{role,content}, ...]` 的 serde 形式。
     pub fn memory_as_json(&self, role_id: i32) -> Option<Vec<LlmMessage>> {
         self.loaded_roles.get(&role_id).map(|r| r.memory.clone())
+    }
+}
+
+#[cfg(test)]
+mod memory_bank_context_tests {
+    use super::GameRoleManager;
+    use crate::ai_service::game_system::persistent_memory_system::{
+        MemorySectionLimits, PersistentMemorySystem,
+    };
+    use crate::ai_service::llm::LlmSlot;
+    use crate::ai_service::types::{GameMemoryBank, LlmMessage};
+    use crate::config::tts::TtsConfig;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    #[test]
+    fn invalidation_covers_systems_for_roles_no_longer_present_in_history() {
+        let llm: LlmSlot = Arc::new(RwLock::new(None));
+        let mut manager = GameRoleManager::new(
+            PathBuf::new(),
+            llm.clone(),
+            TtsConfig::default(),
+            None,
+            true,
+            250,
+            30,
+            MemorySectionLimits::default(),
+        );
+        for role_id in [1, 2] {
+            manager.memory_bank_systems.insert(
+                role_id,
+                PersistentMemorySystem::new(
+                    role_id,
+                    &GameMemoryBank::default(),
+                    llm.clone(),
+                    true,
+                    250,
+                    30,
+                    MemorySectionLimits::default(),
+                    "AI",
+                ),
+            );
+        }
+
+        manager.invalidate_memory_history();
+        assert!(manager
+            .memory_bank_systems
+            .values()
+            .all(|system| system.history_revision_for_test() == 1));
+    }
+
+    #[test]
+    fn short_term_summary_is_prepended_to_the_first_user_message_once() {
+        let output = GameRoleManager::merge_memory_bank_into_context(
+            vec![LlmMessage::system("persona"), LlmMessage::user("hello")],
+            "\nMEMORY\n",
+            "【近期回顾】summary\n\n",
+        );
+        assert_eq!(output[0].role, "system");
+        assert!(output[0].content.contains("MEMORY"));
+        assert_eq!(output[1].role, "user");
+        assert_eq!(output[1].content, "【近期回顾】summary\n\nhello");
+        assert_eq!(output[1].content.matches("【近期回顾】summary").count(), 1);
+    }
+
+    #[test]
+    fn short_term_summary_is_inserted_before_an_earlier_assistant_block() {
+        let output = GameRoleManager::merge_memory_bank_into_context(
+            vec![
+                LlmMessage::system("persona"),
+                LlmMessage::assistant("older assistant"),
+                LlmMessage::user("later user"),
+            ],
+            "",
+            "【近期回顾】summary\n\n",
+        );
+        assert_eq!(output[0].role, "system");
+        assert_eq!(output[1], LlmMessage::user("【近期回顾】summary\n\n"));
+        assert_eq!(output[2].role, "assistant");
+        assert_eq!(output[3].content, "later user");
+    }
+
+    #[test]
+    fn short_term_summary_is_inserted_when_no_user_message_exists() {
+        let output = GameRoleManager::merge_memory_bank_into_context(
+            vec![LlmMessage::system("persona"), LlmMessage::assistant("hello")],
+            "",
+            "【近期回顾】summary\n\n",
+        );
+        assert_eq!(output[0].role, "system");
+        assert_eq!(output[1], LlmMessage::user("【近期回顾】summary\n\n"));
+        assert_eq!(output[2].role, "assistant");
     }
 }
 

--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -293,6 +293,7 @@ impl MessageGenerator {
             return Ok(());
         };
         let mut gs = self.deps.game_status.lock().await;
+        gs.role_manager.invalidate_memory_history();
         if let Some(line) = gs.line_list.get_mut(idx) {
             line.base.content = ctx.processed.replace(temp, "");
         }
@@ -552,6 +553,7 @@ impl MessageGenerator {
             let mut gs = self.deps.game_status.lock().await;
             // 试玩代号守卫：试玩中止后丢弃迟到回填，与 add_assistant_line 行为一致
             if gs.preview_generation == self.deps.generation {
+                gs.role_manager.invalidate_memory_history();
                 let insert_pos = tool_insert_pos.min(gs.line_list.len());
                 let perceived: Vec<i32> = gs.present_role_ids.iter().copied().collect();
 

--- a/src-tauri/src/ai_service/service.rs
+++ b/src-tauri/src/ai_service/service.rs
@@ -148,6 +148,7 @@ impl AIService {
 
     pub async fn init_game_status(&mut self) -> Result<()> {
         let mut gs = self.game_status.lock().await;
+        gs.role_manager.invalidate_memory_history();
         gs.role_manager.reset_roles();
         gs.line_list.clear();
         gs.onstage_role_ids.clear();
@@ -202,6 +203,7 @@ impl AIService {
     ) -> Result<()> {
         {
             let mut gs = self.game_status.lock().await;
+            gs.role_manager.invalidate_memory_history();
             gs.line_list = lines;
             if let Some(sid) = save_id {
                 gs.active_save_id = Some(sid);
@@ -238,6 +240,7 @@ impl AIService {
     /// 轻量清理：只清空台词 + 主角短期记忆，NPC 记忆保留。
     pub async fn clear_lines(&mut self) -> Result<()> {
         let mut gs = self.game_status.lock().await;
+        gs.role_manager.invalidate_memory_history();
         gs.line_list.clear();
 
         let system_line = LineBase {

--- a/src-tauri/src/api/chat.rs
+++ b/src-tauri/src/api/chat.rs
@@ -285,6 +285,7 @@ pub async fn rollback_conversation(
             .ok_or_else(|| format!("未找到序号为 {} 的用户消息", message_seq))?;
 
         // truncate(idx) 移除 idx..len（含目标消息及之后所有内容）
+        gs.role_manager.invalidate_memory_history();
         gs.line_list.truncate(idx);
         gs.refresh_memories(&db)
             .await

--- a/src-tauri/src/api/script_editor/commands.rs
+++ b/src-tauri/src/api/script_editor/commands.rs
@@ -1562,6 +1562,7 @@ impl PreviewSession {
         // 失败时把已拍快照套回去再报错：否则试玩启动失败也会把自由对话的
         // 在场角色/台词表留在被清空的状态。
         if let Err(e) = gs.get_role(db, main_id).await {
+            gs.role_manager.invalidate_memory_history();
             gs.line_list.truncate(saved.line_len);
             gs.apply_snapshot(&saved.scene);
             gs.main_role_id = saved.main_role_id;
@@ -1617,6 +1618,7 @@ impl PreviewSession {
         // 立即过期，它们的迟到写入会被 add_assistant_line 的守卫丢弃，不再
         // 污染已还原的自由对话会话。
         gs.preview_generation = gs.preview_generation.wrapping_add(1);
+        gs.role_manager.invalidate_memory_history();
         gs.line_list.truncate(self.line_len);
         gs.apply_snapshot(&self.scene);
         gs.main_role_id = self.main_role_id;

--- a/src-tauri/src/api/settings.rs
+++ b/src-tauri/src/api/settings.rs
@@ -18,11 +18,35 @@ use crate::ai_service::llm::provider_config::{
     LlmProvidersResponse,
 };
 use crate::ai_service::llm::LlmModelInfo;
-use crate::config::app_config::{MAX_LLM_TIMEOUT_SECS, MIN_LLM_TIMEOUT_SECS};
+use crate::config::app_config::{
+    MAX_LLM_TIMEOUT_SECS, MAX_MEMORY_RECENT_WINDOW, MAX_MEMORY_SECTION_CHARS,
+    MAX_MEMORY_UPDATE_INTERVAL, MIN_LLM_TIMEOUT_SECS, MIN_MEMORY_UPDATE_INTERVAL,
+};
 use crate::config::{self, keys, ConfigSetting, ConfigTree};
 use crate::AppState;
 
 // ========== Settings CRUD ==========
+
+fn validate_u32_setting(
+    values: &BTreeMap<String, String>,
+    key: &str,
+    label: &str,
+    min: u32,
+    max: u32,
+) -> Result<(), String> {
+    let Some(raw) = values.get(key) else {
+        return Ok(());
+    };
+    let value = raw
+        .parse::<u64>()
+        .ok()
+        .and_then(|number| u32::try_from(number).ok())
+        .ok_or_else(|| format!("{label} 必须是 0–{max} 范围内的整数"))?;
+    if !(min..=max).contains(&value) {
+        return Err(format!("{label} 必须在 {min}–{max} 之间"));
+    }
+    Ok(())
+}
 
 #[tauri::command]
 pub fn get_settings_tree(app: AppHandle) -> ConfigTree {
@@ -41,6 +65,42 @@ pub fn save_settings(app: AppHandle, values: BTreeMap<String, String>) -> Result
             ));
         }
     }
+
+    validate_u32_setting(
+        &values,
+        keys::MEMORY_UPDATE_INTERVAL,
+        "记忆压缩触发条数",
+        MIN_MEMORY_UPDATE_INTERVAL,
+        MAX_MEMORY_UPDATE_INTERVAL,
+    )?;
+    validate_u32_setting(
+        &values,
+        keys::MEMORY_RECENT_WINDOW,
+        "记忆最近窗口",
+        0,
+        MAX_MEMORY_RECENT_WINDOW,
+    )?;
+    for (key, label) in [
+        (keys::MEMORY_SHORT_TERM_MAX_CHARS, "短期记忆长度上限"),
+        (keys::MEMORY_LONG_TERM_MAX_CHARS, "长期记忆长度上限"),
+        (keys::MEMORY_USER_INFO_MAX_CHARS, "用户信息长度上限"),
+        (keys::MEMORY_PROMISES_MAX_CHARS, "约定长度上限"),
+    ] {
+        validate_u32_setting(&values, key, label, 0, MAX_MEMORY_SECTION_CHARS)?;
+    }
+
+    let memory_settings_changed = values.keys().any(|key| {
+        matches!(
+            key.as_str(),
+            keys::USE_PERSISTENT_MEMORY
+                | keys::MEMORY_UPDATE_INTERVAL
+                | keys::MEMORY_RECENT_WINDOW
+                | keys::MEMORY_SHORT_TERM_MAX_CHARS
+                | keys::MEMORY_LONG_TERM_MAX_CHARS
+                | keys::MEMORY_USER_INFO_MAX_CHARS
+                | keys::MEMORY_PROMISES_MAX_CHARS
+        )
+    });
 
     let store = config::settings_store(&app).map_err(|e| e.to_string())?;
 
@@ -65,7 +125,11 @@ pub fn save_settings(app: AppHandle, values: BTreeMap<String, String>) -> Result
 
     store.save().map_err(|e| e.to_string())?;
 
-    Ok("配置已成功保存并已生效！".to_string())
+    if memory_settings_changed {
+        Ok("配置已成功保存；记忆压缩相关设置将在重启 LingChat 后生效。".to_string())
+    } else {
+        Ok("配置已成功保存并已生效！".to_string())
+    }
 }
 
 #[tauri::command]
@@ -298,4 +362,44 @@ pub fn set_hdr_mode(app: AppHandle, enabled: bool) -> Result<(), String> {
     );
     store.save().map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[cfg(test)]
+mod memory_setting_validation_tests {
+    use super::validate_u32_setting;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn rejects_overflow_negative_and_out_of_range_values() {
+        for raw in ["4294967296", "-1", "0"] {
+            let values = BTreeMap::from([("memory".to_string(), raw.to_string())]);
+            assert!(validate_u32_setting(&values, "memory", "memory", 1, 10_000).is_err());
+        }
+    }
+
+    #[test]
+    fn zero_min_accepts_zero_and_rejects_invalid_large_values() {
+        let zero = BTreeMap::from([("memory".to_string(), "0".to_string())]);
+        assert!(validate_u32_setting(&zero, "memory", "memory", 0, 10_000).is_ok());
+        for raw in ["10001", "18446744073709551615", "not-a-number"] {
+            let values = BTreeMap::from([("memory".to_string(), raw.to_string())]);
+            assert!(validate_u32_setting(&values, "memory", "memory", 0, 10_000).is_err());
+        }
+    }
+
+    #[test]
+    fn accepts_valid_boundaries_and_missing_values() {
+        for raw in ["1", "10000"] {
+            let values = BTreeMap::from([("memory".to_string(), raw.to_string())]);
+            assert!(validate_u32_setting(&values, "memory", "memory", 1, 10_000).is_ok());
+        }
+        assert!(validate_u32_setting(
+            &BTreeMap::new(),
+            "memory",
+            "memory",
+            1,
+            10_000,
+        )
+        .is_ok());
+    }
 }

--- a/src-tauri/src/config/app_config.rs
+++ b/src-tauri/src/config/app_config.rs
@@ -56,6 +56,10 @@ fn default_memory_promises_max_chars() -> u32 {
 pub const DEFAULT_LLM_TIMEOUT_SECS: u64 = 120;
 pub const MIN_LLM_TIMEOUT_SECS: u64 = 10;
 pub const MAX_LLM_TIMEOUT_SECS: u64 = 3600;
+pub const MIN_MEMORY_UPDATE_INTERVAL: u32 = 1;
+pub const MAX_MEMORY_UPDATE_INTERVAL: u32 = 10_000;
+pub const MAX_MEMORY_RECENT_WINDOW: u32 = 10_000;
+pub const MAX_MEMORY_SECTION_CHARS: u32 = 1_000_000;
 
 fn default_llm_timeout_secs() -> u64 {
     DEFAULT_LLM_TIMEOUT_SECS
@@ -158,6 +162,21 @@ fn get_u32(store: &Store<Wry>, key: &str, default: u32) -> u32 {
         .unwrap_or(default)
 }
 
+fn get_u32_in_range(
+    store: &Store<Wry>,
+    key: &str,
+    default: u32,
+    min: u32,
+    max: u32,
+) -> u32 {
+    store
+        .get(key)
+        .and_then(|value| value.as_u64())
+        .and_then(|value| u32::try_from(value).ok())
+        .filter(|value| (min..=max).contains(value))
+        .unwrap_or(default)
+}
+
 fn get_u64_in_range(store: &Store<Wry>, key: &str, default: u64, min: u64, max: u64) -> u64 {
     store
         .get(key)
@@ -208,35 +227,47 @@ impl AppConfig {
                 keys::USE_PERSISTENT_MEMORY,
                 default.use_persistent_memory,
             ),
-            memory_update_interval: get_u32(
+            memory_update_interval: get_u32_in_range(
                 &store,
                 keys::MEMORY_UPDATE_INTERVAL,
                 default.memory_update_interval,
+                MIN_MEMORY_UPDATE_INTERVAL,
+                MAX_MEMORY_UPDATE_INTERVAL,
             ),
-            memory_recent_window: get_u32(
+            memory_recent_window: get_u32_in_range(
                 &store,
                 keys::MEMORY_RECENT_WINDOW,
                 default.memory_recent_window,
+                0,
+                MAX_MEMORY_RECENT_WINDOW,
             ),
-            memory_short_term_max_chars: get_u32(
+            memory_short_term_max_chars: get_u32_in_range(
                 &store,
                 keys::MEMORY_SHORT_TERM_MAX_CHARS,
                 default.memory_short_term_max_chars,
+                0,
+                MAX_MEMORY_SECTION_CHARS,
             ),
-            memory_long_term_max_chars: get_u32(
+            memory_long_term_max_chars: get_u32_in_range(
                 &store,
                 keys::MEMORY_LONG_TERM_MAX_CHARS,
                 default.memory_long_term_max_chars,
+                0,
+                MAX_MEMORY_SECTION_CHARS,
             ),
-            memory_user_info_max_chars: get_u32(
+            memory_user_info_max_chars: get_u32_in_range(
                 &store,
                 keys::MEMORY_USER_INFO_MAX_CHARS,
                 default.memory_user_info_max_chars,
+                0,
+                MAX_MEMORY_SECTION_CHARS,
             ),
-            memory_promises_max_chars: get_u32(
+            memory_promises_max_chars: get_u32_in_range(
                 &store,
                 keys::MEMORY_PROMISES_MAX_CHARS,
                 default.memory_promises_max_chars,
+                0,
+                MAX_MEMORY_SECTION_CHARS,
             ),
             tts: TtsConfig::from_store(Some(&store)),
         })

--- a/src-tauri/src/config/tree.rs
+++ b/src-tauri/src/config/tree.rs
@@ -176,7 +176,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
         feat_subs.insert(
             "记忆系统".to_string(),
             Subcategory {
-                description: "在这里设定你想要的永久记忆效果".to_string(),
+                description: "在这里设定永久记忆效果；本组设置保存后需重启 LingChat 才会应用到压缩引擎".to_string(),
                 settings: vec![
                     ConfigSetting {
                         key: keys::USE_PERSISTENT_MEMORY.to_string(),
@@ -197,7 +197,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             keys::MEMORY_UPDATE_INTERVAL,
                             &app_defaults.memory_update_interval.to_string(),
                         ),
-                        description: "MEMORY_UPDATE_INTERVAL — 触发记忆摘要的新消息数（默认 250）"
+                        description: "MEMORY_UPDATE_INTERVAL — 触发记忆摘要的可见台词数（1–10000，默认 250，重启生效）"
                             .to_string(),
                         setting_type: "text".to_string(),
                     },
@@ -208,7 +208,7 @@ pub fn build_config_tree(app: &AppHandle) -> ConfigTree {
                             keys::MEMORY_RECENT_WINDOW,
                             &app_defaults.memory_recent_window.to_string(),
                         ),
-                        description: "MEMORY_RECENT_WINDOW — 摘要时保留的最近消息数（默认 30）"
+                        description: "MEMORY_RECENT_WINDOW — 压缩后保留的该角色最近可见台词数（0–10000，默认 30，重启生效）"
                             .to_string(),
                         setting_type: "text".to_string(),
                     },

--- a/src-tauri/src/init/mod.rs
+++ b/src-tauri/src/init/mod.rs
@@ -65,6 +65,16 @@ pub async fn initialize(
 
     // 提前加载配置 + 构建 LlmClient（AIService 的子成员 GameRoleManager 需要它）
     let app_config = AppConfig::load(&app.handle()).unwrap_or_default();
+    tracing::info!(
+        "MemoryBank 配置: enabled={}, update_interval={}, recent_window={}, limits=[{},{},{},{}]（记忆设置需重启生效）",
+        app_config.use_persistent_memory,
+        app_config.memory_update_interval,
+        app_config.memory_recent_window,
+        app_config.memory_short_term_max_chars,
+        app_config.memory_long_term_max_chars,
+        app_config.memory_user_info_max_chars,
+        app_config.memory_promises_max_chars,
+    );
 
     // 构建聊天主 LLM 槽位（支持运行时热切换）。
     // 槽位本身始终存在，未配置模型时内部值为 None。

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -218,9 +218,9 @@ export default {
       features: {
         enable_time_sense: "USE_TIME_SENSE — Enable time awareness (adds system reminders based on contextual time)",
         enable_emotion_classifier: "ENABLE_EMOTION_CLASSIFIER — Enable the emotion classifier (ONNX model, auto-tags dialogue emotions)",
-        use_persistent_memory: "USE_PERSISTENT_MEMORY — When on, memory is auto-compressed to reduce token usage",
-        memory_update_interval: "MEMORY_UPDATE_INTERVAL — Number of new messages that triggers a memory summary (default 250)",
-        memory_recent_window: "MEMORY_RECENT_WINDOW — Number of recent messages kept when summarizing (default 30)",
+        use_persistent_memory: "USE_PERSISTENT_MEMORY — Auto-compress memory; restart after saving to apply",
+        memory_update_interval: "MEMORY_UPDATE_INTERVAL — Visible lines that trigger a summary (1–10000; default 250)",
+        memory_recent_window: "MEMORY_RECENT_WINDOW — Recent role-visible lines kept after compression (0–10000; default 30)",
       },
       tts: {
         simple_vits_api_url: "Simple-Vits-API address (VITS adapter)",
@@ -711,7 +711,7 @@ export default {
     },
     memory: {
       title: "Enable Persistent Memory",
-      desc: "When on, memory is automatically compressed",
+      desc: "When on, memory is automatically compressed; restart LingChat after saving to apply",
     },
     voiceSound: {
       title: "Voice Sound Effects",

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -217,9 +217,9 @@ export default {
       features: {
         enable_time_sense: 'USE_TIME_SENSE — 時間認識を有効化（コンテキストの時刻に応じてシステムリマインドを追加）',
         enable_emotion_classifier: 'ENABLE_EMOTION_CLASSIFIER — 感情分類器を有効化（ONNX モデル、会話 emotion の自動タグ付け）',
-        use_persistent_memory: 'USE_PERSISTENT_MEMORY — オンにすると記憶が自動圧縮されトークン消費を削減',
-        memory_update_interval: 'MEMORY_UPDATE_INTERVAL — 記憶要約を発動する新規メッセージ数（デフォルト 250）',
-        memory_recent_window: 'MEMORY_RECENT_WINDOW — 要約時に保持する直近メッセージ数（デフォルト 30）',
+        use_persistent_memory: 'USE_PERSISTENT_MEMORY — 記憶を自動圧縮します。保存後の再起動で反映されます',
+        memory_update_interval: 'MEMORY_UPDATE_INTERVAL — 要約を開始する可視台詞数（1–10000、既定 250）',
+        memory_recent_window: 'MEMORY_RECENT_WINDOW — 圧縮後に保持する役割可視台詞数（0–10000、既定 30）',
       },
       tts: {
         simple_vits_api_url: 'Simple-Vits-API アドレス（VITS アダプター）',
@@ -709,7 +709,7 @@ export default {
     },
     memory: {
       title: '永続メモリを有効化',
-      desc: '有効にすると、記憶は自動的に圧縮されます',
+      desc: '有効にすると記憶が自動圧縮されます。保存後に LingChat を再起動すると反映されます',
     },
     voiceSound: {
       title: '音声効果音スイッチ',

--- a/src/locales/zh-CN/settings.ts
+++ b/src/locales/zh-CN/settings.ts
@@ -218,9 +218,9 @@ export default {
       features: {
         enable_time_sense: 'USE_TIME_SENSE — 启用时间感知（根据上下文时间添加系统提醒）',
         enable_emotion_classifier: 'ENABLE_EMOTION_CLASSIFIER — 启用情感分类器（ONNX 模型，用于自动标注对话 emotion）',
-        use_persistent_memory: 'USE_PERSISTENT_MEMORY — 开启后记忆会自动压缩，减少 token 消耗',
-        memory_update_interval: 'MEMORY_UPDATE_INTERVAL — 触发记忆摘要的新消息数（默认 250）',
-        memory_recent_window: 'MEMORY_RECENT_WINDOW — 摘要时保留的最近消息数（默认 30）',
+        use_persistent_memory: 'USE_PERSISTENT_MEMORY — 开启后记忆会自动压缩，保存后需重启生效',
+        memory_update_interval: 'MEMORY_UPDATE_INTERVAL — 触发摘要的可见台词数（1–10000，默认 250）',
+        memory_recent_window: 'MEMORY_RECENT_WINDOW — 压缩后保留的角色可见台词数（0–10000，默认 30）',
       },
       tts: {
         simple_vits_api_url: 'Simple-Vits-API 地址（VITS 适配器）',
@@ -710,7 +710,7 @@ export default {
     },
     memory: {
       title: '启用永久记忆',
-      desc: '开启后记忆将会自动压缩',
+      desc: '开启后记忆将自动压缩，保存后需重启 LingChat 生效',
     },
     voiceSound: {
       title: '语音音效开关',

--- a/src/locales/zh-HK/settings.ts
+++ b/src/locales/zh-HK/settings.ts
@@ -218,9 +218,9 @@ export default {
       "features": {
         "enable_time_sense": "USE_TIME_SENSE — 啟用時間感知（按上下文時間加系統提醒）",
         "enable_emotion_classifier": "ENABLE_EMOTION_CLASSIFIER — 啟用情感分類器（ONNX 模型，用嚟自動標註對話嘅 emotion）",
-        "use_persistent_memory": "USE_PERSISTENT_MEMORY — 開咗之後記憶會自動壓縮，慳返 token",
-        "memory_update_interval": "MEMORY_UPDATE_INTERVAL — 觸發記憶摘要嘅新訊息數（預設 250）",
-        "memory_recent_window": "MEMORY_RECENT_WINDOW — 做摘要嗰陣保留嘅最近訊息數（預設 30）"
+        "use_persistent_memory": "USE_PERSISTENT_MEMORY — 自動壓縮記憶，儲存後要重啟先會生效",
+        "memory_update_interval": "MEMORY_UPDATE_INTERVAL — 觸發摘要嘅可見台詞數（1–10000，預設 250）",
+        "memory_recent_window": "MEMORY_RECENT_WINDOW — 壓縮後保留嘅角色可見台詞數（0–10000，預設 30）"
       },
       "tts": {
         "simple_vits_api_url": "Simple-Vits-API 地址（VITS 適配器）",
@@ -710,7 +710,7 @@ export default {
     },
     "memory": {
       "title": "啟用永久記憶",
-      "desc": "開咗之後記憶會自動壓縮"
+      "desc": "開咗之後記憶會自動壓縮，儲存後要重啟 LingChat 先會生效"
     },
     "voiceSound": {
       "title": "語音音效開關",


### PR DESCRIPTION
## 问题

自动 MemoryBank 压缩存在多处实际失效或竞态：短期摘要生成但从未注入；recent_window=0 退化成全历史；窗口按原始行而非角色可见台词计算；撤回/读档期间旧后台任务可写回过期摘要或污染 60 秒失败冷却；配置数值可 u32 回绕；设置保存结果没有说明重启生效。

## 修复

- 把短期摘要按时间顺序前置到第一条非-system 消息，并跳过默认占位文本。
- recent_window 改按角色可见、非 system、非空台词计数；0 正确表示不保留已压缩历史。
- 所有 line_list 语义变更在 mutation 前统一 invalidate 全部 MemoryBank systems。
- 用 history revision + commit gate 线性化失效、成功提交和失败冷却；旧任务不能写入摘要/指针/pending/cooldown。
- `compare_exchange` 防止并发双启动，RAII guard 确保 panic 后释放 updating。
- 指针越界修正会进入 pending 并可持久化。
- 记忆数值配置使用 `u32::try_from` 和业务范围验证，拒绝负数、溢出和非法边界。
- 设置页及四语言文案明确记忆设置需重启生效；启动日志打印实际 MemoryBank 配置。

## 验证

- `cargo test --manifest-path src-tauri/Cargo.toml --lib`：22 passed
- `pnpm build`：通过
- `git diff --check`：通过

当前实机存档只有 18 条台词、当前角色可见 17 条，低于默认 250 条阈值，因此没有触发日志属于正常现象，不是此次修复后的失败。