### PR TITLE
fix:对ios进行了适配，增加了ios的打包工作流

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,0 +1,73 @@
+name: iOS 无签名 IPA 构建
+
+on:
+  workflow_dispatch:
+    inputs:
+      compression:
+        description: 'data.7z 压缩等级（0-9）'
+        required: false
+        default: '9'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-latest
+    env:
+      # 移动端构建必须启用：让 webview 从应用内嵌资产加载前端
+      # （tauri CLI 会在 iOS 构建时自动附加 custom-protocol feature）
+      CARGO_PROFILE_RELEASE_OPT_LEVEL: 's'
+      CARGO_PROFILE_RELEASE_STRIP: 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      - name: 拉取 LFS 资源（游戏数据 + 图标）
+        run: |
+          git lfs pull --include="data/game_data/**,src-tauri/icons/**"
+
+      - uses: pnpm/setup@v1
+        with:
+          runtime: node@26
+          cache: true
+
+      - name: 安装 Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios
+
+      - name: 设置 rust 缓存
+        uses: swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/dev' }}
+
+      - name: 安装 xcodegen
+        run: brew install xcodegen
+
+      - name: 初始化（图标 + 下载情绪模型）
+        run: |
+          pnpm install
+          pnpm run init
+
+      - name: 初始化并配置 iOS Xcode 工程（iPhone + iPad）
+        run: bash scripts/configure-ios-project.sh
+
+      - name: 打包默认资源 data.7z
+        run: node scripts/prepare-bundled-resources.mjs ${{ github.event.inputs.compression }}
+
+      - name: 构建无签名 IPA
+        # beforeBuildCommand 会自动执行 prepare-desktop-resources.mjs + pnpm build；
+        # --no-sign 跳过代码签名（无需证书/描述文件）
+        run: pnpm tauri ios build --no-sign
+
+      - name: 上传 IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: lingchat-ios-unsigned
+          path: |
+            src-tauri/gen/apple/target/**/*.ipa
+          retention-days: 7

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -18,16 +18,8 @@ jobs:
     env:
       # workflow_dispatch 的 compression 输入 → 脚本内 data.7z 压缩等级（默认 9）
       IOS_BUNDLED_7Z_LEVEL: ${{ github.event.inputs.compression }}
-      # 移动端构建必须启用：让 webview 从应用内嵌资产加载前端
-      # （tauri CLI 会在 iOS 构建时自动附加 custom-protocol feature）
-      CARGO_PROFILE_RELEASE_OPT_LEVEL: 's'
-      CARGO_PROFILE_RELEASE_STRIP: 'true'
-      # pnpm 11 在 Xcode 的 Build Rust Code 脚本（无 TTY）里会做依赖校验并触发
-      # 自动 pnpm install，模块目录需清空时直接中止（ERR_PNPM_ABORTED_..._NO_TTY）。
-      # 用 pnpm_config_ 前缀的环境变量关闭（.npmrc 中的同名键会被 pnpm 11 过滤）。
-      pnpm_config_verify_deps_before_run: 'false'
-      pnpm_config_confirm_modules_purge: 'false'
-      CI: 'true'
+      # 其余构建环境（CI / pnpm_config_* / CARGO_PROFILE_RELEASE_*）由
+      # build-ios-unsigned.sh 内置设置（与本地流程单一事实来源）。
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -49,7 +49,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          save-if: ${{ github.ref == 'refs/heads/dev' }}
+          save-if: 'true'
 
       - name: 安装 xcodegen
         run: brew install xcodegen
@@ -84,5 +84,5 @@ jobs:
         with:
           name: lingchat-ios-unsigned
           path: |
-            src-tauri/gen/apple/target/**/*.ipa
+            src-tauri/gen/apple/build/**/*.ipa
           retention-days: 7

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -19,6 +19,12 @@ jobs:
       # （tauri CLI 会在 iOS 构建时自动附加 custom-protocol feature）
       CARGO_PROFILE_RELEASE_OPT_LEVEL: 's'
       CARGO_PROFILE_RELEASE_STRIP: 'true'
+      # pnpm 11 在 Xcode 的 Build Rust Code 脚本（无 TTY）里会做依赖校验并触发
+      # 自动 pnpm install，模块目录需清空时直接中止（ERR_PNPM_ABORTED_..._NO_TTY）。
+      # 用 pnpm_config_ 前缀的环境变量关闭（.npmrc 中的同名键会被 pnpm 11 过滤）。
+      pnpm_config_verify_deps_before_run: 'false'
+      pnpm_config_confirm_modules_purge: 'false'
+      CI: 'true'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -55,21 +55,9 @@ jobs:
 
       - name: 初始化并配置 iOS Xcode 工程（iPhone + iPad）
         run: |
-          echo "=== bash version ==="
-          bash --version | head -1
-          echo "=== git config core.autocrlf ==="
-          git config --get core.autocrlf || echo "(unset)"
-          echo "=== check-attr ==="
-          git check-attr text eol working-tree-encoding -- scripts/configure-ios-project.sh || true
-          echo "=== blob sha vs worktree sha ==="
+          echo "=== blob sha vs worktree sha (must be equal) ==="
           git rev-parse HEAD:scripts/configure-ios-project.sh
           git hash-object scripts/configure-ios-project.sh
-          echo "=== file type ==="
-          file scripts/configure-ios-project.sh
-          echo "=== od -c (first 32 lines) ==="
-          od -c scripts/configure-ios-project.sh | head -32
-          echo "=== cat -A (first 12 lines) ==="
-          cat -A scripts/configure-ios-project.sh | head -12
           echo "=== run configure script ==="
           bash scripts/configure-ios-project.sh
 
@@ -77,8 +65,8 @@ jobs:
         run: node scripts/prepare-bundled-resources.mjs ${{ github.event.inputs.compression }}
 
       - name: 构建无签名 IPA
-        # beforeBuildCommand 会自动执行 prepare-desktop-resources.mjs + pnpm build；
-        # --no-sign 跳过代码签名（无需证书/描述文件）
+        # beforeBuildCommand runs prepare-desktop-resources.mjs + pnpm build automatically;
+        # --no-sign skips code signing (no certificate / provisioning profile needed)
         run: pnpm tauri ios build --no-sign
 
       - name: 上传 IPA

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -67,6 +67,10 @@ jobs:
       - name: 构建无签名 IPA
         # beforeBuildCommand runs prepare-desktop-resources.mjs + pnpm build automatically;
         # --no-sign skips code signing (no certificate / provisioning profile needed)
+        env:
+          # pnpm 11 在 Xcode 的 Build Rust Code 脚本里做依赖校验时会触发自动 install；
+          # 显式 CI=true + .npmrc 的 verify-deps-before-run=false 避免无 TTY 中止
+          CI: "true"
         run: pnpm tauri ios build --no-sign
 
       - name: 上传 IPA

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -14,7 +14,10 @@ permissions:
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 90
     env:
+      # workflow_dispatch 的 compression 输入 → 脚本内 data.7z 压缩等级（默认 9）
+      IOS_BUNDLED_7Z_LEVEL: ${{ github.event.inputs.compression }}
       # 移动端构建必须启用：让 webview 从应用内嵌资产加载前端
       # （tauri CLI 会在 iOS 构建时自动附加 custom-protocol feature）
       CARGO_PROFILE_RELEASE_OPT_LEVEL: 's'
@@ -59,25 +62,13 @@ jobs:
           pnpm install
           pnpm run init
 
-      - name: 初始化并配置 iOS Xcode 工程（iPhone + iPad）
-        run: |
-          echo "=== blob sha vs worktree sha (must be equal) ==="
-          git rev-parse HEAD:scripts/configure-ios-project.sh
-          git hash-object scripts/configure-ios-project.sh
-          echo "=== run configure script ==="
-          bash scripts/configure-ios-project.sh
-
-      - name: 打包默认资源 data.7z
-        run: node scripts/prepare-bundled-resources.mjs ${{ github.event.inputs.compression }}
-
-      - name: 构建无签名 IPA
-        # beforeBuildCommand runs prepare-desktop-resources.mjs + pnpm build automatically;
-        # --no-sign skips code signing (no certificate / provisioning profile needed)
-        env:
-          # pnpm 11 在 Xcode 的 Build Rust Code 脚本里做依赖校验时会触发自动 install；
-          # 显式 CI=true + .npmrc 的 verify-deps-before-run=false 避免无 TTY 中止
-          CI: "true"
-        run: pnpm tauri ios build --no-sign
+      - name: 打包与构建无签名 IPA
+        # pnpm run ios:build = build-ios-unsigned.sh，内部依次执行：
+        #   configure-ios-project.sh（init 工程 + iPhone/iPad 兜底）
+        #   prepare-bundled-resources.mjs（data.7z → gen/apple/assets/data/）
+        #   pnpm tauri ios build --no-sign（含 beforeBuildCommand 前端构建）
+        # 脚本内部已设置 CI/pnpm_config_* 环境变量，与 job env 一致。
+        run: pnpm run ios:build
 
       - name: 上传 IPA
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -54,7 +54,24 @@ jobs:
           pnpm run init
 
       - name: 初始化并配置 iOS Xcode 工程（iPhone + iPad）
-        run: bash scripts/configure-ios-project.sh
+        run: |
+          echo "=== bash version ==="
+          bash --version | head -1
+          echo "=== git config core.autocrlf ==="
+          git config --get core.autocrlf || echo "(unset)"
+          echo "=== check-attr ==="
+          git check-attr text eol working-tree-encoding -- scripts/configure-ios-project.sh || true
+          echo "=== blob sha vs worktree sha ==="
+          git rev-parse HEAD:scripts/configure-ios-project.sh
+          git hash-object scripts/configure-ios-project.sh
+          echo "=== file type ==="
+          file scripts/configure-ios-project.sh
+          echo "=== od -c (first 32 lines) ==="
+          od -c scripts/configure-ios-project.sh | head -32
+          echo "=== cat -A (first 12 lines) ==="
+          cat -A scripts/configure-ios-project.sh | head -12
+          echo "=== run configure script ==="
+          bash scripts/configure-ios-project.sh
 
       - name: 打包默认资源 data.7z
         run: node scripts/prepare-bundled-resources.mjs ${{ github.event.inputs.compression }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -26,9 +26,14 @@ jobs:
         with:
           lfs: false
 
-      - name: 拉取 LFS 资源（游戏数据 + 图标）
+      - name: 拉取 LFS 资源
+        # checkout(lfs: false) 后手动拉取。必须覆盖全部 LFS 目录：
+        # - data/game_data/**：游戏数据（进 data.7z）
+        # - src-tauri/icons/**：应用图标
+        # - public/** + src/assets/**：前端静态资源（字体/背景插画/Tip 图标/音频），
+        #   漏拉会导致 vite 把 LFS 指针文本拷进 dist，App 内字体/背景/图标缺失
         run: |
-          git lfs pull --include="data/game_data/**,src-tauri/icons/**"
+          git lfs pull --include="data/game_data/**,src-tauri/icons/**,public/**,src/assets/**"
 
       - uses: pnpm/setup@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,9 @@ src-tauri/gen/android/app/src/main/assets/
 src-tauri/gen/android/app/src/main/res/mipmap-*/ic_launcher*.png
 src-tauri/gen/android/app/src/main/res/mipmap-anydpi-v26/
 
+# iOS 工程与构建产物（本地 tauri ios dev/build 生成，CI 由 configure-ios-project.sh + tauri ios build 现生成）
+src-tauri/gen/apple/
+
 **/.cargo/**
 
 # ============================================================

--- a/.npmrc
+++ b/.npmrc
@@ -1,11 +1,10 @@
-# pnpm: 关闭脚本执行前的依赖校验与模块目录清空确认。
-# 原因：iOS 的 Xcode 构建脚本（Build Rust Code）在无 TTY 环境下通过 pnpm
-# 调用 tauri CLI 时，pnpm 11 的 verify-deps-before-run 会尝试自动 pnpm install，
-# 而模块目录需要清空重装时在无 TTY 下直接中止
-# （ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY → xcodebuild exit 65）。
+# pnpm 11 会在脚本执行前做依赖校验（verify-deps-before-run），模块目录需要
+# 清空重装时若无 TTY 直接中止（ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY）。
+# iOS 的 Xcode "Build Rust Code" 脚本阶段即属此类（详见 docs/ios-build.md）。
 #
 # 注意：pnpm 11 的 isNpmrcReadableKey 会过滤 .npmrc 里的非 ini/auth/网络键，
-# 因此这两个键在 .npmrc 中可能不生效；可靠做法是环境变量（pnpm_config_ 前缀），
-# CI 工作流 build-ios.yml 的 job env 已设置。
-verify-deps-before-run=false
-confirm-modules-purge=false
+# 因此不要把 verify-deps-before-run / confirm-modules-purge 写在这里（不生效且
+# 会触发 npm 的 Unknown project config 警告）；可靠做法是环境变量
+# （pnpm_config_ 前缀）：
+#   - scripts/build-ios-unsigned.sh 已内置（本地 + CI 共用，单一事实来源）
+#   - .github/workflows/build-ios.yml 的 job env 亦显式设置

--- a/.npmrc
+++ b/.npmrc
@@ -3,5 +3,9 @@
 # 调用 tauri CLI 时，pnpm 11 的 verify-deps-before-run 会尝试自动 pnpm install，
 # 而模块目录需要清空重装时在无 TTY 下直接中止
 # （ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY → xcodebuild exit 65）。
+#
+# 注意：pnpm 11 的 isNpmrcReadableKey 会过滤 .npmrc 里的非 ini/auth/网络键，
+# 因此这两个键在 .npmrc 中可能不生效；可靠做法是环境变量（pnpm_config_ 前缀），
+# CI 工作流 build-ios.yml 的 job env 已设置。
 verify-deps-before-run=false
-confirmModulesPurge=false
+confirm-modules-purge=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# pnpm: 关闭脚本执行前的依赖校验与模块目录清空确认。
+# 原因：iOS 的 Xcode 构建脚本（Build Rust Code）在无 TTY 环境下通过 pnpm
+# 调用 tauri CLI 时，pnpm 11 的 verify-deps-before-run 会尝试自动 pnpm install，
+# 而模块目录需要清空重装时在无 TTY 下直接中止
+# （ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY → xcodebuild exit 65）。
+verify-deps-before-run=false
+confirmModulesPurge=false

--- a/docs/ios-build.md
+++ b/docs/ios-build.md
@@ -140,7 +140,12 @@ macOS runner 实测复现；错误信息中变量名后出现 U+FFFD，文件本
 
 ## 构建验证
 
-- 本仓库的 iOS 构建通过 GitHub Actions（`build-ios.yml`，macOS runner）实测：
-  配置工程 → 打包 `data.7z` → `tauri ios build --no-sign`。
-  验证结果以最近一次 workflow run 为准（IPA 见 workflow artifact）。
+- 本仓库的 iOS 构建已在 GitHub Actions（`build-ios.yml`，macOS arm64 runner）上
+  **实测通过**：配置工程 → 打包 `data.7z` → `tauri ios build --no-sign` 产出无签名
+  IPA（`src-tauri/gen/apple/build/arm64/LingChat.ipa`，约 170 MB，含前端 + Rust +
+  情绪模型 data.7z），并作为 workflow artifact `lingchat-ios-unsigned` 上传。
+- 实测过程中修复的三个平台级问题（见上文踩坑记录）：
+  1. macOS bash 3.2 多字节解析 bug → `.sh` 脚本纯 ASCII；
+  2. pnpm 11 在 Xcode 脚本阶段无 TTY 中止 → patch pbxproj 绕开 pnpm；
+  3. IPA 产物路径为 `gen/apple/build/<arch>/`（非 `gen/apple/target/`）。
 

--- a/docs/ios-build.md
+++ b/docs/ios-build.md
@@ -70,9 +70,17 @@ pnpm tauri ios build --no-sign             # 3. 构建（beforeBuildCommand 自�
 
 `.github/workflows/build-ios.yml`（手动触发）在 `macos-latest` 上执行同一流程，
 IPA 作为 workflow artifact 上传（保留 7 天）。构建步骤直接复用
-`pnpm run ios:build`（`build-ios-unsigned.sh`），与本地流程单一事实来源，
-workflow 的 `compression` 输入通过 `IOS_BUNDLED_7Z_LEVEL` 环境变量透传给
+`pnpm run ios:build`（`build-ios-unsigned.sh`），与本地流程单一事实来源；
+构建相关环境变量（`CI` / `pnpm_config_*` / `CARGO_PROFILE_RELEASE_*`）由脚本
+内置设置，workflow 的 `compression` 输入通过 `IOS_BUNDLED_7Z_LEVEL` 透传给
 `prepare-bundled-resources.mjs`（默认 9）。
+
+**本地与 CI 产出的等价性**：流程、依赖锁、资源清单（`data.7z` 按 git ls-files）、
+图标与前端构建（同一 commit + 同一 lockfile）均一致，IPA 可互换使用。已知且
+**无法消除**的非确定性：构建时间戳/UUID、Rust 与 Xcode 工具链版本（CI 的
+`rust-toolchain@stable` 与 `macos-latest` 会滚动更新）、以及 Apple 对
+Assets.car/签名的重编码。**注意**：本地工作区如有未提交的 `data/` 改动，会被
+`prepare-bundled-resources.mjs` 打进本地 IPA（CI 只打包 commit 内容）。
 
 ## 侧载安装
 

--- a/docs/ios-build.md
+++ b/docs/ios-build.md
@@ -14,6 +14,12 @@
 - Xcode 工程由 `tauri ios init` 生成（XcodeGen），目标**兼容 iPhone 与 iPad**
   （`TARGETED_DEVICE_FAMILY = "1,2"`，XcodeGen 默认即此值，`scripts/configure-ios-project.sh`
   会显式归一化兜底）。
+- **App 图标与 Android 同源**：`configure-ios-project.sh` 每次配置时把
+  `src-tauri/icons/ios/`（`tauri icon` 基于 `src-tauri/icons/icon.png` 生成，与
+  Android 使用的源图相同）同步到 Xcode 工程 `Assets.xcassets/AppIcon.appiconset/`。
+  `gen/apple` 是本地持久产物（gitignored），工程已存在时会跳过 `ios init`，
+  不同步图标会停留在旧版本（实测曾出现 iOS 显示旧版 logo、Android 显示新版蓝猫
+  图标的不一致）。若同步时提示目录缺失，先执行 `pnpm run init` 生成图标。
 - 截图插件（`tauri-plugin-screenshots`）依赖的 `xcap` 不支持 iOS，已在插件内打桩：
   iOS 构建时排除 xcap，所有截图命令返回「不支持」错误（`screenshots:default`
   权限仍可正常解析，capabilities 无需改动）。

--- a/docs/ios-build.md
+++ b/docs/ios-build.md
@@ -1,0 +1,104 @@
+# iOS 构建指南（无签名 IPA）
+
+> 本文档描述 LingChat 的 iOS 支持现状与打包流程。
+> **iOS 构建只能在 macOS 上执行**（`tauri ios` 子命令仅存在于 macOS 版 tauri-cli）。
+
+## 现状
+
+- 后端（Rust）已支持 iOS：数据播种走 `data.7z`（与 Android 同一机制，见
+  `src-tauri/src/init/static_copy.rs` 的 `seed_via_fs_plugin`）。
+- iOS 数据目录 = 沙盒内 **Documents**（`<container>/Documents`），配合
+  `src-tauri/Info.ios.plist` 的 `UIFileSharingEnabled` / `LSSupportsOpeningDocumentsInPlace`，
+  用户可在系统「文件」App 中直接看到并访问整个 `data/` 目录
+  （游戏数据、语音、截图、数据库等）。
+- Xcode 工程由 `tauri ios init` 生成（XcodeGen），目标**兼容 iPhone 与 iPad**
+  （`TARGETED_DEVICE_FAMILY = "1,2"`，XcodeGen 默认即此值，`scripts/configure-ios-project.sh`
+  会显式归一化兜底）。
+- 截图插件（`tauri-plugin-screenshots`）依赖的 `xcap` 不支持 iOS，已在插件内打桩：
+  iOS 构建时排除 xcap，所有截图命令返回「不支持」错误（`screenshots:default`
+  权限仍可正常解析，capabilities 无需改动）。
+
+## 前置条件（macOS）
+
+```bash
+brew install xcodegen
+rustup target add aarch64-apple-ios      # 真机目标
+rustup target add aarch64-apple-ios-sim  # 模拟器（可选，本流程默认只打真机包）
+pnpm install
+pnpm run init        # 生成图标 + 下载情绪模型（ONNX）到 data/third_party
+```
+
+## 打包无签名 IPA
+
+### 一键脚本
+
+```bash
+pnpm run ios:build
+```
+
+等价于（分步）：
+
+```bash
+bash scripts/configure-ios-project.sh      # 1. init Xcode 工程 + iPhone/iPad 兜底
+node scripts/prepare-bundled-resources.mjs 9  # 2. data.7z → gen/apple/assets/data/
+pnpm tauri ios build --no-sign             # 3. 构建（beforeBuildCommand 自动跑前端构建）
+```
+
+产物：`src-tauri/gen/apple/target/**/*.ipa`（无签名）。
+
+### CI
+
+`.github/workflows/build-ios.yml`（手动触发）在 `macos-latest` 上执行同一流程，
+IPA 作为 workflow artifact 上传（保留 7 天）。
+
+## 侧载安装
+
+无签名 IPA 无法直接双击安装，需要用侧载工具：
+
+- **Sideloadly** / **AltStore**（免费，Apple ID 签名后安装，7 天有效）
+- **爱思助手 / 3uTools**（无签名直装，需越狱或开发者模式）
+- 企业签名 / TestFlight（需开发者账号）
+
+安装后首次启动需在 设置 → 通用 → VPN 与设备管理 中信任该开发者。
+
+## 关键设计决策
+
+### 1. 为什么数据目录放 Documents 而不是默认的 app_data_dir
+
+- iOS 的 `app_data_dir()` 位于 `Library/Application Support/`，「文件」App 不可见；
+- `UIFileSharingEnabled` 只暴露沙盒的 **Documents** 目录；
+- 因此 `static_copy.rs` 的 iOS 分支使用 `document_dir()`。
+
+> 注意：Documents 默认会参与 **iCloud 备份**。若担心 `third_party/` 模型（数百 MB）
+> 占用备份空间，可后续在启动时对 `data/third_party` 设置 `NSURLIsExcludedFromBackupKey`
+> 排除备份（不影响「文件」App 可见性）。
+
+### 2. 为什么 Info.ios.plist 是单独的 plist
+
+`tauri ios build` 每次构建都会**重新合并** Info.plist，来源按序为：
+`gen/apple/<app>_iOS/Info.plist`（XcodeGen 生成）→ 版本号 → `src-tauri/Info.plist`（可选）
+→ **`src-tauri/Info.ios.plist`（可选，iOS 专属钩子）** → `bundle.ios.info_plist`（配置）。
+因此把文件共享键与设备族写进 `Info.ios.plist` 可稳定生效，不随工程再生成而丢失。
+
+### 3. 资源文件怎么进包
+
+| 内容 | 机制 | 落点 |
+|---|---|---|
+| 游戏数据 + 模型 | `prepare-bundled-resources.mjs` 打包 `data.7z` → `gen/apple/assets/data/data.7z` | `<bundle>/data/data.7z`，首启解压到 Documents |
+| 桌面 `.official` 资源 | `prepare-desktop-resources.mjs` 在移动端（`TAURI_ENV_PLATFORM=ios/android`）**只生成空占位** | 不进包（避免与 data.7z 重复） |
+
+`gen/apple/assets/` 在 project.yml 中是 folder reference（`type: folder`），构建时整体
+拷入 bundle 根目录，因此 `assets/data/data.7z` → `<bundle>/data/data.7z`，与 Rust 读取路径
+`{resource_dir}/data/data.7z` 一致。
+
+> 兼容性说明：`prepare-desktop-resources.mjs` 的 `isMobile` 跳过逻辑对 Android 同样生效，
+> Android APK 也会因此去掉重复打包的 `.official` 文件（移动端播种本就只认 data.7z）。
+
+## 已知限制
+
+- 无签名 IPA 只能侧载自用，**不能上架 App Store / TestFlight**；
+- Windows / Linux 无法生成或构建 iOS 工程（tauri-cli 未提供 ios 子命令）；
+- 本仓库在 Windows 侧无法做 iOS 交叉编译验证，首次真机构建请以 macOS 上
+  `pnpm run ios:build` 的实际结果为准；
+- ort（ONNX Runtime）在 iOS 有官方预编译产物（`aarch64-apple-ios`），
+  已确认可编译链接，无需额外配置。

--- a/docs/ios-build.md
+++ b/docs/ios-build.md
@@ -28,6 +28,20 @@ pnpm install
 pnpm run init        # 生成图标 + 下载情绪模型（ONNX）到 data/third_party
 ```
 
+## 模拟器开发调试（tauri ios dev）
+
+```bash
+node scripts/prepare-bundled-resources.mjs 9   # 先生成 data.7z（首次必须，之后资源变更时重跑）
+pnpm tauri ios dev "iPhone 17 Pro"             # 设备名可换成任意可用模拟器（xcrun simctl list devices）
+```
+
+注意：
+- **`tauri ios dev` 前必须先有 `gen/apple/assets/data/data.7z`**（`prepare-bundled-resources.mjs` 生成），
+  否则首启播种失败，setup 报错后在 `did_finish_launching` 内触发不可 unwind 的 panic（SIGABRT）。
+- 不要给该命令设置相对路径的 `CARGO_TARGET_DIR`（如 `src-tauri/target`）：cargo 会把它解析到
+  `src-tauri` 内部（如 `src-tauri/src-tauri/target`），tauri-cli 的文件 watcher 监听到 target 目录
+  变化会无限触发重建-重部署循环。默认（不设该变量，产物落在 `src-tauri/target`）即正常。
+
 ## 打包无签名 IPA
 
 ### 一键脚本
@@ -89,11 +103,41 @@ IPA 作为 workflow artifact 上传（保留 7 天）。
 
 `gen/apple/assets/` 在 project.yml 中是 folder reference（`type: folder`），构建时**连同目录名**拷入
 bundle（`assets/data/data.7z` → `<bundle>/assets/data/data.7z`）。
-Rust 侧 `seed_via_fs_plugin` 的 iOS 读取路径为 `{resource_dir}/assets/data/data.7z`
-（Android 为 `{resource_dir}/data/data.7z`，因为 APK 的 resource_dir 就是 assets 根）。
+Rust 侧 `seed_via_fs_plugin` 的 iOS 读取路径为 `{resource_dir}/data/data.7z`：
+iOS 上 tauri 的 `resource_dir()` 返回的**就是** bundle 内的 `assets/` 目录
+（`<bundle>/assets/`，即 folder reference 的落点），不要再拼一层 `assets/`。
+Android 同样是 `{resource_dir}/data/data.7z`（APK 的 resource_dir 即 assets 根）。
+> 实测记录：曾写成 `{resource_dir}/assets/data/data.7z`，在 iOS 上解析为
+> `<bundle>/assets/assets/data/data.7z` 导致首启播种失败、setup 报错并触发
+> `did_finish_launching` 内不可 unwind 的 panic（SIGABRT）。CI 只打包不运行，
+> 因此该路径错误长期未被发现；`tauri ios dev` 首次真跑才暴露。
 
 > 兼容性说明：`prepare-desktop-resources.mjs` 的 `isMobile` 跳过逻辑对 Android 同样生效，
 > Android APK 也会因此去掉重复打包的 `.official` 文件（移动端播种本就只认 data.7z）。
+
+### 4. 前端安全区 / 视口适配（dvw/dvh + env）
+
+iOS 全屏 webview（`viewport-fit=cover`）里 `env(safe-area-inset-*)` 是真实非零值
+（iPhone 17 Pro 实测：top 62px / bottom 34px / left,right 0），而桌面/Android 桌面为 0。
+前端适配口径（`src/App.vue`、`src/composables/useZoom.ts`）：
+
+- **视口单位统一为动态视口** `dvw/dvh`（替换 `vw/vh`）：iOS 竖屏 `100vh` 不含顶部安全区、
+  横屏 `100vw` 含左右安全区，`dvw/dvh` 与视觉视口一致；桌面 `dvw/dvh === vw/vh`，零回归。
+- **`#app` 铺满整个视觉视口**（`position: fixed` + `100dvw×100dvh`），**不**整体内缩安全区——
+  各屏壁纸/背景因此天然全出血显示（含状态栏与 Home 指示器区域，不会出现上下黑边）。
+- **安全区内缩由各边缘元素自行处理**：全局已定义 `--safe-area-inset-*`（`base.css`，回退 env()）
+  与工具类 `.pt-safe/.pb-safe/.pl-safe/.pr-safe`（及 `-gap` 变体）；聊天输入区用
+  `.main-box { padding-bottom: env(safe-area-inset-bottom) }` 抬离 Home 指示器，
+  菜单 Logo（`StartLogo`）用 `top: env(safe-area-inset-top)` 避开状态栏。
+- **不要**整体收缩 `#app` 成安全区盒子：会留下裸露黑边（壁纸只画在 #app 内），
+  且与已在各 fixed 元素里加过 `var(--safe-area-inset-*)` 的偏移形成**双重内缩**。
+- 小屏菜单排布：`StartItem` 在 <768px 允许换行（`max-[767px]:whitespace-normal`）并缩小字号
+  （`clamp(26px,4vw,72px)`），否则"剧情模式（在自由模式进入自由模式）"这类长文案
+  会横向溢出被裁掉。
+
+> 实测记录：曾把 `#app` 内缩为安全区盒子（`top/env` + `100dvh - insets`），
+> 模拟器截图（`xcrun simctl io booted screenshot`）可见屏幕上下各一条黑/透明带——
+> 之前无视觉模型、纯靠尺寸推断没有发现；`tauri ios dev` + 截图人工核对才暴露。
 
 ## 已知限制
 

--- a/docs/ios-build.md
+++ b/docs/ios-build.md
@@ -44,7 +44,7 @@ node scripts/prepare-bundled-resources.mjs 9  # 2. data.7z → gen/apple/assets/
 pnpm tauri ios build --no-sign             # 3. 构建（beforeBuildCommand 自动跑前端构建）
 ```
 
-产物：`src-tauri/gen/apple/target/**/*.ipa`（无签名）。
+产物：`src-tauri/gen/apple/build/<arch>/LingChat.ipa`（无签名）。
 
 ### CI
 
@@ -117,3 +117,30 @@ macOS runner 实测复现；错误信息中变量名后出现 U+FFFD，文件本
 
 对策：**本仓库的 `.sh` 脚本一律保持纯 ASCII**（注释/输出用英文），
 不要在多字节字符后紧跟变量展开。`.gitattributes` 已强制 `*.sh` 为 LF。
+
+### pnpm 11 在 Xcode "Build Rust Code" 阶段的无 TTY 中止
+
+`tauri ios init` 在 pnpm 环境下会把 Xcode 工程的 "Build Rust Code" 脚本阶段
+渲染为 `pnpm tauri ... xcode-script ...`（tauri-cli 依据 argv[0] 与
+`PNPM_PACKAGE_NAME` 决定 tauri-binary）。pnpm 11 执行脚本前会做依赖校验
+（verify-deps-before-run）并自动跑 `pnpm install`；一旦需要清空 node_modules，
+在无 TTY 环境（Xcode 脚本阶段）直接中止：
+`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` → `xcodebuild exit 65`。
+
+要点：
+- `CI=true` 与 `pnpm_config_verify_deps_before_run` / `pnpm_config_confirm_modules_purge`
+  环境变量（pnpm 11 只认 `pnpm_config_*`/`PNPM_CONFIG_*` 前缀，不认 `PNPM_*`；
+  `.npmrc` 里的这两个键会被 pnpm 11 的 `isNpmrcReadableKey` 过滤）实测都无法阻止；
+- 根治方案：`scripts/configure-ios-project.sh` 在 init 后 patch pbxproj 的
+  shellScript，把开头的 `pnpm tauri ` 替换为
+  `node "$PROJECT_DIR/../../../node_modules/@tauri-apps/cli/tauri.js" `
+  （`$PROJECT_DIR` = `src-tauri/gen/apple`，上三级到仓库根），
+  使 Xcode 脚本阶段直接经 node 调用 tauri CLI，完全绕开包管理器。
+  `tauri ios build` 的 `synchronize_project_config` 不会重写 shellScript，patch 持久生效。
+
+## 构建验证
+
+- 本仓库的 iOS 构建通过 GitHub Actions（`build-ios.yml`，macOS runner）实测：
+  配置工程 → 打包 `data.7z` → `tauri ios build --no-sign`。
+  验证结果以最近一次 workflow run 为准（IPA 见 workflow artifact）。
+

--- a/docs/ios-build.md
+++ b/docs/ios-build.md
@@ -63,7 +63,10 @@ pnpm tauri ios build --no-sign             # 3. 构建（beforeBuildCommand 自�
 ### CI
 
 `.github/workflows/build-ios.yml`（手动触发）在 `macos-latest` 上执行同一流程，
-IPA 作为 workflow artifact 上传（保留 7 天）。
+IPA 作为 workflow artifact 上传（保留 7 天）。构建步骤直接复用
+`pnpm run ios:build`（`build-ios-unsigned.sh`），与本地流程单一事实来源，
+workflow 的 `compression` 输入通过 `IOS_BUNDLED_7Z_LEVEL` 环境变量透传给
+`prepare-bundled-resources.mjs`（默认 9）。
 
 ## 侧载安装
 
@@ -183,14 +186,56 @@ macOS runner 实测复现；错误信息中变量名后出现 U+FFFD，文件本
   使 Xcode 脚本阶段直接经 node 调用 tauri CLI，完全绕开包管理器。
   `tauri ios build` 的 `synchronize_project_config` 不会重写 shellScript，patch 持久生效。
 
+### 本地 gen/apple 残留被 folder reference 整包（包体膨胀）
+
+`gen/apple/` 被 `.gitignore` 忽略（本地产物），其中 `gen/apple/assets/data/` 以
+folder reference（`type: folder`）参与资源阶段——**目录里有什么就进什么包**。
+若此前构建/实验把 `.official` 真实文件或 `third_party` 模型目录留在了
+`gen/apple/assets/data/` 下，会与 `data.7z` 重复进包（实测 IPA 膨胀到 216 MB，
+本应约 172 MB），且桌面 `.official` 内容重复出现。
+
+对策：`scripts/prepare-bundled-resources.mjs` 的 iOS 部署分支与 Android 分支对齐，
+**先清空 `gen/apple/assets/data/` 再写入**，确保 bundle 内的 `assets/data/` 只含
+`data.7z`。CI 每次全新生成工程、无此问题，但本地反复构建时必须通过该脚本部署资源。
+
+### 本地并发 xcodebuild 会互相破坏 DerivedData
+
+`tauri ios build` / `tauri ios dev` / 手动 `xcodebuild` 共享同一个
+`~/Library/Developer/Xcode/DerivedData/ling_chat-*`。多个 xcodebuild 并发（如
+`tauri ios dev` 挂着又跑 `tauri ios build`）会导致 `build.db` 磁盘 I/O 错误与
+clang `.resp` 响应文件丢失（`** ARCHIVE FAILED **`）。本地排查顺序：确认无残留
+`tauri.js`/`xcodebuild` 进程 → `rm -rf ~/Library/Developer/Xcode/DerivedData/ling_chat-*`
+→ 重跑。CI 为全新环境，不会触发。
+
+### 已知但未处理的链接警告
+
+`Externals/arm64/release/libapp.a`（ORT 相关静态库）按 iOS 15.1 编译，而工程
+deployment target 为 14.0：`ld: warning: object file ... was built for newer 'iOS'
+version (15.1) than being linked (14.0)`。当前仅警告、构建不受影响；若未来需要
+保证 iOS 14 实机运行，应把 deployment target 统一提升到 15.1（影响面：XcodeGen
+工程每次 `tauri ios init` 后需重新设定，需在 configure 脚本中兜底）。
+
 ## 构建验证
 
 - 本仓库的 iOS 构建已在 GitHub Actions（`build-ios.yml`，macOS arm64 runner）上
   **实测通过**：配置工程 → 打包 `data.7z` → `tauri ios build --no-sign` 产出无签名
   IPA（`src-tauri/gen/apple/build/arm64/LingChat.ipa`，约 170 MB，含前端 + Rust +
   情绪模型 data.7z），并作为 workflow artifact `lingchat-ios-unsigned` 上传。
-- 实测过程中修复的三个平台级问题（见上文踩坑记录）：
-  1. macOS bash 3.2 多字节解析 bug → `.sh` 脚本纯 ASCII；
-  2. pnpm 11 在 Xcode 脚本阶段无 TTY 中止 → patch pbxproj 绕开 pnpm；
-  3. IPA 产物路径为 `gen/apple/build/<arch>/`（非 `gen/apple/target/`）。
+- **本地实测结论（macOS 26.6.1 + Xcode 26.6 + iPhone 17 Pro 模拟器 iOS 26.5）**：
+  - 打包流程 `pnpm run ios:build` 全链路通过，IPA 约 **172 MB**；
+  - `tauri ios dev` 安装到模拟器后 app 正常启动：主菜单完整显示（壁纸插画 /
+    Logo / 全部菜单项），安全区适配正确（状态栏与 Home 指示器无遮挡）；
+  - `data.7z` 首启播种成功：`Documents/` 下 `game_data/`（3 个角色、背景、剧本、
+    技能，135 个文件）+ `data_manifest.json`（147 条）+ `third_party/` 模型齐全；
+  - IPA 内 `assets/data/data.7z`（74 MB）与 Rust 侧读取路径
+    `{resource_dir}/data/data.7z` 对应，bundled `data/.official/` 仅含空占位。
+- 实测过程中修复的问题（详见踩坑记录）：
+  1. 本地 `gen/apple/assets/data/` 旧残留（`.official` 真实文件 + 重复模型）被
+     folder reference 整体打进包体，IPA 膨胀到 216 MB → `prepare-bundled-resources.mjs`
+     的 iOS 部署改为**先清空再写入**（与 Android 分支一致），修复后 172 MB；
+  2. `Info.ios.plist` 的 `UIDeviceFamily` 与 `TARGETED_DEVICE_FAMILY` build setting
+     冲突（xcodebuild 警告且该键会被覆盖）→ 从 `Info.ios.plist` 移除，设备族统一
+     由 `configure-ios-project.sh` 归一化；
+  3. `build-ios-unsigned.sh` 内置 `CI=true` + `pnpm_config_*` 环境变量，本地直跑
+     不再因 pnpm 11 无 TTY 依赖校验中止（此前只有 CI 步骤设置，本地脚本缺失）。
 

--- a/docs/ios-build.md
+++ b/docs/ios-build.md
@@ -84,12 +84,13 @@ IPA 作为 workflow artifact 上传（保留 7 天）。
 
 | 内容 | 机制 | 落点 |
 |---|---|---|
-| 游戏数据 + 模型 | `prepare-bundled-resources.mjs` 打包 `data.7z` → `gen/apple/assets/data/data.7z` | `<bundle>/data/data.7z`，首启解压到 Documents |
+| 游戏数据 + 模型 | `prepare-bundled-resources.mjs` 打包 `data.7z` → `gen/apple/assets/data/data.7z` | `<bundle>/assets/data/data.7z`（folder reference 保留 `assets/` 目录名），首启解压到 Documents |
 | 桌面 `.official` 资源 | `prepare-desktop-resources.mjs` 在移动端（`TAURI_ENV_PLATFORM=ios/android`）**只生成空占位** | 不进包（避免与 data.7z 重复） |
 
-`gen/apple/assets/` 在 project.yml 中是 folder reference（`type: folder`），构建时整体
-拷入 bundle 根目录，因此 `assets/data/data.7z` → `<bundle>/data/data.7z`，与 Rust 读取路径
-`{resource_dir}/data/data.7z` 一致。
+`gen/apple/assets/` 在 project.yml 中是 folder reference（`type: folder`），构建时**连同目录名**拷入
+bundle（`assets/data/data.7z` → `<bundle>/assets/data/data.7z`）。
+Rust 侧 `seed_via_fs_plugin` 的 iOS 读取路径为 `{resource_dir}/assets/data/data.7z`
+（Android 为 `{resource_dir}/data/data.7z`，因为 APK 的 resource_dir 就是 assets 根）。
 
 > 兼容性说明：`prepare-desktop-resources.mjs` 的 `isMobile` 跳过逻辑对 Android 同样生效，
 > Android APK 也会因此去掉重复打包的 `.official` 文件（移动端播种本就只认 data.7z）。

--- a/docs/ios-build.md
+++ b/docs/ios-build.md
@@ -102,3 +102,18 @@ IPA 作为 workflow artifact 上传（保留 7 天）。
   `pnpm run ios:build` 的实际结果为准；
 - ort（ONNX Runtime）在 iOS 有官方预编译产物（`aarch64-apple-ios`），
   已确认可编译链接，无需额外配置。
+
+## 踩坑记录
+
+### macOS 自带 bash 3.2 的多字节解析 bug
+
+macOS 自带 `/bin/bash` 是 3.2.57，存在多字节（UTF-8）解析缺陷：
+**双引号内 `$VAR` 紧跟多字节字符（如全角逗号 `，`）时，bash 会把多字节字节串
+错误并入变量名**，`set -u` 下报 `VAR<乱码>: unbound variable`（即使变量已赋值）。
+
+例：`echo "未找到 $GEN_APPLE，执行..."` 在 bash 3.2 上触发该 bug（GitHub Actions
+macOS runner 实测复现；错误信息中变量名后出现 U+FFFD，文件本身经字节级校验为
+干净 LF UTF-8，与 CRLF 无关）。
+
+对策：**本仓库的 `.sh` 脚本一律保持纯 ASCII**（注释/输出用英文），
+不要在多字节字符后紧跟变量展开。`.gitattributes` 已强制 `*.sh` 为 LF。

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <title>Tauri + Vue + Typescript App</title>
     <!-- 小屏根字号缩放（min(vw,vh) 横竖屏均覆盖，!important 防止构建产物覆盖） -->
     <style></style>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
+    <!-- user-scalable=no + maximum-scale=1.0：锁定移动端视口，禁用 WebView 原生
+         双指捏合 & 双击放大（这是 WebView 原生缩放手势，与 useZoom 的 Ctrl+滚轮
+         全局 UI 缩放是两回事，后者仅桌面端生效）。interactive-widget=resizes-content
+         保留用于 iOS 键盘让位，viewport-fit=cover 保留用于安全区。 -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content, maximum-scale=1.0, user-scalable=no" />
     <title>Tauri + Vue + Typescript App</title>
     <!-- 小屏根字号缩放（min(vw,vh) 横竖屏均覆盖，!important 防止构建产物覆盖） -->
     <style></style>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "android:prepare": "tauri android init && node scripts/generate-android-icons.mjs",
     "android:dev": "tauri android dev",
     "android:build": "node scripts/prepare-bundled-resources.mjs 9 && tauri android build --target aarch64",
+    "ios:init": "tauri ios init",
+    "ios:build": "bash scripts/build-ios-unsigned.sh",
     "format": "prettier --write . && cargo fmt --manifest-path src-tauri/Cargo.toml",
     "format:rs": "cargo fmt --manifest-path src-tauri/Cargo.toml",
     "format:frontend": "prettier --write \"src/**/*.{vue,js,ts,css,scss}\"",

--- a/scripts/build-ios-unsigned.sh
+++ b/scripts/build-ios-unsigned.sh
@@ -18,13 +18,20 @@
 # ============================================================================
 set -euo pipefail
 
-# pnpm 11 的 verify-deps-before-run 在无 TTY 环境下（脚本/CI 触发、Xcode
-# Build Rust Code 阶段）会因模块目录需要清空重装而直接中止
-# （ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY）。与 build-ios.yml 的 job env
-# 保持一致：显式关闭依赖校验与清理确认（.npmrc 中的同名键会被 pnpm 11 过滤）。
+# 构建环境与 CI（build-ios.yml）保持完全一致（单一事实来源），确保本地与
+# GitHub Actions 产出等价 IPA：
+# - CI=true + pnpm_config_*：pnpm 11 的 verify-deps-before-run 在无 TTY 环境下
+#   （脚本/CI 触发、Xcode Build Rust Code 阶段）会因模块目录需要清空重装而直接
+#   中止（ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY）；.npmrc 中的同名键会被
+#   pnpm 11 过滤，因此用环境变量。
+# - CARGO_PROFILE_RELEASE_*：等价于 [profile.release] opt-level="s" + strip=true
+#   （项目 Cargo.toml 未覆盖 release profile，CI 由此控制；原先本地未设置，
+#   会得到未 strip 的 opt-level=3 二进制，IPA 偏大）。
 export CI=true
 export pnpm_config_verify_deps_before_run=false
 export pnpm_config_confirm_modules_purge=false
+export CARGO_PROFILE_RELEASE_OPT_LEVEL=s
+export CARGO_PROFILE_RELEASE_STRIP=true
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"

--- a/scripts/build-ios-unsigned.sh
+++ b/scripts/build-ios-unsigned.sh
@@ -18,6 +18,14 @@
 # ============================================================================
 set -euo pipefail
 
+# pnpm 11 的 verify-deps-before-run 在无 TTY 环境下（脚本/CI 触发、Xcode
+# Build Rust Code 阶段）会因模块目录需要清空重装而直接中止
+# （ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY）。与 build-ios.yml 的 job env
+# 保持一致：显式关闭依赖校验与清理确认（.npmrc 中的同名键会被 pnpm 11 过滤）。
+export CI=true
+export pnpm_config_verify_deps_before_run=false
+export pnpm_config_confirm_modules_purge=false
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
@@ -27,7 +35,9 @@ bash scripts/configure-ios-project.sh
 
 # --- 2. Pack resources into data.7z ------------------------------------------
 echo "[build-ios] Step 2/3: packing default resources into data.7z (incl. third_party models)"
-node scripts/prepare-bundled-resources.mjs 9
+# 压缩等级 0-9 可选（默认 9），与 prepare-bundled-resources.mjs 的参数约定一致；
+# CI 通过 IOS_BUNDLED_7Z_LEVEL 环境变量透传 workflow 的 compression 输入。
+node scripts/prepare-bundled-resources.mjs "${IOS_BUNDLED_7Z_LEVEL:-9}"
 
 # --- 3. Unsigned build --------------------------------------------------------
 echo "[build-ios] Step 3/3: pnpm tauri ios build --no-sign (unsigned IPA)"

--- a/scripts/build-ios-unsigned.sh
+++ b/scripts/build-ios-unsigned.sh
@@ -35,12 +35,14 @@ echo "[build-ios] Step 3/3: pnpm tauri ios build --no-sign (unsigned IPA)"
 pnpm tauri ios build --no-sign "$@"
 
 # --- 4. Locate the artifact ---------------------------------------------------
-IPA="$(find src-tauri/gen/apple/target -name "*.ipa" 2>/dev/null | head -1 || true)"
+# cargo-mobile2 把产物放在 gen/apple/build/<arch>/ 下（如 build/arm64/LingChat.ipa）；
+# 兼容旧目录 gen/apple/target 一并查找
+IPA="$(find src-tauri/gen/apple/build src-tauri/gen/apple/target -name "*.ipa" 2>/dev/null | head -1 || true)"
 if [ -n "$IPA" ]; then
   echo ""
   echo "[build-ios] unsigned IPA ready: $(pwd)/$IPA"
   echo "[build-ios] sideload to iPhone/iPad with Sideloadly / AltStore / 3uTools"
 else
-  echo "[build-ios] ERROR: no .ipa found under src-tauri/gen/apple/target, check the build log above" >&2
+  echo "[build-ios] ERROR: no .ipa found under src-tauri/gen/apple/build or target, check the build log above" >&2
   exit 1
 fi

--- a/scripts/build-ios-unsigned.sh
+++ b/scripts/build-ios-unsigned.sh
@@ -1,46 +1,46 @@
 #!/usr/bin/env bash
 # ============================================================================
-# 在 macOS 上构建 LingChat 的 iOS 无签名 IPA。
+# Build LingChat's iOS unsigned IPA (macOS only).
 #
-# 流程：
-#   1. configure-ios-project.sh —— 初始化/配置 Xcode 工程（iPhone + iPad）
-#   2. prepare-bundled-resources.mjs —— 把默认资源打包成 data.7z 并部署到
-#      gen/apple/assets/data/（folder reference 打进 app bundle 根目录）
-#   3. pnpm tauri ios build --no-sign —— 前端构建 + Rust 交叉编译 + 产出
-#      无签名 IPA（tauri-cli 内建 create_ipa，无需额外打包步骤）
+# Pipeline:
+#   1. configure-ios-project.sh -- init/configure the Xcode project (iPhone + iPad)
+#   2. prepare-bundled-resources.mjs -- pack default resources into data.7z and
+#      deploy to gen/apple/assets/data/ (folder reference -> app bundle root)
+#   3. pnpm tauri ios build --no-sign -- build frontend + cross-compile Rust and
+#      produce an UNSIGNED IPA (tauri-cli has a built-in create_ipa step)
 #
-# 产物：src-tauri/gen/apple/target/.../release-iphoneos/.../LingChat.ipa
-#       可直接用侧载工具（如 Sideloadly / AltStore / 爱思助手）安装到真机，
-#       或转交开发者证书签名后分发。
+# Output: src-tauri/gen/apple/target/**/*.ipa
+#   Install via sideloading tools (Sideloadly / AltStore / 爱思助手) or sign it
+#   with a developer certificate for distribution.
 #
-# 依赖（仅 macOS）：Xcode、xcodegen、Rust 目标 aarch64-apple-ios、
-#       aarch64-apple-ios-sim（模拟器可选）。
+# Requirements (macOS only): Xcode, xcodegen, Rust target aarch64-apple-ios
+# (aarch64-apple-ios-sim optional for the simulator).
 # ============================================================================
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-# ─── 1. 配置 Xcode 工程 ───────────────────────────────────────
-echo "▶ 步骤 1/3：配置 iOS Xcode 工程"
+# --- 1. Configure the Xcode project ------------------------------------------
+echo "[build-ios] Step 1/3: configuring the iOS Xcode project"
 bash scripts/configure-ios-project.sh
 
-# ─── 2. 打包资源 data.7z ──────────────────────────────────────
-echo "▶ 步骤 2/3：打包默认资源 data.7z（含 third_party 模型）"
+# --- 2. Pack resources into data.7z ------------------------------------------
+echo "[build-ios] Step 2/3: packing default resources into data.7z (incl. third_party models)"
 node scripts/prepare-bundled-resources.mjs 9
 
-# ─── 3. 无签名构建 ────────────────────────────────────────────
-echo "▶ 步骤 3/3：pnpm tauri ios build --no-sign（产物为无签名 IPA）"
-# beforeBuildCommand 会自动执行 prepare-desktop-resources.mjs + pnpm build
+# --- 3. Unsigned build --------------------------------------------------------
+echo "[build-ios] Step 3/3: pnpm tauri ios build --no-sign (unsigned IPA)"
+# beforeBuildCommand automatically runs prepare-desktop-resources.mjs + pnpm build
 pnpm tauri ios build --no-sign "$@"
 
-# ─── 4. 定位产物 ──────────────────────────────────────────────
+# --- 4. Locate the artifact ---------------------------------------------------
 IPA="$(find src-tauri/gen/apple/target -name "*.ipa" 2>/dev/null | head -1 || true)"
 if [ -n "$IPA" ]; then
   echo ""
-  echo "📦 无签名 IPA 已生成：$(pwd)/$IPA"
-  echo "   （可侧载到 iPhone/iPad：Sideloadly / AltStore / 爱思助手）"
+  echo "[build-ios] unsigned IPA ready: $(pwd)/$IPA"
+  echo "[build-ios] sideload to iPhone/iPad with Sideloadly / AltStore / 3uTools"
 else
-  echo "⚠ 未在 src-tauri/gen/apple/target 下找到 .ipa，请检查上方构建日志" >&2
+  echo "[build-ios] ERROR: no .ipa found under src-tauri/gen/apple/target, check the build log above" >&2
   exit 1
 fi

--- a/scripts/build-ios-unsigned.sh
+++ b/scripts/build-ios-unsigned.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# ============================================================================
+# 在 macOS 上构建 LingChat 的 iOS 无签名 IPA。
+#
+# 流程：
+#   1. configure-ios-project.sh —— 初始化/配置 Xcode 工程（iPhone + iPad）
+#   2. prepare-bundled-resources.mjs —— 把默认资源打包成 data.7z 并部署到
+#      gen/apple/assets/data/（folder reference 打进 app bundle 根目录）
+#   3. pnpm tauri ios build --no-sign —— 前端构建 + Rust 交叉编译 + 产出
+#      无签名 IPA（tauri-cli 内建 create_ipa，无需额外打包步骤）
+#
+# 产物：src-tauri/gen/apple/target/.../release-iphoneos/.../LingChat.ipa
+#       可直接用侧载工具（如 Sideloadly / AltStore / 爱思助手）安装到真机，
+#       或转交开发者证书签名后分发。
+#
+# 依赖（仅 macOS）：Xcode、xcodegen、Rust 目标 aarch64-apple-ios、
+#       aarch64-apple-ios-sim（模拟器可选）。
+# ============================================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# ─── 1. 配置 Xcode 工程 ───────────────────────────────────────
+echo "▶ 步骤 1/3：配置 iOS Xcode 工程"
+bash scripts/configure-ios-project.sh
+
+# ─── 2. 打包资源 data.7z ──────────────────────────────────────
+echo "▶ 步骤 2/3：打包默认资源 data.7z（含 third_party 模型）"
+node scripts/prepare-bundled-resources.mjs 9
+
+# ─── 3. 无签名构建 ────────────────────────────────────────────
+echo "▶ 步骤 3/3：pnpm tauri ios build --no-sign（产物为无签名 IPA）"
+# beforeBuildCommand 会自动执行 prepare-desktop-resources.mjs + pnpm build
+pnpm tauri ios build --no-sign "$@"
+
+# ─── 4. 定位产物 ──────────────────────────────────────────────
+IPA="$(find src-tauri/gen/apple/target -name "*.ipa" 2>/dev/null | head -1 || true)"
+if [ -n "$IPA" ]; then
+  echo ""
+  echo "📦 无签名 IPA 已生成：$(pwd)/$IPA"
+  echo "   （可侧载到 iPhone/iPad：Sideloadly / AltStore / 爱思助手）"
+else
+  echo "⚠ 未在 src-tauri/gen/apple/target 下找到 .ipa，请检查上方构建日志" >&2
+  exit 1
+fi

--- a/scripts/build-ios-unsigned.sh
+++ b/scripts/build-ios-unsigned.sh
@@ -10,7 +10,7 @@
 #      produce an UNSIGNED IPA (tauri-cli has a built-in create_ipa step)
 #
 # Output: src-tauri/gen/apple/target/**/*.ipa
-#   Install via sideloading tools (Sideloadly / AltStore / 爱思助手) or sign it
+#   Install via sideloading tools (Sideloadly / AltStore / 3uTools) or sign it
 #   with a developer certificate for distribution.
 #
 # Requirements (macOS only): Xcode, xcodegen, Rust target aarch64-apple-ios

--- a/scripts/configure-ios-project.sh
+++ b/scripts/configure-ios-project.sh
@@ -64,4 +64,27 @@ else
   echo "[configure-ios] WARNING: src-tauri/Info.ios.plist missing (UIFileSharingEnabled etc. will be absent)" >&2
 fi
 
+# --- 4. Bypass pnpm in the "Build Rust Code" Xcode phase ---------------------
+# tauri ios init 在 pnpm 环境下会把 tauri-binary 渲染为 `pnpm`，于是 Xcode 脚本
+# 阶段执行 `pnpm tauri ... xcode-script ...`。pnpm 11 的 verify-deps-before-run
+# 会先跑一次自动 `pnpm install`；模块目录需要清空重装时，在无 TTY 环境下直接
+# 中止（ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY -> xcodebuild exit 65）。
+# CI=true 与 pnpm_config_* 环境变量都无法阻止（Xcode 脚本阶段不继承/或该检查
+# 无视它们）。这里把 shellScript 开头的 `pnpm tauri` 替换为直接调用本仓库的
+# tauri.js shim（node 直跑，等价于 pnpm tauri 但完全绕开包管理器）。
+# tauri ios build 的 synchronize_project_config 不会重写 shellScript，patch 持久生效。
+
+if grep -q 'shellScript = "pnpm tauri ' "$PBXPROJ"; then
+  # 用 | 作 sed 分隔符避免转义 /；\\" 在 pbxproj 字符串内输出 \"（嵌套引号）
+  sed -i '' 's|shellScript = "pnpm tauri |shellScript = "node \\"$PROJECT_DIR/../../node_modules/@tauri-apps/cli/tauri.js\\" |g' "$PBXPROJ"
+  echo "[configure-ios] Build Rust Code phase patched: pnpm tauri -> node tauri.js (bypass pnpm)"
+else
+  echo "[configure-ios] Build Rust Code phase: no 'pnpm tauri' prefix found (already patched or not pnpm-wrapped)"
+fi
+
+# --- 5. Show the patched shell script for verification -----------------------
+
+echo "[configure-ios] Build Rust Code shellScript (first 220 chars):"
+grep -o 'shellScript = ".*' "$PBXPROJ" | head -3 | cut -c1-220 || true
+
 echo "[configure-ios] iOS project configured: iPhone + iPad, data dir visible in the Files app"

--- a/scripts/configure-ios-project.sh
+++ b/scripts/configure-ios-project.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# ============================================================================
+# 配置 LingChat 的 iOS Xcode 工程（仅在 macOS 上运行）。
+#
+# 职责：
+#   1. 若 src-tauri/gen/apple/ 不存在，执行 `tauri ios init` 生成 Xcode 工程
+#      （内部通过 XcodeGen 生成，产物保留 project.yml 与 <app>.xcodeproj）。
+#   2. 断言/归一化 TARGETED_DEVICE_FAMILY = "1,2"（iPhone + iPad 兼容）。
+#      XcodeGen 默认即 '1,2'，这里显式兜底，满足「兼容 iPhone 和 iPad」要求。
+#
+# 注意：Windows/Linux 上 tauri-cli 不提供 ios 子命令，本脚本只能在 macOS 执行。
+# 依赖：Xcode（含 Command Line Tools）、xcodegen（brew install xcodegen）、
+#       Rust 目标 aarch64-apple-ios（rustup target add aarch64-apple-ios）。
+# ============================================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+GEN_APPLE="src-tauri/gen/apple"
+
+# ─── 1. 初始化 Xcode 工程 ─────────────────────────────────────
+
+if [ ! -d "$GEN_APPLE" ]; then
+  echo "🔧 未找到 $GEN_APPLE，执行 tauri ios init ..."
+  if ! command -v xcodegen >/dev/null 2>&1; then
+    echo "❌ 缺少 xcodegen，请先安装：brew install xcodegen" >&2
+    exit 1
+  fi
+  pnpm tauri ios init --ci
+  echo "✅ Xcode 工程已生成"
+else
+  echo "ℹ️  已存在 $GEN_APPLE，跳过 init"
+fi
+
+PBXPROJ="$(ls "$GEN_APPLE"/*.xcodeproj/project.pbxproj 2>/dev/null | head -1 || true)"
+if [ -z "$PBXPROJ" ] || [ ! -f "$PBXPROJ" ]; then
+  echo "❌ 未找到 project.pbxproj，请检查 $GEN_APPLE 下的 Xcode 工程" >&2
+  exit 1
+fi
+
+# ─── 2. 归一化 TARGETED_DEVICE_FAMILY = "1,2" ────────────────
+
+if grep -q "TARGETED_DEVICE_FAMILY" "$PBXPROJ"; then
+  # BSD sed（macOS 自带）：把所有设备族设置统一为 iPhone + iPad
+  sed -i '' -E 's/TARGETED_DEVICE_FAMILY = [^;]+;/TARGETED_DEVICE_FAMILY = "1,2";/g' "$PBXPROJ"
+  echo "✅ TARGETED_DEVICE_FAMILY 已归一化为 \"1,2\"（iPhone + iPad）"
+else
+  echo "⚠  pbxproj 中未找到 TARGETED_DEVICE_FAMILY（XcodeGen 应默认生成 '1,2'），" \
+    "请打开 Xcode 工程在 Build Settings 中确认 TARGETED_DEVICE_FAMILY = 1,2" >&2
+fi
+
+COUNT="$(grep -c 'TARGETED_DEVICE_FAMILY = "1,2"' "$PBXPROJ" || true)"
+echo "   TARGETED_DEVICE_FAMILY=\"1,2\" 出现 $COUNT 处"
+
+# ─── 3. 校验 iOS 专属 Info.plist 合并钩子 ─────────────────────
+
+if [ -f "src-tauri/Info.ios.plist" ]; then
+  echo "ℹ️  src-tauri/Info.ios.plist 存在（文件 App 可见 + 设备族），构建时会自动合并进 Info.plist"
+else
+  echo "⚠  缺少 src-tauri/Info.ios.plist（UIFileSharingEnabled 等键将缺失）" >&2
+fi
+
+echo "✅ iOS 工程配置完成：iPhone + iPad 兼容、数据目录对「文件」App 可见"

--- a/scripts/configure-ios-project.sh
+++ b/scripts/configure-ios-project.sh
@@ -83,7 +83,23 @@ else
   echo "[configure-ios] Build Rust Code phase: no 'pnpm tauri' prefix found (already patched or not pnpm-wrapped)"
 fi
 
-# --- 5. Show the patched shell script for verification -----------------------
+# --- 5. Sync AppIcon from src-tauri/icons/ios --------------------------------
+# gen/apple 是本地持久产物（gitignored），configure 时若已存在会跳过 init，
+# 图标可能停留在旧版本（Android 每次都由 tauri icon 按 icon.png 重新生成）。
+# 这里把 src-tauri/icons/ios/（tauri icon 的输出，与 Android 同源 icon.png）
+# 同步到 Xcode 工程的 AppIcon.appiconset，保证 iOS 图标与 Android 一致。
+
+IOS_ICON_SRC="src-tauri/icons/ios"
+APPICON_DIR="$GEN_APPLE/Assets.xcassets/AppIcon.appiconset"
+if [ -d "$IOS_ICON_SRC" ] && [ -d "$APPICON_DIR" ]; then
+  cp "$IOS_ICON_SRC"/AppIcon-*.png "$APPICON_DIR/"
+  echo "[configure-ios] AppIcon synced from $IOS_ICON_SRC (same source as Android)"
+else
+  echo "[configure-ios] WARNING: AppIcon dirs missing (src=$IOS_ICON_SRC dst=$APPICON_DIR);" \
+    "run 'pnpm run init' first (generates src-tauri/icons/ios via 'tauri icon')" >&2
+fi
+
+# --- 6. Show the patched shell script for verification -----------------------
 
 echo "[configure-ios] Build Rust Code shellScript (first 220 chars):"
 grep -o 'shellScript = ".*' "$PBXPROJ" | head -3 | cut -c1-220 || true

--- a/scripts/configure-ios-project.sh
+++ b/scripts/configure-ios-project.sh
@@ -76,7 +76,8 @@ fi
 
 if grep -q 'shellScript = "pnpm tauri ' "$PBXPROJ"; then
   # 用 | 作 sed 分隔符避免转义 /；\\" 在 pbxproj 字符串内输出 \"（嵌套引号）
-  sed -i '' 's|shellScript = "pnpm tauri |shellScript = "node \\"$PROJECT_DIR/../../node_modules/@tauri-apps/cli/tauri.js\\" |g' "$PBXPROJ"
+  # $PROJECT_DIR = src-tauri/gen/apple，需要 ../../.. 三级回到仓库根
+  sed -i '' 's|shellScript = "pnpm tauri |shellScript = "node \\"$PROJECT_DIR/../../../node_modules/@tauri-apps/cli/tauri.js\\" |g' "$PBXPROJ"
   echo "[configure-ios] Build Rust Code phase patched: pnpm tauri -> node tauri.js (bypass pnpm)"
 else
   echo "[configure-ios] Build Rust Code phase: no 'pnpm tauri' prefix found (already patched or not pnpm-wrapped)"

--- a/scripts/configure-ios-project.sh
+++ b/scripts/configure-ios-project.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 # ============================================================================
-# 配置 LingChat 的 iOS Xcode 工程（仅在 macOS 上运行）。
+# Configure LingChat's iOS Xcode project (macOS only).
 #
-# 职责：
-#   1. 若 src-tauri/gen/apple/ 不存在，执行 `tauri ios init` 生成 Xcode 工程
-#      （内部通过 XcodeGen 生成，产物保留 project.yml 与 <app>.xcodeproj）。
-#   2. 断言/归一化 TARGETED_DEVICE_FAMILY = "1,2"（iPhone + iPad 兼容）。
-#      XcodeGen 默认即 '1,2'，这里显式兜底，满足「兼容 iPhone 和 iPad」要求。
+# Responsibilities:
+#   1. If src-tauri/gen/apple/ does not exist, run `tauri ios init` to
+#      generate the Xcode project (XcodeGen under the hood; keeps project.yml
+#      and <app>.xcodeproj).
+#   2. Normalize TARGETED_DEVICE_FAMILY = "1,2" (iPhone + iPad).
+#      XcodeGen's default is already '1,2'; we force it here to guarantee
+#      iPhone & iPad compatibility.
 #
-# 注意：Windows/Linux 上 tauri-cli 不提供 ios 子命令，本脚本只能在 macOS 执行。
-# 依赖：Xcode（含 Command Line Tools）、xcodegen（brew install xcodegen）、
-#       Rust 目标 aarch64-apple-ios（rustup target add aarch64-apple-ios）。
+# NOTE: tauri-cli does not ship the `ios` subcommand on Windows/Linux, so
+# this script only runs on macOS.
+# Requirements: Xcode (+ Command Line Tools), xcodegen (`brew install xcodegen`),
+# Rust target aarch64-apple-ios (`rustup target add aarch64-apple-ios`).
 # ============================================================================
 set -euo pipefail
 
@@ -19,46 +22,46 @@ cd "$ROOT"
 
 GEN_APPLE="src-tauri/gen/apple"
 
-# ─── 1. 初始化 Xcode 工程 ─────────────────────────────────────
+# --- 1. Initialize the Xcode project ----------------------------------------
 
 if [ ! -d "$GEN_APPLE" ]; then
-  echo "🔧 未找到 $GEN_APPLE，执行 tauri ios init ..."
+  echo "[configure-ios] gen/apple missing, running: pnpm tauri ios init --ci"
   if ! command -v xcodegen >/dev/null 2>&1; then
-    echo "❌ 缺少 xcodegen，请先安装：brew install xcodegen" >&2
+    echo "[configure-ios] ERROR: xcodegen not found. Install it with: brew install xcodegen" >&2
     exit 1
   fi
   pnpm tauri ios init --ci
-  echo "✅ Xcode 工程已生成"
+  echo "[configure-ios] Xcode project generated"
 else
-  echo "ℹ️  已存在 $GEN_APPLE，跳过 init"
+  echo "[configure-ios] $GEN_APPLE already exists, skipping init"
 fi
 
 PBXPROJ="$(ls "$GEN_APPLE"/*.xcodeproj/project.pbxproj 2>/dev/null | head -1 || true)"
 if [ -z "$PBXPROJ" ] || [ ! -f "$PBXPROJ" ]; then
-  echo "❌ 未找到 project.pbxproj，请检查 $GEN_APPLE 下的 Xcode 工程" >&2
+  echo "[configure-ios] ERROR: project.pbxproj not found under $GEN_APPLE" >&2
   exit 1
 fi
 
-# ─── 2. 归一化 TARGETED_DEVICE_FAMILY = "1,2" ────────────────
+# --- 2. Normalize TARGETED_DEVICE_FAMILY = "1,2" (iPhone + iPad) -------------
 
 if grep -q "TARGETED_DEVICE_FAMILY" "$PBXPROJ"; then
-  # BSD sed（macOS 自带）：把所有设备族设置统一为 iPhone + iPad
+  # BSD sed (built into macOS): unify every device-family setting to iPhone + iPad
   sed -i '' -E 's/TARGETED_DEVICE_FAMILY = [^;]+;/TARGETED_DEVICE_FAMILY = "1,2";/g' "$PBXPROJ"
-  echo "✅ TARGETED_DEVICE_FAMILY 已归一化为 \"1,2\"（iPhone + iPad）"
+  echo "[configure-ios] TARGETED_DEVICE_FAMILY normalized to \"1,2\" (iPhone + iPad)"
 else
-  echo "⚠  pbxproj 中未找到 TARGETED_DEVICE_FAMILY（XcodeGen 应默认生成 '1,2'），" \
-    "请打开 Xcode 工程在 Build Settings 中确认 TARGETED_DEVICE_FAMILY = 1,2" >&2
+  echo "[configure-ios] WARNING: TARGETED_DEVICE_FAMILY not found in pbxproj " \
+    "(XcodeGen should generate '1,2' by default). Verify in Xcode Build Settings." >&2
 fi
 
 COUNT="$(grep -c 'TARGETED_DEVICE_FAMILY = "1,2"' "$PBXPROJ" || true)"
-echo "   TARGETED_DEVICE_FAMILY=\"1,2\" 出现 $COUNT 处"
+echo "[configure-ios] TARGETED_DEVICE_FAMILY=\"1,2\" occurrences: $COUNT"
 
-# ─── 3. 校验 iOS 专属 Info.plist 合并钩子 ─────────────────────
+# --- 3. Verify the iOS-specific Info.plist merge hook ------------------------
 
 if [ -f "src-tauri/Info.ios.plist" ]; then
-  echo "ℹ️  src-tauri/Info.ios.plist 存在（文件 App 可见 + 设备族），构建时会自动合并进 Info.plist"
+  echo "[configure-ios] src-tauri/Info.ios.plist present (Files-app visibility + device family); it is merged into Info.plist on every tauri ios build"
 else
-  echo "⚠  缺少 src-tauri/Info.ios.plist（UIFileSharingEnabled 等键将缺失）" >&2
+  echo "[configure-ios] WARNING: src-tauri/Info.ios.plist missing (UIFileSharingEnabled etc. will be absent)" >&2
 fi
 
-echo "✅ iOS 工程配置完成：iPhone + iPad 兼容、数据目录对「文件」App 可见"
+echo "[configure-ios] iOS project configured: iPhone + iPad, data dir visible in the Files app"

--- a/scripts/prepare-bundled-resources.mjs
+++ b/scripts/prepare-bundled-resources.mjs
@@ -1,5 +1,6 @@
 // 在 tauri 构建之前，将 git 追踪的 data/ 文件打包为 data.7z
-// 直接放入 Android 原生 assets 目录（src-tauri/gen/android/app/src/main/assets/data/）
+// - Android：直接放入原生 assets 目录（src-tauri/gen/android/app/src/main/assets/data/）
+// - iOS：放入 Xcode 工程资源目录（src-tauri/gen/apple/assets/data/，folder reference 打进 bundle）
 // .gitignore 决定哪些是默认资源、哪些是用户自定义内容。
 // third_party/ 作为例外始终包含（运行时需要的模型文件）。
 
@@ -26,8 +27,6 @@ console.log(`7z compression level: -mx=${level} (LZMA2)`);
 const buildDir = join(srcTauri, '.bundled_build');
 
 // Android assets 目标目录
-// iOS：尚未实现 iOS 构建支持，暂无 gen/ios/ 目录及 data.7z 部署流程
-// 若后续添加 iOS 构建，需在此处增加复制到 iOS bundle resources 的逻辑
 const androidAssetsDir = join(srcTauri, 'gen', 'android', 'app', 'src', 'main', 'assets', 'data');
 
 // 清理
@@ -103,6 +102,23 @@ if (existsSync(androidAssetsDir)) {
 mkdirSync(androidAssetsDir, { recursive: true });
 copyFileSync(archivePath, join(androidAssetsDir, 'data.7z'));
 console.log(`Copied data.7z to ${androidAssetsDir}`);
+
+// --- iOS：部署 data.7z 到 Xcode 工程资源目录 ---
+// gen/apple/assets/ 在 project.yml 中以 folder reference（type: folder）参与
+// resources build phase，构建时整体拷入 app bundle 根目录，
+// 因此 gen/apple/assets/data/data.7z → <bundle>/data/data.7z，
+// 与 Rust 侧 seed_via_fs_plugin 的读取路径 {resource_dir}/data/data.7z 一致。
+const iosGenApple = join(srcTauri, 'gen', 'apple');
+if (existsSync(iosGenApple)) {
+  const iosDataDir = join(iosGenApple, 'assets', 'data');
+  mkdirSync(iosDataDir, { recursive: true });
+  copyFileSync(archivePath, join(iosDataDir, 'data.7z'));
+  console.log(`Copied data.7z to ${iosDataDir}`);
+} else {
+  console.log(
+    '⚠ gen/apple 不存在，跳过 iOS data.7z 部署（请先在 macOS 上执行 pnpm ios:init 生成 Xcode 工程）'
+  );
+}
 
 // --- 清理临时目录 ---
 rmSync(buildDir, { recursive: true });

--- a/scripts/prepare-bundled-resources.mjs
+++ b/scripts/prepare-bundled-resources.mjs
@@ -111,6 +111,12 @@ console.log(`Copied data.7z to ${androidAssetsDir}`);
 const iosGenApple = join(srcTauri, 'gen', 'apple');
 if (existsSync(iosGenApple)) {
   const iosDataDir = join(iosGenApple, 'assets', 'data');
+  // 与 Android 分支一致：先清空再写入，避免旧构建残留
+  // （如曾误放入 gen/apple/assets/data/ 的 .official/third_party 真实文件）
+  // 被 folder reference 整体打进 iOS bundle，导致包体膨胀与资源重复。
+  if (existsSync(iosDataDir)) {
+    rmSync(iosDataDir, { recursive: true });
+  }
   mkdirSync(iosDataDir, { recursive: true });
   copyFileSync(archivePath, join(iosDataDir, 'data.7z'));
   console.log(`Copied data.7z to ${iosDataDir}`);

--- a/scripts/prepare-desktop-resources.mjs
+++ b/scripts/prepare-desktop-resources.mjs
@@ -34,6 +34,11 @@ if (existsSync(stagingDir)) {
 }
 mkdirSync(stagingDir, { recursive: true });
 
+// 移动端（android/ios）：默认资源全部走 data.7z（见 prepare-bundled-resources.mjs），
+// 桌面端 .official 资源不进入移动端包体。但仍需生成空占位目录与空 manifest，
+// 否则 tauri-cli 的 inject_resources 在移动端构建时因 bundle.resources 源缺失而报错。
+const isMobile = ['android', 'ios'].includes(process.env.TAURI_ENV_PLATFORM);
+
 // ─── 获取 git 跟踪的 data/ 文件 ─────────────────────────────
 
 let gitFiles = [];
@@ -87,19 +92,25 @@ console.log(`   game_data: ${gameDataFiles.length} 个文件`);
 // ─── 复制 game_data 文件 ────────────────────────────────────
 
 let gameDataCount = 0;
-for (const subPath of gameDataFiles) {
-  const src = join(projectRoot, "data", subPath);
-  // subPath 已经是 "game_data/backgrounds/白天.webp" 这种形式
-  const dst = join(stagingDir, subPath);
+if (isMobile) {
+  // 移动端：game_data 已打包进 data.7z，这里只创建空占位目录，
+  // 满足 tauri-cli inject_resources 对 bundle.resources 源路径的校验。
+  mkdirSync(join(stagingDir, "game_data"), { recursive: true });
+} else {
+  for (const subPath of gameDataFiles) {
+    const src = join(projectRoot, "data", subPath);
+    // subPath 已经是 "game_data/backgrounds/白天.webp" 这种形式
+    const dst = join(stagingDir, subPath);
 
-  if (!existsSync(src)) {
-    console.warn(`  ⚠ 文件不存在: ${subPath}`);
-    continue;
+    if (!existsSync(src)) {
+      console.warn(`  ⚠ 文件不存在: ${subPath}`);
+      continue;
+    }
+
+    mkdirSync(dirname(dst), { recursive: true });
+    copyFileSync(src, dst);
+    gameDataCount++;
   }
-
-  mkdirSync(dirname(dst), { recursive: true });
-  copyFileSync(src, dst);
-  gameDataCount++;
 }
 console.log(`✅ 已复制 ${gameDataCount} 个 game_data 文件`);
 
@@ -110,7 +121,7 @@ console.log(`✅ 已复制 ${gameDataCount} 个 game_data 文件`);
 // 移动端（android/ios）下 third_party 已打包在 data.zip 中，跳过以避免
 // bundle.resources 在 assets 中产生重复副本。
 
-const isMobile = ['android', 'ios'].includes(process.env.TAURI_ENV_PLATFORM);
+// isMobile 已在文件顶部定义（TAURI_ENV_PLATFORM 在 beforeBuildCommand 阶段可用）
 
 const thirdPartySrc = join(projectRoot, "data", "third_party");
 const thirdPartyDst = join(stagingDir, "third_party");

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -17,11 +17,11 @@
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	<true/>
 
-	<!-- 明确声明兼容 iPhone (1) 与 iPad (2)，与工程 TARGETED_DEVICE_FAMILY=1,2 保持一致 -->
-	<key>UIDeviceFamily</key>
-	<array>
-		<integer>1</integer>
-		<integer>2</integer>
-	</array>
+	<!--
+		设备族（iPhone/iPad）不在这里声明：UIDeviceFamily 是派生子键，
+		tauri-cli 合并 Info.plist 时以 TARGETED_DEVICE_FAMILY build setting
+		为准并覆盖此处声明（xcodebuild 会对此输出警告）。设备族统一由
+		scripts/configure-ios-project.sh 归一化 TARGETED_DEVICE_FAMILY = "1,2"。
+	-->
 </dict>
 </plist>

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+		iOS 专属 Info.plist 合并片段。
+
+		由 `tauri ios build` 在每次构建时自动与 XcodeGen 生成的 Info.plist
+		合并（见 tauri-cli mobile/ios/build.rs 的 Info.plist merge 逻辑，
+		该文件与 src-tauri/Info.plist 同级，属 iOS 专属钩子），
+		因此这里声明的键会稳定生效，不依赖 gen/apple 工程的重新生成。
+	-->
+
+	<!-- 文件 App 可见应用数据目录（配合 Rust 侧 data 目录定位到 Documents） -->
+	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+
+	<!-- 明确声明兼容 iPhone (1) 与 iPad (2)，与工程 TARGETED_DEVICE_FAMILY=1,2 保持一致 -->
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+</dict>
+</plist>

--- a/src-tauri/plugins/tauri-plugin-screenshots/Cargo.toml
+++ b/src-tauri/plugins/tauri-plugin-screenshots/Cargo.toml
@@ -15,8 +15,12 @@ links = "tauri-plugin-screenshots"
 tauri = { version = "2" }
 serde = "1"
 thiserror = "2"
-xcap = "0.9.6"
 log = "0.4"
+
+# xcap 不支持 iOS（无 #[cfg(target_os = "ios")] 平台实现），
+# iOS 构建时排除 xcap，命令降级为「不支持」桩（见 src/commands.rs）。
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+xcap = "0.9.6"
 
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src-tauri/plugins/tauri-plugin-screenshots/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-screenshots/src/commands.rs
@@ -5,6 +5,9 @@ use std::{
 
 use serde::Serialize;
 use tauri::{command, AppHandle, Manager, Runtime};
+// xcap 不支持 iOS（桌面窗口/显示器截图在 iOS 无意义），
+// iOS 构建时不引入 xcap，各命令走文件末尾的「不支持」桩实现。
+#[cfg(not(target_os = "ios"))]
 use xcap::{Monitor, Window};
 
 #[derive(Debug, Serialize)]
@@ -35,6 +38,7 @@ pub struct ScreenshotableMonitor {
 /// let windows = get_screenshotable_windows().await.unwrap();
 /// println!("{:#?}", windows); // Vec<ScreenshotableWindow>
 /// ```
+#[cfg(not(target_os = "ios"))]
 #[command]
 pub async fn get_screenshotable_windows() -> Result<Vec<ScreenshotableWindow>, String> {
     // On Windows, use our custom enumeration that does NOT filter out
@@ -90,6 +94,7 @@ pub async fn get_screenshotable_windows() -> Result<Vec<ScreenshotableWindow>, S
 /// let monitors = get_screenshotable_monitors().await.unwrap();
 /// println!("{:#?}", monitors); // Vec<ScreenshotableMonitor>
 /// ```
+#[cfg(not(target_os = "ios"))]
 #[command]
 pub async fn get_screenshotable_monitors() -> Result<Vec<ScreenshotableMonitor>, String> {
     let monitors = Monitor::all().map_err(|err| err.to_string())?;
@@ -106,6 +111,7 @@ pub async fn get_screenshotable_monitors() -> Result<Vec<ScreenshotableMonitor>,
     Ok(screenshotable_monitors)
 }
 
+#[cfg(not(target_os = "ios"))]
 fn get_save_dir<R: Runtime>(app_handle: AppHandle<R>) -> Result<PathBuf, String> {
     let save_dir = app_handle
         .path()
@@ -116,6 +122,7 @@ fn get_save_dir<R: Runtime>(app_handle: AppHandle<R>) -> Result<PathBuf, String>
     Ok(save_dir)
 }
 
+#[cfg(not(target_os = "ios"))]
 fn get_save_path<R: Runtime>(
     app_handle: AppHandle<R>,
     id: u32,
@@ -149,6 +156,7 @@ fn get_save_path<R: Runtime>(
 /// let path = get_window_screenshot(app_handle, 1).await.unwrap();
 /// println!("{:?}", path); // xx/tauri-plugin-screenshots/window-1.png
 /// ```
+#[cfg(not(target_os = "ios"))]
 #[command]
 pub async fn get_window_screenshot<R: Runtime>(
     app_handle: AppHandle<R>,
@@ -205,6 +213,7 @@ pub async fn get_window_screenshot<R: Runtime>(
 /// let path = get_monitor_screenshot(app_handle, 1).await.unwrap();
 /// println!("{:?}", path); // xx/tauri-plugin-screenshots/monitor-1.png
 /// ```
+#[cfg(not(target_os = "ios"))]
 #[command]
 pub async fn get_monitor_screenshot<R: Runtime>(
     app_handle: AppHandle<R>,
@@ -241,6 +250,7 @@ pub async fn get_monitor_screenshot<R: Runtime>(
 ///
 /// remove_window_screenshot(app_handle, 1).await.unwrap();
 /// ```
+#[cfg(not(target_os = "ios"))]
 #[command]
 pub async fn remove_window_screenshot<R: Runtime>(
     app_handle: AppHandle<R>,
@@ -267,6 +277,7 @@ pub async fn remove_window_screenshot<R: Runtime>(
 ///
 /// remove_monitor_screenshot(app_handle, 1).await.unwrap();
 /// ```
+#[cfg(not(target_os = "ios"))]
 #[command]
 pub async fn remove_monitor_screenshot<R: Runtime>(
     app_handle: AppHandle<R>,
@@ -289,9 +300,71 @@ pub async fn remove_monitor_screenshot<R: Runtime>(
 ///
 /// clear_screenshots(app_handle).await.unwrap();
 /// ```
+#[cfg(not(target_os = "ios"))]
 #[command]
 pub async fn clear_screenshots<R: Runtime>(app_handle: AppHandle<R>) -> Result<(), String> {
     let save_dir = get_save_dir(app_handle)?;
 
     remove_dir_all(save_dir).map_err(|err| err.to_string())
+}
+
+// ─── iOS 桩实现 ──────────────────────────────────────────────
+//
+// iOS 上不实现桌面窗口/显示器截图（xcap 不支持 iOS 平台），
+// 所有命令返回「不支持」错误，保证 invoke_handler 注册一致、
+// capabilities 的 screenshots:default 权限可正常解析。
+// 前端在 iOS 上不会调用这些命令。
+
+#[cfg(target_os = "ios")]
+#[command]
+pub async fn get_screenshotable_windows() -> Result<Vec<ScreenshotableWindow>, String> {
+    Err("screenshots are not supported on iOS".to_string())
+}
+
+#[cfg(target_os = "ios")]
+#[command]
+pub async fn get_screenshotable_monitors() -> Result<Vec<ScreenshotableMonitor>, String> {
+    Err("screenshots are not supported on iOS".to_string())
+}
+
+#[cfg(target_os = "ios")]
+#[command]
+pub async fn get_window_screenshot<R: Runtime>(
+    _app_handle: AppHandle<R>,
+    _id: u32,
+) -> Result<PathBuf, String> {
+    Err("screenshots are not supported on iOS".to_string())
+}
+
+#[cfg(target_os = "ios")]
+#[command]
+pub async fn get_monitor_screenshot<R: Runtime>(
+    _app_handle: AppHandle<R>,
+    _id: u32,
+) -> Result<PathBuf, String> {
+    Err("screenshots are not supported on iOS".to_string())
+}
+
+#[cfg(target_os = "ios")]
+#[command]
+pub async fn remove_window_screenshot<R: Runtime>(
+    _app_handle: AppHandle<R>,
+    _id: u32,
+) -> Result<(), String> {
+    Err("screenshots are not supported on iOS".to_string())
+}
+
+#[cfg(target_os = "ios")]
+#[command]
+pub async fn remove_monitor_screenshot<R: Runtime>(
+    _app_handle: AppHandle<R>,
+    _id: u32,
+) -> Result<(), String> {
+    Err("screenshots are not supported on iOS".to_string())
+}
+
+#[cfg(target_os = "ios")]
+#[command]
+pub async fn clear_screenshots<R: Runtime>(_app_handle: AppHandle<R>) -> Result<(), String> {
+    Err("screenshots are not supported on iOS".to_string())
 }

--- a/src-tauri/src/init/static_copy.rs
+++ b/src-tauri/src/init/static_copy.rs
@@ -137,12 +137,14 @@ fn seed_desktop(
 /// 该 7z 由构建脚本放入移动端资源目录。
 /// 这种方式从根本上避开了 asset:// 协议处理中文路径的问题。
 ///
-/// 路径差异：
+/// 路径差异（实测：iOS 的 resource_dir() 返回的就是 bundle 内的 assets/ 目录，
+/// 因此两端统一读 `{resource_dir}/data/data.7z`）：
 /// - Android：data.7z 在 APK 的 assets/data/data.7z，resource_dir() 即 assets 根
 ///   → 读取 `{resource_dir}/data/data.7z`
 /// - iOS：data.7z 在 `gen/apple/assets/data/data.7z`，XcodeGen 的 folder reference
-///   会把 `assets/` **整个目录**拷进 app bundle（保留目录名），resource_dir() 是
-///   bundle 根 → 读取 `{resource_dir}/assets/data/data.7z`
+///   把 `assets/` **整个目录**拷进 app bundle 后即 resource_dir()
+///   → 读取 `{resource_dir}/data/data.7z`（不要再拼一层 `assets/`，否则变成
+///   `<bundle>/assets/assets/data/data.7z` 导致播种失败）
 #[cfg(any(target_os = "android", target_os = "ios"))]
 fn seed_via_fs_plugin(app: &tauri::AppHandle, data_dir: &std::path::Path) -> anyhow::Result<()> {
     use anyhow::Context;
@@ -158,9 +160,10 @@ fn seed_via_fs_plugin(app: &tauri::AppHandle, data_dir: &std::path::Path) -> any
     let base = base.trim_end_matches('/');
 
     // 读取 data.7z（唯一需要从 asset:// 读取的文件，纯 ASCII 路径）
-    #[cfg(target_os = "ios")]
-    let archive_asset = format!("{}/assets/data/data.7z", base);
-    #[cfg(not(target_os = "ios"))]
+    // iOS：tauri 的 resource_dir() 返回 bundle 内的 assets/ 目录
+    //   （gen/apple/assets/ 以 folder reference 打进 bundle 后即 resource_dir），
+    //   因此 data.7z 的读取路径是 {resource_dir}/data/data.7z。
+    // Android：resource_dir() 即 APK assets 根，同样读 {resource_dir}/data/data.7z。
     let archive_asset = format!("{}/data/data.7z", base);
 
     let archive_bytes = app

--- a/src-tauri/src/init/static_copy.rs
+++ b/src-tauri/src/init/static_copy.rs
@@ -134,8 +134,15 @@ fn seed_desktop(
 /// 通过 tauri-plugin-fs 读取打包的 data.7z 并解压到 data_dir。
 ///
 /// 所有游戏资源文件在构建时被打包成一个 7z（ASCII 文件名），
-/// 该 7z 由构建脚本直接放入 Android assets 目录。
-/// 这种方式从根本上避开了 Android asset:// 协议处理中文路径的问题。
+/// 该 7z 由构建脚本放入移动端资源目录。
+/// 这种方式从根本上避开了 asset:// 协议处理中文路径的问题。
+///
+/// 路径差异：
+/// - Android：data.7z 在 APK 的 assets/data/data.7z，resource_dir() 即 assets 根
+///   → 读取 `{resource_dir}/data/data.7z`
+/// - iOS：data.7z 在 `gen/apple/assets/data/data.7z`，XcodeGen 的 folder reference
+///   会把 `assets/` **整个目录**拷进 app bundle（保留目录名），resource_dir() 是
+///   bundle 根 → 读取 `{resource_dir}/assets/data/data.7z`
 #[cfg(any(target_os = "android", target_os = "ios"))]
 fn seed_via_fs_plugin(app: &tauri::AppHandle, data_dir: &std::path::Path) -> anyhow::Result<()> {
     use anyhow::Context;
@@ -151,7 +158,11 @@ fn seed_via_fs_plugin(app: &tauri::AppHandle, data_dir: &std::path::Path) -> any
     let base = base.trim_end_matches('/');
 
     // 读取 data.7z（唯一需要从 asset:// 读取的文件，纯 ASCII 路径）
+    #[cfg(target_os = "ios")]
+    let archive_asset = format!("{}/assets/data/data.7z", base);
+    #[cfg(not(target_os = "ios"))]
     let archive_asset = format!("{}/data/data.7z", base);
+
     let archive_bytes = app
         .fs()
         .read(std::path::Path::new(&archive_asset))

--- a/src-tauri/src/init/static_copy.rs
+++ b/src-tauri/src/init/static_copy.rs
@@ -21,7 +21,7 @@ pub fn get_data_dir() -> &'static PathBuf {
 ///
 /// 优先级：
 /// 1. Android：应用专属外部存储 (/storage/emulated/0/Android/data/<package>/files)
-/// 2. iOS：平台沙盒内的应用数据目录
+/// 2. iOS：沙盒 Documents 目录（配合 Info.ios.plist 的文件共享键，「文件」App 可见）
 /// 3. 桌面端开发模式（debug）：项目根目录下的 `data/`
 /// 4. 桌面端发布模式（release portable）：exe 所在目录下的 `data/`
 fn resolve_data_dir(app: &tauri::AppHandle) -> PathBuf {
@@ -43,10 +43,15 @@ fn resolve_data_dir_impl(app: &tauri::AppHandle) -> PathBuf {
 #[cfg(target_os = "ios")]
 fn resolve_data_dir_impl(app: &tauri::AppHandle) -> PathBuf {
     use tauri::Manager;
-    // iOS 继续使用沙盒路径
+    // iOS：使用沙盒内的 Documents 目录（<container>/Documents）。
+    // 配合 src-tauri/Info.ios.plist 中的 UIFileSharingEnabled /
+    // LSSupportsOpeningDocumentsInPlace，用户可以在系统「文件」App 里
+    // 直接看到并访问整个 data/ 目录（游戏数据、语音、截图等）。
+    // 注意不要改回 app_data_dir()（Library/Application Support），
+    // 那部分对「文件」App 不可见。
     app.path()
-        .app_data_dir()
-        .expect("failed to resolve app_data_dir on iOS")
+        .document_dir()
+        .expect("failed to resolve document_dir on iOS")
 }
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/src/App.vue
+++ b/src/App.vue
@@ -73,6 +73,99 @@ void getImportedFonts().then((fonts) => {
 
 const route = useRoute()
 
+// ─── iOS 键盘适配：仿 Android 实现（MainActivity 注入 --safe-area-inset-*） ─────
+// Android：WebView 不随键盘改变布局，而是把键盘/系统 bars 高度作为
+//   --safe-area-inset-bottom 注入 CSS 变量，UI 用 var() 自行让位，页面永不滚动。
+// iOS 照搬同一模式：
+//   1. 键盘/配件条高度并入 --safe-area-inset-bottom（存在 .pb-safe/pb-safe-gap、
+//      对话框 padding、MusicPlayer 等 var() 用法，自动上移让位）
+//   2. 硬锁滚动：任何 scroll 事件立即归零，页面不可上下滑动（与 Android 一致）
+const vv = window.visualViewport
+// 基准底部安全区（无键盘时的 env 值，首个值即基线）
+let safeBaseBottom = 0
+let safeBaseInitialized = false
+// 当前已施加的抬升量（几何解算用自然位置 = 当前底部 + 已抬升量，避免自引用震荡）
+let currentLift = 0
+// 键盘状态兜底轮询：外部/配件键盘等场景 vv 事件偶发不触发，
+// 轮询 vv.height 变化触发重算（800ms 一次，开销可忽略）
+let kbGuardTimer: ReturnType<typeof setInterval> | null = null
+let lastKbSig = 0
+
+const lockScroll = () => {
+  window.scrollTo(0, 0)
+  if (document.documentElement.scrollTop) document.documentElement.scrollTop = 0
+  if (document.body.scrollTop) document.body.scrollTop = 0
+}
+
+// 页面级平移拦截（iOS 键盘收起后剩余的可滚动区）：根级 touchmove 直接 preventDefault，
+// 内部滚动容器（聊天记录/设置页等 overflow-y-auto/custom-scroll）不受影响
+const preventRootTouchScroll = (e: TouchEvent) => {
+  const t = e.target as HTMLElement | null
+  if (
+    t &&
+    t.closest(
+      '.overflow-y-auto, .overflow-auto, .custom-scroll, .scrollbar-thin, [data-scrollable]',
+    )
+  ) {
+    return
+  }
+  e.preventDefault()
+}
+
+const syncVisualViewport = () => {
+  if (!vv) return
+  const root = document.documentElement
+  if (!safeBaseInitialized) {
+    // 初始同步：读取当前 env() 解析值作为基线（iOS: 34px 左右；桌面 0）
+    const cur = parseFloat(getComputedStyle(root).getPropertyValue('--safe-area-inset-bottom')) || 0
+    safeBaseBottom = Number.isFinite(cur) ? cur : 0
+    safeBaseInitialized = true
+  }
+
+  // iPad 检测：现代 iPadOS 为桌面版 UA（MacIntel + 多点触控）
+  const isIPad =
+    navigator.userAgent.includes('iPad') ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+
+  // 键盘可见高度 = 取两种来源的最大值：
+  //   - env(keyboard-inset-height)：iPad 悬浮小键盘/常规键盘上报的可见高度（iOS 16.4+）
+  //   - vv 高度差：iPhone 软键盘、配件条等
+  let kbd = 0
+  try {
+    const envKbd = parseFloat(
+      getComputedStyle(root).getPropertyValue('keyboard-inset-height'),
+    )
+    if (Number.isFinite(envKbd)) kbd = Math.max(kbd, envKbd)
+  } catch {
+    /* env 不可读时忽略 */
+  }
+  kbd = Math.max(kbd, window.innerHeight - vv.height)
+
+  // 键盘可见区顶部（可见区高度 = min(vv.height, 窗口 - 键盘高度)）
+  const visibleHeight = Math.min(vv.height, window.innerHeight - kbd)
+
+  // 不让位的情形：无键盘；或 iPad 悬浮小键盘（可拖动，挡到输入框用户会自行移开）
+  if (kbd <= 20 || (isIPad && kbd < 200)) {
+    currentLift = 0
+  } else {
+    // 几何解算让位：以「聚焦输入框自然底部 + 间距」相对键盘上方可见区的高度差为准。
+    // 自然位置 = 当前底部 + 已施加抬升量（移除抬升影响），公式稳定不震荡。
+    const ae = document.activeElement as HTMLElement | null
+    if (ae && typeof ae.getBoundingClientRect === 'function') {
+      const r = ae.getBoundingClientRect()
+      const naturalBottom = r.bottom + currentLift
+      if (naturalBottom - 16 > visibleHeight) {
+        currentLift = Math.max(0, Math.round(naturalBottom - 16 - visibleHeight))
+      }
+    }
+  }
+  // 仿 Android：底部安全区 = 基线 + 抬升量
+  root.style.setProperty('--safe-area-inset-bottom', `${safeBaseBottom + currentLift}px`)
+
+  // 页面始终锚定原点（键盘弹出的系统 focus-scroll 与手势滚动都会被锁回）
+  lockScroll()
+}
+
 // 仅主窗口挂载全局弹窗（通知/成就/对话确认），日志窗口等复用 App.vue 的窗口不弹
 const isMainWindow = getCurrentWindow().label === 'main'
 
@@ -144,6 +237,45 @@ onMounted(async () => {
   // 注册 F11 全屏快捷键
   window.addEventListener('keydown', handleKeyDown)
 
+  // ─── iOS 键盘：视觉视口收缩时同步布局视口 ──────────────────────
+  // WKWebView 固定布局下聚焦输入框弹出键盘时，布局视口不会自动收缩，
+  // 页面（874 高）比可视区高 → 整个 webview 可上下滑动、输入框被键盘盖住。
+  // 这里把 documentElement 高度跟随 visualViewport（键盘弹出=可视区高度），
+  // 配合 index.html 的 interactive-widget=resizes-content 双保险；
+  // 桌面 visualViewport == window，同步为无操作。
+  if (vv) {
+    vv.addEventListener('resize', syncVisualViewport)
+    vv.addEventListener('scroll', syncVisualViewport)
+  }
+  window.addEventListener('orientationchange', syncVisualViewport)
+  // 硬锁滚动：任何滚动（键盘 focus-scroll / 手势）立即归零
+  window.addEventListener('scroll', lockScroll, { passive: true, capture: true })
+  document.addEventListener('touchmove', preventRootTouchScroll, { passive: false })
+  // 聚焦变化 → 重算让位（focusin 先清 0 由 vv resize 收敛，focusout 归零）
+  document.addEventListener('focusin', syncVisualViewport, true)
+  document.addEventListener('focusout', syncVisualViewport, true)
+  if (vv) {
+    kbGuardTimer = setInterval(() => {
+      let envKbd = 0
+      try {
+        envKbd =
+          parseFloat(
+            getComputedStyle(document.documentElement).getPropertyValue(
+              'keyboard-inset-height',
+            ),
+          ) || 0
+      } catch {
+        /* ignore */
+      }
+      const sig = Math.round(vv.height) * 1000 + Math.round(envKbd)
+      if (sig !== lastKbSig) {
+        lastKbSig = sig
+        syncVisualViewport()
+      }
+    }, 800)
+  }
+  lockScroll()
+
   // ─── 关闭确认逻辑 ──────────────────────────────────────────
 
   // 1. 监听 Rust 存档完成事件
@@ -179,6 +311,19 @@ onMounted(async () => {
 
 onUnmounted(() => {
   window.removeEventListener('keydown', handleKeyDown)
+  window.removeEventListener('orientationchange', syncVisualViewport)
+  window.removeEventListener('scroll', lockScroll, { capture: true } as any)
+  document.removeEventListener('touchmove', preventRootTouchScroll)
+  document.removeEventListener('focusin', syncVisualViewport, true)
+  document.removeEventListener('focusout', syncVisualViewport, true)
+  if (kbGuardTimer) {
+    clearInterval(kbGuardTimer)
+    kbGuardTimer = null
+  }
+  if (vv) {
+    vv.removeEventListener('resize', syncVisualViewport)
+    vv.removeEventListener('scroll', syncVisualViewport)
+  }
   if (unlistenCloseReady) unlistenCloseReady()
   if (unlistenCloseRequested) unlistenCloseRequested()
 })
@@ -205,7 +350,14 @@ html {
 }
 
 #app {
-  width: 100vw;
-  height: 100vh;
+  /* 视口口径统一为动态视口（dvw/dvh，iOS 全屏态下 dvw 横屏自动排除左右安全区、dvh 竖屏含上下安全区）：
+     #app 铺满整个视觉视口（含状态栏/Home 指示器区域），使各屏壁纸全出血显示；
+     安全区内缩由各边缘元素通过 env(safe-area-inset-*)（桌面/Android 桌面为 0px，零回归）自行处理——
+     已在全局提供 --safe-area-inset-* 变量与 .pt-safe/.pb-safe 工具类（见 base.css）。 */
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100dvw;
+  height: 100dvh;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -166,6 +166,19 @@ const syncVisualViewport = () => {
   lockScroll()
 }
 
+// 旋转/分屏后安全区基线失效：iPhone 竖屏底部 inset ≈34px、横屏 ≈21px（灵动岛移到左右），
+// iPad 台前调度改窗口尺寸同理。挂载时采样的基线在旋转后是旧值，这里强制重采样：
+//   1. 先清掉本模块写入的内联覆盖（iOS 回落 :root 的 env() 实时解析新值；
+//      Android 的 --safe-area-inset-* 由 MainActivity insets 监听注入，旋转后监听
+//      会重新触发注入，此处的临时清空无影响）
+//   2. 重置基线标记，下一次 sync 重读 env() 解析值作为新基线
+const handleOrientationChange = () => {
+  document.documentElement.style.removeProperty('--safe-area-inset-bottom')
+  safeBaseInitialized = false
+  currentLift = 0
+  syncVisualViewport()
+}
+
 // 仅主窗口挂载全局弹窗（通知/成就/对话确认），日志窗口等复用 App.vue 的窗口不弹
 const isMainWindow = getCurrentWindow().label === 'main'
 
@@ -247,7 +260,7 @@ onMounted(async () => {
     vv.addEventListener('resize', syncVisualViewport)
     vv.addEventListener('scroll', syncVisualViewport)
   }
-  window.addEventListener('orientationchange', syncVisualViewport)
+  window.addEventListener('orientationchange', handleOrientationChange)
   // 硬锁滚动：任何滚动（键盘 focus-scroll / 手势）立即归零
   window.addEventListener('scroll', lockScroll, { passive: true, capture: true })
   document.addEventListener('touchmove', preventRootTouchScroll, { passive: false })
@@ -311,7 +324,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   window.removeEventListener('keydown', handleKeyDown)
-  window.removeEventListener('orientationchange', syncVisualViewport)
+  window.removeEventListener('orientationchange', handleOrientationChange)
   window.removeEventListener('scroll', lockScroll, { capture: true } as any)
   document.removeEventListener('touchmove', preventRootTouchScroll)
   document.removeEventListener('focusin', syncVisualViewport, true)

--- a/src/App.vue
+++ b/src/App.vue
@@ -112,6 +112,23 @@ const preventRootTouchScroll = (e: TouchEvent) => {
   e.preventDefault()
 }
 
+// 移动端禁用 WebView 原生缩放（双指捏合 / 双击放大）：
+// index.html 的 viewport meta（user-scalable=no + maximum-scale=1）与 base.css 的
+// touch-action: manipulation 为主，这里再兜底拦截 WebKit 缩放手势与多触点手势，
+// 确保 Android WebView / iOS WKWebView 都无法捏合或双击放大界面。
+const preventZoomGestures = (e: Event) => {
+  // iOS Safari/WKWebView 的捏合缩放会触发 gesturestart/change/end，preventDefault 可取消缩放
+  if (e.type === 'gesturestart' || e.type === 'gesturechange' || e.type === 'gestureend') {
+    e.preventDefault()
+    return
+  }
+  // 触点 >= 2 即是双指捏合手势（Android/通用），preventDefault 取消缩放
+  const te = e as TouchEvent
+  if (te.touches && te.touches.length > 1) {
+    e.preventDefault()
+  }
+}
+
 const syncVisualViewport = () => {
   if (!vv) return
   const root = document.documentElement
@@ -264,6 +281,12 @@ onMounted(async () => {
   // 硬锁滚动：任何滚动（键盘 focus-scroll / 手势）立即归零
   window.addEventListener('scroll', lockScroll, { passive: true, capture: true })
   document.addEventListener('touchmove', preventRootTouchScroll, { passive: false })
+  // 兜底：禁用双指/双击/捏合的原生缩放
+  document.addEventListener('gesturestart', preventZoomGestures, { passive: false })
+  document.addEventListener('gesturechange', preventZoomGestures, { passive: false })
+  document.addEventListener('gestureend', preventZoomGestures, { passive: false })
+  document.addEventListener('touchstart', preventZoomGestures, { passive: false })
+  document.addEventListener('touchmove', preventZoomGestures, { passive: false })
   // 聚焦变化 → 重算让位（focusin 先清 0 由 vv resize 收敛，focusout 归零）
   document.addEventListener('focusin', syncVisualViewport, true)
   document.addEventListener('focusout', syncVisualViewport, true)
@@ -327,6 +350,11 @@ onUnmounted(() => {
   window.removeEventListener('orientationchange', handleOrientationChange)
   window.removeEventListener('scroll', lockScroll, { capture: true } as any)
   document.removeEventListener('touchmove', preventRootTouchScroll)
+  document.removeEventListener('gesturestart', preventZoomGestures)
+  document.removeEventListener('gesturechange', preventZoomGestures)
+  document.removeEventListener('gestureend', preventZoomGestures)
+  document.removeEventListener('touchstart', preventZoomGestures)
+  document.removeEventListener('touchmove', preventZoomGestures)
   document.removeEventListener('focusin', syncVisualViewport, true)
   document.removeEventListener('focusout', syncVisualViewport, true)
   if (kbGuardTimer) {

--- a/src/assets/styles/base.css
+++ b/src/assets/styles/base.css
@@ -38,6 +38,12 @@
 .pt-safe-gap { padding-top: calc(8px + var(--safe-area-inset-top)); }
 .pb-safe-gap { padding-bottom: calc(8px + var(--safe-area-inset-bottom)); }
 
+/* 输入控件字号下限 16px：阻止 iOS 聚焦时对 <16px 输入框的自动缩放（页面放大一下） */
+input,
+textarea {
+  font-size: max(16px, 1em);
+}
+
 @keyframes spin {
   0% {
     transform: rotate(0deg);

--- a/src/assets/styles/base.css
+++ b/src/assets/styles/base.css
@@ -79,6 +79,15 @@ textarea {
   body {
     overflow: hidden;
   }
+
+  /* 移动端禁用原生缩放手势（双指捏合 / 双击放大）：
+     viewport meta 的 user-scalable=no + maximum-scale=1 为主,
+     touch-action: manipulation 在组件索引里作为兜底再压掉一次双击缩放。
+     manipulation = 允许 pan/滚动（保留组件内容滚动），仅禁用双击缩放。 */
+  html,
+  body {
+    touch-action: manipulation;
+  }
 }
 
 /* 滚动条样式 */

--- a/src/components/LanSyncDialog.vue
+++ b/src/components/LanSyncDialog.vue
@@ -6,7 +6,7 @@
       @click="emit('close')"
     >
       <div
-        class="relative w-full max-w-lg max-h-[80vh] overflow-hidden rounded-3xl border border-white/20 bg-slate-900/40 backdrop-blur-2xl shadow-2xl flex flex-col"
+        class="relative w-full max-w-lg max-h-[80dvh] overflow-hidden rounded-3xl border border-white/20 bg-slate-900/40 backdrop-blur-2xl shadow-2xl flex flex-col"
         @click.stop
       >
         <!-- ─── 头部 ─── -->

--- a/src/components/ResourceSyncDialog.vue
+++ b/src/components/ResourceSyncDialog.vue
@@ -5,7 +5,7 @@
         v-if="visible && phase !== 'idle'"
         class="fixed inset-0 z-[10000] flex items-center justify-center bg-slate-900/60 backdrop-blur-sm"
       >
-        <div class="w-[520px] max-h-[80vh] rounded-3xl bg-slate-800/90 shadow-2xl flex flex-col overflow-hidden">
+        <div class="w-[520px] max-h-[80dvh] rounded-3xl bg-slate-800/90 shadow-2xl flex flex-col overflow-hidden">
           <!-- 头部 -->
           <div class="px-6 pt-6 pb-4">
             <h2 class="text-xl font-semibold text-white">{{ dialogTitle }}</h2>
@@ -28,7 +28,7 @@
               </div>
 
               <!-- 文件树：按目录分组 -->
-              <div class="max-h-[50vh] overflow-y-auto space-y-1">
+              <div class="max-h-[50dvh] overflow-y-auto space-y-1">
                 <template v-for="group in fileGroups" :key="group.dir">
                   <!-- 目录头 -->
                   <div

--- a/src/components/effects/CursorEffects.vue
+++ b/src/components/effects/CursorEffects.vue
@@ -100,6 +100,7 @@ class MouseSpark {
   onMouseMove: (e: MouseEvent) => void = () => {}
   onMouseUp: (e: MouseEvent) => void = () => {}
   onResize: () => void = () => {}
+  resizeObserver: ResizeObserver | null = null
 
   bindHandlers() {
     const getPos = (e: MouseEvent) => ({ x: e.clientX, y: e.clientY })
@@ -178,6 +179,11 @@ class MouseSpark {
     window.addEventListener('mousemove', this.onMouseMove)
     window.addEventListener('mouseup', this.onMouseUp)
     window.addEventListener('resize', this.onResize)
+    // 容器尺寸变化（状态栏显隐/键盘/窗口化）时重算画布位图，防止拉伸错位
+    if (typeof ResizeObserver !== 'undefined' && this.mainCanvas.parentElement) {
+      this.resizeObserver = new ResizeObserver(() => this.resize())
+      this.resizeObserver.observe(this.mainCanvas.parentElement)
+    }
   }
 
   destroy() {
@@ -185,6 +191,8 @@ class MouseSpark {
     window.removeEventListener('mousemove', this.onMouseMove)
     window.removeEventListener('mouseup', this.onMouseUp)
     window.removeEventListener('resize', this.onResize)
+    this.resizeObserver?.disconnect()
+    this.resizeObserver = null
     if (this.animationId) {
       cancelAnimationFrame(this.animationId)
     }
@@ -203,8 +211,12 @@ class MouseSpark {
 
   resize() {
     const dpr = window.devicePixelRatio || 1
-    const cssWidth = Math.max(1, window.innerWidth)
-    const cssHeight = Math.max(1, window.innerHeight)
+    // 优先按容器自身盒子计算画布位图：重启时状态栏出现/键盘/台前调度改窗口等场景，
+    // 容器（inset:0 铺满视觉视口）与 window.innerWidth/Height 短期不一致时，
+    // 按窗口值算出的位图会被拉伸（特效偏移随 y 线性增大）——以容器为准则恒 1:1。
+    const el = this.mainCanvas.parentElement
+    const cssWidth = Math.max(1, el ? el.clientWidth : window.innerWidth)
+    const cssHeight = Math.max(1, el ? el.clientHeight : window.innerHeight)
     const w = Math.max(1, Math.floor(cssWidth * dpr))
     const h = Math.max(1, Math.floor(cssHeight * dpr))
 
@@ -753,10 +765,10 @@ onBeforeUnmount(() => {
 .cursor-effects-container {
   pointer-events: none;
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
+  /* 用 inset:0 铺满视觉视口：避免 100vw/100dvh 与 window.innerWidth/Height
+     在 iOS 键盘弹出/窗口化（iPad 台前调度）等场景出现坐标偏差，
+     保证波纹/轨迹与 clientX/clientY 严格同原点 */
+  inset: 0;
   z-index: 9999;
 }
 

--- a/src/components/game/standard/GameDialog.vue
+++ b/src/components/game/standard/GameDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="relative z-2 flex w-full scrollbar-thin [scrollbar-color:var(--accent-color)_transparent]
+    class="game-dialog relative z-2 flex w-full scrollbar-thin [scrollbar-color:var(--accent-color)_transparent]
       justify-center p-3.75 transition-all duration-200 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]
       before:pointer-events-none before:absolute before:-top-10 before:right-0 before:left-0
       before:h-10 before:bg-linear-to-b before:from-transparent before:via-[rgba(0,14,39,0.3)]
@@ -8,7 +8,7 @@
     :class="{
       [`z-[-1]! overflow-hidden opacity-0 duration-500! ease-linear before:opacity-0
       before:duration-1000!`]: isHidden,
-      'max-h-[40vh]': !uiStore.isNarrowScreen,
+      'max-h-[40dvh]': !uiStore.isNarrowScreen,
     }"
     :style="dialogWrapperStyle"
     @wheel="handleWheelHistory"
@@ -234,7 +234,7 @@
             v-show="currentStatus === 'responding'"
             ref="inlineDisplayRef"
             tabindex="0"
-            class="response-display my-1.25 max-h-[50vh] min-h-30 flex-1 resize-none overflow-y-auto
+            class="response-display my-1.25 max-h-[50dvh] min-h-30 flex-1 resize-none overflow-y-auto
               border-none bg-transparent font-[inherit] text-xl font-bold break-all
               whitespace-pre-line outline-none text-shadow-[inherit]"
             :class="textareaMotionClass"
@@ -246,8 +246,8 @@
             v-show="currentStatus !== 'responding'"
             id="inputMessage"
             ref="textareaRef"
-            class="my-1.25 max-h-[50vh] min-h-30 flex-1 resize-none border-none bg-transparent
-              font-[inherit] text-xl font-bold transition-all duration-300 outline-none
+            class="my-1.25 max-h-[50dvh] min-h-30 flex-1 resize-none border-none bg-transparent
+              font-[inherit] text-[max(1.25rem,16px)] font-bold transition-all duration-300 outline-none
               text-shadow-[inherit] placeholder:text-white/50 placeholder:shadow-none"
             :placeholder="placeholderText"
             v-model="inputMessage"
@@ -973,6 +973,11 @@
 </style>
 
 <style>
+  /* 底部 Home 指示器安全区：对话框本体铺到屏幕底（其半透明底盖住背景条带），
+     仅内容底部让出 env() 高度，输入框不被 Home 指示器遮挡（桌面/Android 桌面 env=0） */
+  .game-dialog {
+    padding-bottom: calc(15px + var(--safe-area-inset-bottom, 0px));
+  }
   /* 逐字符淡入+上浮动画。keyframes 必须全局：span 由 JS 动态生成，scoped 选择器无法命中 */
   @keyframes tw-char-rise {
     from {

--- a/src/components/game/standard/animations/MeteorAnimation.vue
+++ b/src/components/game/standard/animations/MeteorAnimation.vue
@@ -404,7 +404,7 @@ onUnmounted(() => {
 <style scoped>
 .meteor-wrapper {
   position: fixed;
-  /* 用 inset-0 代替 100vw×100vh：#app 上 transform: scale 缩放时，vw/vh 尺寸
+  /* 用 inset-0 代替 100vw×100dvh：#app 上 transform: scale 缩放时，vw/vh 尺寸
      会被放大导致溢出裁切，inset-0 相对缩放后的 #app 盒恒填满视口 */
   inset: 0;
   width: 100%;

--- a/src/components/game/standard/extra/GameChoices.vue
+++ b/src/components/game/standard/extra/GameChoices.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fixed inset-0 flex flex-col items-center justify-center mt-[-15vh] pointer-events-none"
+    class="fixed inset-0 flex flex-col items-center justify-center mt-[-15dvh] pointer-events-none"
   >
     <transition-group
       appear

--- a/src/components/game/standard/extra/ScriptCompleteDisplay.vue
+++ b/src/components/game/standard/extra/ScriptCompleteDisplay.vue
@@ -1,9 +1,9 @@
 <template>
   <transition appear :css="false" @before-enter="beforeEnter" @enter="enter" @leave="leave">
-    <!-- 使用 mt-[-20vh] 让整体位置中间偏上 -->
+    <!-- 使用 mt-[-20dvh] 让整体位置中间偏上 -->
     <div
       v-if="isVisible"
-      class="fixed inset-0 flex flex-col items-center justify-center mt-[-20vh] pointer-events-none z-1000"
+      class="fixed inset-0 flex flex-col items-center justify-center mt-[-20dvh] pointer-events-none z-1000"
     >
       <!-- 柔和的雾化背景层 -->
       <div

--- a/src/components/game/standard/extra/ScriptFreeDialogueDisplay.vue
+++ b/src/components/game/standard/extra/ScriptFreeDialogueDisplay.vue
@@ -1,9 +1,9 @@
 <template>
-  <!-- 1. 上方提示动画 (带有两边渐变透明的背景，且位置上移至 top-20vh) -->
+  <!-- 1. 上方提示动画 (带有两边渐变透明的背景，且位置上移至 top-20dvh) -->
   <transition appear :css="false" @before-enter="beforeEnter" @enter="enter" @leave="leave">
     <div
       v-if="showAnimation"
-      class="fixed left-0 right-0 top-[20vh] flex justify-center pointer-events-none z-1000"
+      class="fixed left-0 right-0 top-[20dvh] flex justify-center pointer-events-none z-1000"
     >
       <!-- 中间实体、两端渐变淡出透明的遮罩背景层 -->
       <div

--- a/src/components/game/standard/extra/ScriptPicDisplay.vue
+++ b/src/components/game/standard/extra/ScriptPicDisplay.vue
@@ -6,7 +6,7 @@
   >
     <ImageAcrossFade
       ref="imageFadeRef"
-      class="h-[40vh] w-auto max-w-[80vw] max-h-[60vh] object-contain"
+      class="h-[40dvh] w-auto max-w-[80vw] max-h-[60dvh] object-contain"
       :style="{ transform: `scale(${uiStore.currentPresentPicScale || 1})` }"
       :src="uiStore.currentPresentPic"
       position="center center"

--- a/src/components/game/standard/extra/SoundEffectPanel.vue
+++ b/src/components/game/standard/extra/SoundEffectPanel.vue
@@ -29,7 +29,7 @@
       <div
         v-if="panelVisible"
         ref="panelRef"
-        class="fixed bottom-[calc(64px+var(--safe-area-inset-bottom))] left-4 w-[520px] max-h-[80vh] overflow-y-auto bg-[#12121c]/75 backdrop-blur-[20px] border border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.4)] rounded-3xl p-4 text-white box-border z-[1000] custom-scrollbar"
+        class="fixed bottom-[calc(64px+var(--safe-area-inset-bottom))] left-4 w-[520px] max-h-[80dvh] overflow-y-auto bg-[#12121c]/75 backdrop-blur-[20px] border border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.4)] rounded-3xl p-4 text-white box-border z-[1000] custom-scrollbar"
       >
         <!-- ===== BGM 区域 ===== -->
         <div class="mb-4">

--- a/src/components/schedule/ScheduleContent.vue
+++ b/src/components/schedule/ScheduleContent.vue
@@ -254,7 +254,7 @@ const goBackToParentView = () => {
 const containerClass = computed(() => {
   // settings：沿用原来的全屏设置页布局
   if (props.variant === 'settings') {
-    return 'h-[85vh] max-w-6xl md:w-[calc(100vw-4rem)] glass-panel bg-white/10 rounded-2xl'
+    return 'h-[85dvh] max-w-6xl md:w-[calc(100vw-4rem)] glass-panel bg-white/10 rounded-2xl'
   }
   // popup：由父级 modal 控制尺寸和样式，此处填满容器
   return 'w-full h-full'

--- a/src/components/schedule/SchedulePanel.vue
+++ b/src/components/schedule/SchedulePanel.vue
@@ -34,7 +34,7 @@
             <div
               v-if="enabled"
               class="relative flex flex-col rounded-3xl border border-white/10 shadow-[0_8px_32px_rgba(0,0,0,0.4)]"
-              :class="uiStore.isNarrowScreen ? 'w-[95vw] h-[85vh]' : 'w-[80vw] h-[80vh] max-w-[1200px]'"
+              :class="uiStore.isNarrowScreen ? 'w-[95vw] h-[85dvh]' : 'w-[80vw] h-[80dvh] max-w-[1200px]'"
             >
               <!-- Header bar -->
               <div class="flex items-center justify-between shrink-0 px-5 py-3 bg-[#12121c]/90 backdrop-blur-xl border-b border-white/10">

--- a/src/components/script-editor/flow/ChapterTimeline.vue
+++ b/src/components/script-editor/flow/ChapterTimeline.vue
@@ -204,7 +204,7 @@
         >
           <div
             class="w-[min(560px,92vw)]
-              max-h-[80vh]
+              max-h-[80dvh]
               overflow-y-auto
               border
               border-white/12.5

--- a/src/components/script-editor/modals/EditorModals.vue
+++ b/src/components/script-editor/modals/EditorModals.vue
@@ -98,7 +98,7 @@ const confirmModal = async () => {
         <!-- 主弹窗 -->
         <div
           class="w-[min(440px,92vw)]
-            max-h-[86vh]
+            max-h-[86dvh]
             overflow-y-auto
             border
             border-white/12.5

--- a/src/components/script-editor/modals/ImageCropModal.vue
+++ b/src/components/script-editor/modals/ImageCropModal.vue
@@ -41,7 +41,7 @@
         </div>
 
         <div class="relative
-          max-h-[52vh]
+          max-h-[52dvh]
           min-h-[300px]
           overflow-hidden
           bg-black/70">

--- a/src/components/script-editor/panels/ShortcutHelpPanel.vue
+++ b/src/components/script-editor/panels/ShortcutHelpPanel.vue
@@ -127,7 +127,7 @@ const rowBinding = (a: ShortcutAction) => settings.shortcuts[a] as ShortcutBindi
       >
         <div
           class="w-[min(460px,92vw)]
-            max-h-[86vh]
+            max-h-[86dvh]
             overflow-y-auto
             border
             border-white/12.5

--- a/src/components/settings/SettingsNav.vue
+++ b/src/components/settings/SettingsNav.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full flex items-center justify-between relative px-5 py-2">
+  <div class="w-full h-full flex items-center justify-between relative px-5 pt-safe pb-2">
     <img src="@/assets/images/LingChatLogo.png" alt="Logo" class="w-20 ml-5 hidden xl:block" />
     <nav
       ref="navContainer"

--- a/src/components/settings/pages/LogConsole.vue
+++ b/src/components/settings/pages/LogConsole.vue
@@ -2,7 +2,7 @@
   <!-- 日志已弹出到独立窗口：显示占位提示 -->
   <div
     v-if="!standalone && popped"
-    class="flex-1 min-h-0 max-h-[70vh] flex flex-col items-center justify-center gap-3.5 border border-dashed border-white/20 rounded-xl bg-black/40 text-white/55 px-4 py-8"
+    class="flex-1 min-h-0 max-h-[70dvh] flex flex-col items-center justify-center gap-3.5 border border-dashed border-white/20 rounded-xl bg-black/40 text-white/55 px-4 py-8"
   >
     <PictureInPicture2 :size="36" />
     <div class="text-sm text-center leading-loose">{{ $t('settings.log.poppedOut') }}</div>
@@ -85,7 +85,7 @@
     <div
       ref="logContainer"
       class="scrollbar-thin flex-1 min-h-0 overflow-y-auto overflow-x-hidden rounded-xl px-3 py-3 bg-black/65 border border-white/10 backdrop-blur-md text-[13px] leading-[1.7] font-['Cascadia_Code','Fira_Code','JetBrains_Mono','Consolas',monospace]"
-      :class="standalone ? 'max-h-none' : 'max-h-[70vh]'"
+      :class="standalone ? 'max-h-none' : 'max-h-[70dvh]'"
       :style="{ scrollbarColor: 'var(--accent-color, #79d9ff) transparent' }"
       @scroll="handleScroll"
     >

--- a/src/components/settings/pages/SettingsAdvance.vue
+++ b/src/components/settings/pages/SettingsAdvance.vue
@@ -1,6 +1,6 @@
 <template>
   <MenuPage>
-    <div class="flex-1 h-[85vh] w-full bg-white/10 p-0 md:p-4 rounded-lg overflow-hidden flex flex-col">
+    <div class="flex-1 h-[85dvh] w-full bg-white/10 p-0 md:p-4 rounded-lg overflow-hidden flex flex-col">
       <!-- 顶部 Tab 切换栏：左 / 中 / 右 -->
       <div class="flex items-center justify-between mb-5 select-none shrink-0">
         <button

--- a/src/components/settings/pages/SettingsCharacterCreate.vue
+++ b/src/components/settings/pages/SettingsCharacterCreate.vue
@@ -6,7 +6,7 @@
       @click="handleClose"
     >
       <div
-        class="w-full max-w-6xl h-[90vh] overflow-hidden rounded-3xl border border-white/20 bg-[radial-gradient(circle_at_10%_10%,rgba(251,191,36,0.12),transparent_35%),radial-gradient(circle_at_90%_20%,rgba(45,212,191,0.12),transparent_40%),linear-gradient(160deg,rgba(15,23,42,0.96),rgba(15,23,42,0.88))] text-white shadow-2xl"
+        class="w-full max-w-6xl h-[90dvh] overflow-hidden rounded-3xl border border-white/20 bg-[radial-gradient(circle_at_10%_10%,rgba(251,191,36,0.12),transparent_35%),radial-gradient(circle_at_90%_20%,rgba(45,212,191,0.12),transparent_40%),linear-gradient(160deg,rgba(15,23,42,0.96),rgba(15,23,42,0.88))] text-white shadow-2xl"
         @click.stop
       >
         <div class="h-full flex flex-col">

--- a/src/components/settings/pages/SettingsCharacterInfo.vue
+++ b/src/components/settings/pages/SettingsCharacterInfo.vue
@@ -6,7 +6,7 @@
       @click="handleClose"
     >
       <div
-        class="bg-[linear-gradient(135deg,rgba(255,255,255,0.15)_0%,rgba(255,255,255,0.05)_100%)] backdrop-blur-[30px] backdrop-saturate-180 rounded-3xl shadow-[0_20px_60px_rgba(0,0,0,0.4),inset_0_0_1px_rgba(255,255,255,0.3)] border border-white/20 w-full max-w-4xl h-[85vh] flex flex-col overflow-hidden text-white"
+        class="bg-[linear-gradient(135deg,rgba(255,255,255,0.15)_0%,rgba(255,255,255,0.05)_100%)] backdrop-blur-[30px] backdrop-saturate-180 rounded-3xl shadow-[0_20px_60px_rgba(0,0,0,0.4),inset_0_0_1px_rgba(255,255,255,0.3)] border border-white/20 w-full max-w-4xl h-[85dvh] flex flex-col overflow-hidden text-white"
         @click.stop
       >
         <!-- Header -->

--- a/src/components/settings/pages/SettingsHistory.vue
+++ b/src/components/settings/pages/SettingsHistory.vue
@@ -4,7 +4,7 @@
       <template #header>
         <History :size="20" />
       </template>
-      <div class="flex flex-col h-full max-h-[75vh] min-h-0">
+      <div class="flex flex-col h-full max-h-[75dvh] min-h-0">
         <div v-if="dialogHistory.length === 0" class="flex flex-1 items-center justify-center">
           <div
             class="py-10 text-center text-2xl font-bold text-gray-100 [text-shadow:0_0_5px_rgba(255,255,255,0.5)]"

--- a/src/components/settings/pages/SettingsSave.vue
+++ b/src/components/settings/pages/SettingsSave.vue
@@ -25,7 +25,7 @@
         <LayoutList :size="20" />
       </template>
       <div class="flex flex-col">
-        <div class="h-[calc(100vh-22rem)] min-h-[300px] overflow-y-auto pr-1 pb-4">
+        <div class="h-[calc(100dvh-22rem)] min-h-[300px] overflow-y-auto pr-1 pb-4">
           <div v-if="loading" class="text-center text-[#888] p-8">{{ $t('settings.shared.loading') }}</div>
 
           <div v-else-if="error" class="text-center text-[#ff6b6b] p-8">{{ $t('settings.save.list.loadFailed', { error }) }}</div>

--- a/src/components/settings/scene/SceneEditModal.vue
+++ b/src/components/settings/scene/SceneEditModal.vue
@@ -7,7 +7,7 @@
         @click="$emit('close')"
       >
         <div
-          class="relative w-full max-w-7xl max-h-[92vh] overflow-hidden rounded-3xl border border-white/20 bg-slate-900/40 backdrop-blur-2xl shadow-2xl flex"
+          class="relative w-full max-w-7xl max-h-[92dvh] overflow-hidden rounded-3xl border border-white/20 bg-slate-900/40 backdrop-blur-2xl shadow-2xl flex"
           @click.stop
         >
           <!-- ====== 左栏：表单 ====== -->

--- a/src/components/ui/Menu/CharacterCard.vue
+++ b/src/components/ui/Menu/CharacterCard.vue
@@ -105,7 +105,7 @@
       @click="closeDetailModal"
     >
       <div
-        class="relative flex max-h-[85vh] w-full max-w-4xl flex-col overflow-hidden rounded-3xl border border-white/20 bg-slate-900/40 shadow-2xl backdrop-blur-2xl"
+        class="relative flex max-h-[85dvh] w-full max-w-4xl flex-col overflow-hidden rounded-3xl border border-white/20 bg-slate-900/40 shadow-2xl backdrop-blur-2xl"
         @click.stop
       >
         <div class="flex items-center gap-4 border-b border-white/10 bg-white/10 p-6">

--- a/src/components/views/Credits.vue
+++ b/src/components/views/Credits.vue
@@ -47,7 +47,7 @@
     >
       <div
         class="credits-scroll absolute top-0 left-0 w-full text-center flex flex-col items-center"
-        :class="[!isStarted ? 'translate-y-[100vh]' : '']"
+        :class="[!isStarted ? 'translate-y-[100dvh]' : '']"
       >
         <StarField ref="starfieldRef" />
 
@@ -140,10 +140,10 @@
 
           <!-- 特殊结尾 (还有...你) -->
           <div v-else-if="section.layout === 'special'" class="flex flex-col items-center mb-15">
-            <div class="h-[60vh]"></div>
+            <div class="h-[60dvh]"></div>
             <h2 class="text-[2.2em] text-[#00e5ff] font-light mb-2">{{ sectionTitle(section) }}</h2>
             <p class="text-[1em] text-white opacity-60 mb-20">{{ sectionSubtitle(section) }}</p>
-            <div class="h-[60vh]"></div>
+            <div class="h-[60dvh]"></div>
             <p class="text-[1.5em] leading-[1.8] font-light">{{ $t('views.credits.you') }}</p>
             <p class="text-[1em] opacity-80 leading-[1.8] font-light">
               {{ isEn ? section.items?.[0]?.name : section.items?.[0]?.enName }}
@@ -442,7 +442,7 @@ onBeforeUnmount(() => {
 
 @keyframes scrollAnimation {
   from {
-    transform: translateY(100vh);
+    transform: translateY(100dvh);
   }
   to {
     transform: translateY(-100%);

--- a/src/components/views/LoadingTransition.vue
+++ b/src/components/views/LoadingTransition.vue
@@ -49,7 +49,7 @@
         class="absolute bottom-4 right-4 w-8 h-8 border-r-2 border-b-2 border-teal-500/30 pointer-events-none"
       ></div>
 
-      <!-- 浮动粒子（position:absolute 默认 top:0，translateY(100vh)→(-10vh) = 底部→顶部） -->
+      <!-- 浮动粒子（position:absolute 默认 top:0，translateY(100dvh)→(-10dvh) = 底部→顶部） -->
       <div
         v-for="p in particles"
         :key="p.id"
@@ -216,15 +216,15 @@
           </div>
 
           <div
-            class="w-[40vh] text-center text-sm font-mono text-cyan-400/70 transition-all duration-300"
+            class="w-[40dvh] text-center text-sm font-mono text-cyan-400/70 transition-all duration-300"
           >
             {{ currentStatusText }}
           </div>
 
           <!-- 进度条 -->
-          <div class="w-[60vh] flex items-center space-y-2 mt-4">
+          <div class="w-[60dvh] flex items-center space-y-2 mt-4">
             <div
-              class="w-[60vh] h-6 bg-slate-950/80 rounded-full border border-teal-500/20 p-0.5 relative overflow-hidden flex items-center"
+              class="w-[60dvh] h-6 bg-slate-950/80 rounded-full border border-teal-500/20 p-0.5 relative overflow-hidden flex items-center"
             >
               <div
                 class="h-full bg-gradient-to-r from-teal-500/80 to-cyan-400 rounded-full glow-cyan transition-all duration-100"
@@ -242,7 +242,7 @@
           </div>
 
           <div
-            class="w-[40vh] flex text-center justify-center gap-12 text-sm font-mono text-cyan-300/80"
+            class="w-[40dvh] flex text-center justify-center gap-12 text-sm font-mono text-cyan-300/80"
           >
             <span class="text-cyan-500/80">{{ randomTip }}</span>
           </div>
@@ -737,14 +737,14 @@ onUnmounted(() => {
 /* ===== 粒子上升 ===== */
 @keyframes particleUp {
   0% {
-    transform: translateY(100vh) scale(0.5);
+    transform: translateY(100dvh) scale(0.5);
     opacity: 0;
   }
   50% {
     opacity: 0.6;
   }
   100% {
-    transform: translateY(-10vh) scale(1.2);
+    transform: translateY(-10dvh) scale(1.2);
     opacity: 0;
   }
 }

--- a/src/components/views/LogWindow.vue
+++ b/src/components/views/LogWindow.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col h-screen p-3 box-border bg-[#1a1b1e]">
+  <div class="flex flex-col h-dvh p-3 box-border bg-[#1a1b1e]">
     <LogConsole standalone />
   </div>
 </template>

--- a/src/components/views/PetMode.vue
+++ b/src/components/views/PetMode.vue
@@ -382,7 +382,7 @@ const handleExitPetMode = async () => {
 #pet-app {
   position: relative;
   width: 100vw;
-  height: 100vh;
+  height: 100dvh;
   overflow: hidden;
 }
 </style>

--- a/src/components/views/menu/base/StartItem.vue
+++ b/src/components/views/menu/base/StartItem.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     v-bind="$attrs"
-    class="bg-transparent
+    class="start-item bg-transparent
       text-white
       border-none
       mt-[15px]
@@ -10,6 +10,8 @@
       cursor-pointer
       text-justify
       whitespace-nowrap
+      max-[767px]:whitespace-normal
+      max-[767px]:text-left
       text-shadow-[0_2px_4px_rgba(0,0,0,0.3)]
       transition-all
       duration-300
@@ -35,3 +37,13 @@ defineOptions({ inheritAttrs: false })
 
 const isUltraWide = inject<{ value: boolean }>('isUltraWide', { value: false })
 </script>
+
+<style>
+/* 二级菜单（menu-subitem）：仅当窄屏内容超宽（如"剧情模式（在自由模式进入自由模式）"）
+   时缩小字号；一级菜单保持原字号（40px），不缩小、不拥挤。 */
+@media (max-width: 767px) {
+  .start-item.menu-subitem {
+    font-size: 32px;
+  }
+}
+</style>

--- a/src/components/views/menu/base/StartLogo.vue
+++ b/src/components/views/menu/base/StartLogo.vue
@@ -3,7 +3,6 @@
     src="../../../../assets/images/LingChatLogo.png"
     alt="LingChatLogo"
     class="absolute
-      top-0
       drop-shadow-[0_4px_8px_rgba(0,0,0,0.3)]
       transition-transform
       hover:scale-105
@@ -14,6 +13,7 @@
       duration-300
       max-w-[40vw]
       h-[16vw]"
+    :style="{ top: 'var(--safe-area-inset-top, 0px)', right: 'var(--safe-area-inset-right, 0px)' }"
     v-bind="$attrs"
   />
 </template>

--- a/src/components/views/menu/base/StartPage.vue
+++ b/src/components/views/menu/base/StartPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="z-5
+    class="start-page z-5
       absolute
       top-0
       bottom-0
@@ -23,3 +23,14 @@
 <script setup lang="ts">
 defineOptions({ inheritAttrs: false })
 </script>
+
+<style>
+/* 小高度视口（手机横屏）：保留原 6vw 边框间距，仅叠加横向安全区，
+   让菜单列避开横屏时位于侧边的灵动岛（桌面/竖屏 safe=0，无影响）。 */
+@media (max-height: 520px) {
+  .start-page {
+    padding-left: var(--safe-area-inset-left, 0px);
+    padding-right: var(--safe-area-inset-right, 0px);
+  }
+}
+</style>

--- a/src/components/views/menu/page/GameModeOptions.vue
+++ b/src/components/views/menu/page/GameModeOptions.vue
@@ -1,19 +1,19 @@
 <template>
   <StartList>
     <StartLine>
-      <StartItem @click="startFreeDialogue">{{ $t('views.menu.freeDialogue') }}</StartItem>
+      <StartItem class="menu-subitem" @click="startFreeDialogue">{{ $t('views.menu.freeDialogue') }}</StartItem>
     </StartLine>
 
     <StartLine>
-      <StartItem disabled="true">{{ $t('views.menu.storyMode') }}</StartItem>
+      <StartItem class="menu-subitem" disabled="true">{{ $t('views.menu.storyMode') }}</StartItem>
     </StartLine>
 
     <StartLine>
-      <StartItem disabled="true">{{ $t('views.menu.miniGame') }}</StartItem>
+      <StartItem class="menu-subitem" disabled="true">{{ $t('views.menu.miniGame') }}</StartItem>
     </StartLine>
 
     <StartLine>
-      <StartItem @click="emit('back')">{{ $t('views.menu.back') }}</StartItem>
+      <StartItem class="menu-subitem" @click="emit('back')">{{ $t('views.menu.back') }}</StartItem>
     </StartLine>
   </StartList>
 </template>

--- a/src/components/views/menu/page/ScriptModeOptions.vue
+++ b/src/components/views/menu/page/ScriptModeOptions.vue
@@ -1,7 +1,7 @@
 <template>
   <StartList>
     <StartLine v-for="(script, index) in currentPageScripts">
-      <StartItem
+      <StartItem class="menu-subitem"
         :key="script.script_name"
         @click="selectScript(script)"
       >
@@ -10,7 +10,7 @@
     </StartLine>
 
     <StartLine>
-      <StartItem
+      <StartItem class="menu-subitem"
         v-for="n in pageSize - currentPageScripts.length"
         :key="'placeholder-' + n"
         disabled="true"
@@ -20,19 +20,19 @@
     </StartLine>
     <!-- 分页控制 -->
     <StartLine>
-      <StartItem
+      <StartItem class="menu-subitem"
         @click="currentPage--"
         :disabled="currentPage === 1"
       >
         <
       </StartItem>
-      <StartItem
+      <StartItem class="menu-subitem"
         disabled="true"
         style="font-size: 28px"
       >
         {{ currentPage }} / {{ totalPages }}
       </StartItem>
-      <StartItem
+      <StartItem class="menu-subitem"
         @click="currentPage++"
         :disabled="currentPage === totalPages"
       >

--- a/src/components/views/menu/page/WorkshopOptions.vue
+++ b/src/components/views/menu/page/WorkshopOptions.vue
@@ -1,23 +1,23 @@
 <template>
   <StartList>
     <StartLine>
-      <StartItem disabled="true">角色编辑器(开发中)</StartItem>
+      <StartItem class="menu-subitem" disabled="true">角色编辑器(开发中)</StartItem>
     </StartLine>
 
     <StartLine>
-      <StartItem @click="router.push('/script-editor')">剧本编辑器</StartItem>
+      <StartItem class="menu-subitem" @click="router.push('/script-editor')">剧本编辑器</StartItem>
     </StartLine>
 
     <StartLine>
-      <StartItem @click="router.push('/workshop')">{{ $t('views.menu.cloudWorkshop') }}</StartItem>
+      <StartItem class="menu-subitem" @click="router.push('/workshop')">{{ $t('views.menu.cloudWorkshop') }}</StartItem>
     </StartLine>
 
     <StartLine>
-      <StartItem disabled="true">游戏编辑器(开发中)</StartItem>
+      <StartItem class="menu-subitem" disabled="true">游戏编辑器(开发中)</StartItem>
     </StartLine>
 
     <StartLine>
-      <StartItem @click="emit('back')">返回</StartItem>
+      <StartItem class="menu-subitem" @click="emit('back')">返回</StartItem>
     </StartLine>
   </StartList>
 </template>

--- a/src/composables/useZoom.ts
+++ b/src/composables/useZoom.ts
@@ -3,7 +3,7 @@
  *
  * 按住 Ctrl 并滚动鼠标滚轮来缩放整个 UI 界面。
  * 使用 `transform: scale` + 尺寸补偿在 #app 元素上实现均匀缩放：
- * #app 布局尺寸设为 `calc(100vw / z) × calc(100vh / z)` 再整体放大 z 倍，
+ * #app 布局尺寸设为 `calc(100dvw / z) × calc(100dvh / z)` 再整体放大 z 倍，
  * 视觉上恒精确填满窗口 —— 旧实现用 CSS zoom 直接缩放 100vw×100vh，
  * 放大时内容溢出视口被裁切（像放大镜）、缩小时填不满窗口留下空白。
  * 缩放级别保存在 localStorage 中，跨会话持久化。
@@ -78,8 +78,10 @@ function applyZoom(level: number): void {
   if (app) {
     app.style.transformOrigin = 'top left'
     app.style.transform = `scale(${level})`
-    app.style.width = `calc(100vw / ${level})`
-    app.style.height = `calc(100vh / ${level})`
+    // #app 铺满整个动态视口（含安全区）；同 App.vue 的 position: fixed 口径：
+    // 布局尺寸 = 视口 / z，缩放后视觉恒精确填满视口。
+    app.style.width = `calc(100dvw / ${level})`
+    app.style.height = `calc(100dvh / ${level})`
   }
   // 防御性归零页面级滚动：transform 方案下 #app 布局尺寸 = 视口 / z，超出视口
   // 使 body 成为可滚动容器，任何 scrollIntoView/编程滚动都可能把 fixed 面板


### PR DESCRIPTION
改动说明：

前端：
- app 改 100dvw/100dvh 全出血，全局 vh→dvh
- 安全区统一走 --safe-area-inset-*，聊天框/菜单/设置页让位
- 键盘适配：仿 Android 的做法，键盘高度并入安全区变量，UI 自动让位，输入框不被挡
- 旋转后重采样安全区基线（横竖屏 inset 不同）
- 菜单窄屏缩字号防溢出；点击特效画布改按容器测量

后端：

- iOS 数据目录挪到沙盒 Documents，「文件」App 里能直接看到
- 截图插件在 iOS 上不编译 xcap，命令降级为「不支持」

还有加载了ios的打包工作流，调用configure-ios-project.sh / build-ios-unsigned.sh

ps：使用了大量vibe coding，尽量审查和测试了（致歉qwq