### PR TITLE
fix(asr): 语音输入总开关改为整体开关

### DIFF
--- a/src/components/game/standard/GameDialog.vue
+++ b/src/components/game/standard/GameDialog.vue
@@ -364,8 +364,7 @@
 
   // mic 按钮 enabled 条件（与 useAsrInput.canStartAsr 对齐）：
   // - auto_listen 模式开 + 总开关开：功能开关可用
-  // - 总开关关 → 退化为手动录音（canStartAsr forManual=true 跳过显示锁与总开关——
-  //   总开关只挡自动，不锁手动）
+  // - 总开关关 → 整体禁用（总开关是语音输入的总闸，手动 mic 一并关闭）
   const canStartMic = computed(
     () =>
       (autoListenOn.value && asrStore.settings.voice_input_enabled) ||

--- a/src/components/pet/GameRolesStage.vue
+++ b/src/components/pet/GameRolesStage.vue
@@ -261,7 +261,7 @@ const micTitle = computed(() => {
 })
 // mic 按钮 enabled 条件（与 GameDialog 一致）：
 // - auto_listen 模式开 + 总开关开：功能开关可用
-// - 总开关关 → 退化为手动录音（canStartAsr 手动变体——总开关只挡自动，不锁手动；
+// - 总开关关 → 整体禁用（总开关是语音输入的总闸，手动 mic 一并关闭；
 //   显示锁只挡 auto 触发，手动不受限）
 const canStartMic = computed(
   () =>

--- a/src/composables/useAsrInput.ts
+++ b/src/composables/useAsrInput.ts
@@ -163,11 +163,11 @@ function discardRecording() {
 // 8.    runningScript && choices.length > 0（剧本选择分支）
 // 9.    loadingComplete === false（启动动画未完成）
 // 10.   显示锁未过期（识别结果填入后短暂禁止再触发；ignoreLock 供监测启停跳过）
-// 11.   语音输入总开关关（auto 触发被挡）
+// 11.   语音输入总开关关（自动与手动录音都被挡——总开关是整体语音输入开关）
 // 12.   TTS 播放中（外放语音会被误识别）
 // 任何一项满足即视为不可用。start() / startEnergyMonitor RMS 触发 / 按钮 enable 都查它。
-// forManual=true（手动 mic 录音）：跳过 10 显示锁与 11 总开关——总开关只挡自动模式、
-// 锁防的是 auto 触发覆盖识别结果（手动是用户主动，不受限）。
+// forManual=true（手动 mic 录音）：仅跳过 10 显示锁——锁防的是 auto 触发覆盖识别
+// 结果（手动是用户主动，不受锁限）；总开关一律生效。
 function canStartAsr(ignoreLock = false, forManual = false): boolean {
   if (!route || !uiStore || !gameStore) return false
   // 6 + 7：路由/抽屉门控（chatActive 已是这两项的合成；/chat 与 /pet 均可）
@@ -184,8 +184,8 @@ function canStartAsr(ignoreLock = false, forManual = false): boolean {
   const script = (gameStore as unknown as { runningScript?: { choices?: unknown[] } })
     .runningScript
   if (script && Array.isArray(script.choices) && script.choices.length > 0) return false
-  // 11：语音输入总开关——只挡自动模式（auto 触发/自动监听）；手动 mic 录音不受限
-  if (!forManual && !asrStore?.settings.voice_input_enabled) return false
+  // 11：语音输入总开关——整体语音输入开关（自动与手动都被挡）
+  if (!asrStore?.settings.voice_input_enabled) return false
   // 12：角色语音（TTS）播放中（外放 TTS 进麦克风 → 误识别 AI 自己的话）
   if (voicePlaying.value) return false
   // 10：识别结果短暂显示锁（fill_only 填入 inputMessage 到自动 send 的窗口期）。
@@ -429,7 +429,7 @@ function stopEnergyMonitor() {
 
 // ── 会话生命周期 ────────────────────────────────────────────
 async function start(source: AsrSource) {
-  // §1 全 12 项门控；手动模式（button）跳过显示锁与总开关（总开关只挡自动）
+  // §1 全 12 项门控；手动模式（button）跳过显示锁（总开关一律生效）
   if (!canStartAsr(false, source === 'button')) {
     // 诊断：静默拒绝会让按钮"按下无反应"，暴露拒绝原因
     console.log('[ASR] start 被门控拒绝', {

--- a/src/locales/en/settings.ts
+++ b/src/locales/en/settings.ts
@@ -1080,7 +1080,7 @@ export default {
     },
     voiceInput: 'Voice input',
     voiceInputHint:
-      'Master switch: when off, auto voice input is disabled; manual mic recording still works',
+      'Master switch: when off, voice input is fully disabled (auto and manual mic)',
     autoListen: 'Enable automatic speech recognition',
     autoListenHint: 'Auto-listen to microphone and convert user speech to text',
     vadSilence: 'Silence timeout (ms)',

--- a/src/locales/ja/settings.ts
+++ b/src/locales/ja/settings.ts
@@ -1077,7 +1077,7 @@ export default {
       vadLoadedNo: '未読込',
     },
     voiceInput: '音声入力',
-    voiceInputHint: 'マスタースイッチ：オフにすると自動音声認識が無効、手動マイク録音は引き続き使用可能',
+    voiceInputHint: 'マスタースイッチ：オフにすると音声入力がすべて無効（自動・手動マイクとも）',
     autoListen: '自動音声認識を有効化',
     autoListenHint: 'マイクを自動監視し、ユーザーの発話をテキストに変換',
     vadSilence: '無音タイムアウト（ms）',

--- a/src/locales/zh-CN/settings.ts
+++ b/src/locales/zh-CN/settings.ts
@@ -1078,7 +1078,7 @@ export default {
       vadLoadedNo: '未加载',
     },
     voiceInput: '语音输入',
-    voiceInputHint: '总开关：关闭后自动语音识别不可用，手动麦克风录音保留',
+    voiceInputHint: '总开关：关闭后语音输入整体不可用（自动与手动麦克风一并关闭）',
     autoListen: '启用自动语音识别',
     autoListenHint: '自动监听麦克风，识别用户说话后自动转为文本',
     vadSilence: '静音计时（毫秒）',

--- a/src/locales/zh-HK/settings.ts
+++ b/src/locales/zh-HK/settings.ts
@@ -1077,7 +1077,7 @@ export default {
       "vadLoadedNo": "未載入"
     },
     "voiceInput": "語音輸入",
-    "voiceInputHint": "總開關：關閉後自動語音識別不可用，手動麥克風錄音保留",
+    "voiceInputHint": "總開關：關閉後語音輸入整體不可用（自動與手動麥克風一併關閉）",
     "autoListen": "啟用自動語音識別",
     "autoListenHint": "自動監聽麥克風，識別用戶說話後自動轉為文字",
     "vadSilence": "靜音計時（毫秒）",


### PR DESCRIPTION
## 问题
- 此前总开关只挡自动模式:代码注释明说"总开关只挡自动，不锁手动"——canStartAsr 的 forManual=true 跳过总开关检查,总开关关闭时手动 mic 按钮仍可录音,与"总开关 = 整体语音输入开关"的直觉不符。
## 改动
- 总开关关闭后手动麦克风一并禁用