### PR TITLE
feat：支持角色收藏跨页置顶

### DIFF
--- a/src-tauri/src/api/character.rs
+++ b/src-tauri/src/api/character.rs
@@ -78,6 +78,43 @@ pub struct CharacterPageResult {
     pub total_pages: i32,
 }
 
+const CHARACTER_FAVORITES_FILE: &str = "favorites.json";
+
+fn character_favorites_path() -> PathBuf {
+    characters_dir().join(CHARACTER_FAVORITES_FILE)
+}
+
+#[tauri::command]
+pub fn get_character_favorites() -> Result<Vec<i32>, String> {
+    let path = character_favorites_path();
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(&path).map_err(|e| format!("读取角色收藏失败: {e}"))?;
+    let mut ids: Vec<i32> =
+        serde_json::from_str(&content).map_err(|e| format!("解析角色收藏失败: {e}"))?;
+    ids.retain(|id| *id > 0);
+    ids.dedup();
+    Ok(ids)
+}
+
+#[tauri::command]
+pub fn save_character_favorites(character_ids: Vec<i32>) -> Result<(), String> {
+    let path = character_favorites_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("创建角色目录失败: {e}"))?;
+    }
+    let mut ids = Vec::with_capacity(character_ids.len());
+    for id in character_ids {
+        if id > 0 && !ids.contains(&id) {
+            ids.push(id);
+        }
+    }
+    let content =
+        serde_json::to_string_pretty(&ids).map_err(|e| format!("序列化角色收藏失败: {e}"))?;
+    fs::write(&path, content).map_err(|e| format!("保存角色收藏失败: {e}"))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct RoleInfoResponse {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -713,6 +713,8 @@ pub fn run() {
             api::font::list_imported_fonts,
             api::font::delete_imported_font,
             api::character::get_character_list,
+            api::character::get_character_favorites,
+            api::character::save_character_favorites,
             api::character::get_role_info,
             api::character::get_role_settings,
             api::character::get_character_file,

--- a/src/api/services/character-favorites.ts
+++ b/src/api/services/character-favorites.ts
@@ -1,0 +1,11 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/** 读取保存在 data/game_data/characters/favorites.json 中的角色收藏。 */
+export const getCharacterFavorites = async (): Promise<number[]> => {
+  return invoke<number[]>("get_character_favorites");
+};
+
+/** 保存角色收藏；文件属于 data/，会随 LAN 同步体系纳入同步范围。 */
+export const saveCharacterFavorites = async (characterIds: number[]): Promise<void> => {
+  await invoke("save_character_favorites", { characterIds });
+};

--- a/src/components/settings/pages/SettingsCharacter.vue
+++ b/src/components/settings/pages/SettingsCharacter.vue
@@ -18,8 +18,9 @@
           :clothes="character.clothes || []"
           :resource-folder="character.resourceFolder"
           :source="character.source"
+          :favored="favoredCharacterIds.includes(character.id)"
           @saved="handleSettingsSaved"
-          @favoredChange="applyCharacterFavoriteOrder"
+          @favoredChange="handleCharacterFavoriteChange"
         />
       </div>
 
@@ -122,6 +123,10 @@
   import { Button } from "../../base";
   import { MenuItem, MenuPage } from "../../ui";
   import { characterGetAll } from "../../../api/services/character";
+  import {
+    getCharacterFavorites,
+    saveCharacterFavorites,
+  } from "../../../api/services/character-favorites";
   import { useRoleImportExport } from "../../../composables/useRoleImportExport";
   import type { ConflictPolicy } from "../../../api/services/role-archive";
   import { useGameStore } from "../../../stores/modules/game";
@@ -147,17 +152,19 @@
   const allCharacters = ref<CharacterCardData[]>([]);
   const currentPage = ref(1);
   const totalPages = ref(1);
-  const CHARACTER_FAVORED_KEY = "lingchat.character.favored.v1";
+  const favoredCharacterIds = ref<number[]>([]);
   const PAGE_SIZE = 6;
   const FETCH_ALL_PAGE_SIZE = 1000;
-  function loadCharFavored(): number[] {
+
+  async function loadCharacterFavorites(): Promise<void> {
     try {
-      const raw = localStorage.getItem(CHARACTER_FAVORED_KEY);
-      return raw ? (JSON.parse(raw) as number[]) : [];
-    } catch {
-      return [];
+      favoredCharacterIds.value = await getCharacterFavorites();
+    } catch (error) {
+      console.error("读取角色收藏失败:", error);
+      favoredCharacterIds.value = [];
     }
   }
+
   function paginate(page: number): void {
     const pages = Math.max(1, Math.ceil(allCharacters.value.length / PAGE_SIZE));
     totalPages.value = pages;
@@ -166,14 +173,30 @@
     characters.value = allCharacters.value.slice(start, start + PAGE_SIZE);
   }
   function applyCharacterFavoriteOrder(): void {
-    const favored = loadCharFavored();
-    const favoredSet = new Set(favored);
-    const favoredCharacters = favored
+    const favoredSet = new Set(favoredCharacterIds.value);
+    const favoredCharacters = favoredCharacterIds.value
       .map((id) => allCharacters.value.find((character) => character.id === id))
       .filter((character): character is CharacterCardData => Boolean(character));
     const others = allCharacters.value.filter((character) => !favoredSet.has(character.id));
     allCharacters.value = [...favoredCharacters, ...others];
     paginate(currentPage.value);
+  }
+
+  async function handleCharacterFavoriteChange(characterId: number): Promise<void> {
+    const previous = favoredCharacterIds.value;
+    const next = previous.includes(characterId)
+      ? previous.filter((id) => id !== characterId)
+      : [...previous, characterId];
+    favoredCharacterIds.value = next;
+    applyCharacterFavoriteOrder();
+
+    try {
+      await saveCharacterFavorites(next);
+    } catch (error) {
+      console.error("保存角色收藏失败:", error);
+      favoredCharacterIds.value = previous;
+      applyCharacterFavoriteOrder();
+    }
   }
   const gameStore = useGameStore();
   const uiStore = useUIStore();
@@ -214,6 +237,7 @@
   };
 
   const loadCharacters = async (): Promise<void> => {
+    await loadCharacterFavorites();
     await fetchCharacters();
   };
 

--- a/src/components/settings/pages/SettingsCharacter.vue
+++ b/src/components/settings/pages/SettingsCharacter.vue
@@ -19,6 +19,7 @@
           :resource-folder="character.resourceFolder"
           :source="character.source"
           @saved="handleSettingsSaved"
+          @favoredChange="applyCharacterFavoriteOrder"
         />
       </div>
 
@@ -143,8 +144,37 @@
   }
 
   const characters = ref<CharacterCardData[]>([]);
+  const allCharacters = ref<CharacterCardData[]>([]);
   const currentPage = ref(1);
   const totalPages = ref(1);
+  const CHARACTER_FAVORED_KEY = "lingchat.character.favored.v1";
+  const PAGE_SIZE = 6;
+  const FETCH_ALL_PAGE_SIZE = 1000;
+  function loadCharFavored(): number[] {
+    try {
+      const raw = localStorage.getItem(CHARACTER_FAVORED_KEY);
+      return raw ? (JSON.parse(raw) as number[]) : [];
+    } catch {
+      return [];
+    }
+  }
+  function paginate(page: number): void {
+    const pages = Math.max(1, Math.ceil(allCharacters.value.length / PAGE_SIZE));
+    totalPages.value = pages;
+    currentPage.value = Math.min(Math.max(page, 1), pages);
+    const start = (currentPage.value - 1) * PAGE_SIZE;
+    characters.value = allCharacters.value.slice(start, start + PAGE_SIZE);
+  }
+  function applyCharacterFavoriteOrder(): void {
+    const favored = loadCharFavored();
+    const favoredSet = new Set(favored);
+    const favoredCharacters = favored
+      .map((id) => allCharacters.value.find((character) => character.id === id))
+      .filter((character): character is CharacterCardData => Boolean(character));
+    const others = allCharacters.value.filter((character) => !favoredSet.has(character.id));
+    allCharacters.value = [...favoredCharacters, ...others];
+    paginate(currentPage.value);
+  }
   const gameStore = useGameStore();
   const uiStore = useUIStore();
   const router = useRouter();
@@ -170,46 +200,25 @@
     };
   };
 
-  const fetchCharacters = async (page: number): Promise<void> => {
+  const fetchCharacters = async (): Promise<void> => {
     try {
-      const result = await characterGetAll(page);
-      totalPages.value = result.total_pages;
-
-      // 防御：删除角色后当前页可能超出 total_pages（例如停在第 2 页删掉最后一个），
-      // 此时分页条 v-if="totalPages > 1" 整条消失，回退按钮不存在 → 空白列表死锁。
-      // 钳制并重取最后一页。
-      if (currentPage.value > result.total_pages && result.total_pages > 0) {
-        currentPage.value = result.total_pages;
-        await fetchCharactersInternal(result.total_pages);
-        return;
-      }
-
-      characters.value = result.items.map(mapCharacter);
+      const result = await characterGetAll(1, FETCH_ALL_PAGE_SIZE);
+      allCharacters.value = result.items.map(mapCharacter);
+      applyCharacterFavoriteOrder();
     } catch (error) {
       console.error("获取角色列表失败:", error);
+      allCharacters.value = [];
       characters.value = [];
-    }
-  };
-
-  // fetchCharacters 的内部调用（钳制回退时用，避免无限递归）
-  const fetchCharactersInternal = async (page: number): Promise<void> => {
-    try {
-      const result = await characterGetAll(page);
-      totalPages.value = result.total_pages;
-      characters.value = result.items.map(mapCharacter);
-    } catch (error) {
-      console.error("获取角色列表失败:", error);
-      characters.value = [];
+      totalPages.value = 1;
     }
   };
 
   const loadCharacters = async (): Promise<void> => {
-    await fetchCharacters(currentPage.value);
+    await fetchCharacters();
   };
 
-  const changePage = async (page: number): Promise<void> => {
-    currentPage.value = page;
-    await fetchCharacters(page);
+  const changePage = (page: number): void => {
+    paginate(page);
   };
 
   const { pickAndImport, rescan } = useRoleImportExport();

--- a/src/components/ui/Menu/CharacterCard.vue
+++ b/src/components/ui/Menu/CharacterCard.vue
@@ -12,15 +12,13 @@
     </div>
     <button
       class="absolute top-2 left-2 z-10 rounded-lg bg-black/5 p-1.5 opacity-0 transition-all
-        group-hover:opacity-100"
+        group-hover:opacity-100 focus-visible:opacity-100"
       @click.stop="handleToggleFavored"
-      :title="isCharFavored(id) ? $t('ui.characterCard.unfav') : $t('ui.characterCard.fav')"
+      :title="favored ? $t('ui.characterCard.unfav') : $t('ui.characterCard.fav')"
     >
       <Star
         :size="16"
-        :class="
-          isCharFavored(id) ? 'fill-amber-400 text-amber-400' : 'text-white/60 hover:text-white'
-        "
+        :class="favored ? 'fill-amber-400 text-amber-400' : 'text-white/60 hover:text-white'"
       />
     </button>
     <div class="absolute top-3 right-3 z-10 flex items-center gap-2">
@@ -263,6 +261,7 @@
     resourceFolder?: string;
     /** 来源："game" 或提供该角色的插件 id。 */
     source?: string | null;
+    favored?: boolean;
   }
 
   const props = withDefaults(defineProps<CharacterProps>(), {
@@ -271,6 +270,7 @@
     info: "",
     clothes: () => [],
     resourceFolder: "",
+    favored: false,
   });
 
   const emit = defineEmits(["saved", "favoredChange"]);
@@ -278,32 +278,8 @@
   // 状态管理
   const isDetailVisible = ref(false);
   const isSettingsModalVisible = ref(false);
-  const CHARACTER_FAVORED_KEY = "lingchat.character.favored.v1";
-  const favoredTick = ref(0);
-  function loadCharFavored(): number[] {
-    try {
-      const raw = localStorage.getItem(CHARACTER_FAVORED_KEY);
-      return raw ? (JSON.parse(raw) as number[]) : [];
-    } catch {
-      return [];
-    }
-  }
-  function isCharFavored(id: number): boolean {
-    void favoredTick.value;
-    return loadCharFavored().includes(id);
-  }
   function handleToggleFavored(): void {
-    let favored = loadCharFavored();
-    favored = favored.includes(props.id)
-      ? favored.filter((id) => id !== props.id)
-      : [...favored, props.id];
-    try {
-      localStorage.setItem(CHARACTER_FAVORED_KEY, JSON.stringify(favored));
-    } catch {
-      // 本地存储不可用时保留当前页面功能。
-    }
-    favoredTick.value++;
-    emit("favoredChange");
+    emit("favoredChange", props.id);
   }
 
   const { t } = useI18n();

--- a/src/components/ui/Menu/CharacterCard.vue
+++ b/src/components/ui/Menu/CharacterCard.vue
@@ -10,6 +10,19 @@
     >
       <Cat :size="20" />
     </div>
+    <button
+      class="absolute top-2 left-2 z-10 rounded-lg bg-black/5 p-1.5 opacity-0 transition-all
+        group-hover:opacity-100"
+      @click.stop="handleToggleFavored"
+      :title="isCharFavored(id) ? $t('ui.characterCard.unfav') : $t('ui.characterCard.fav')"
+    >
+      <Star
+        :size="16"
+        :class="
+          isCharFavored(id) ? 'fill-amber-400 text-amber-400' : 'text-white/60 hover:text-white'
+        "
+      />
+    </button>
     <div class="absolute top-3 right-3 z-10 flex items-center gap-2">
       <RoleExportMenu :role-id="id" :role-name="name" />
       <button
@@ -235,7 +248,7 @@
   import { useGameStore } from "@/stores/modules/game";
   import { applyWebInitData } from "@/stores/modules/game/actions";
   import { useDialogStore } from "@/stores/modules/ui/dialog";
-  import { Settings } from "lucide-vue-next";
+  import { Settings, Star } from "lucide-vue-next";
   import { Cat, Check } from "lucide-vue-next";
   import type { Clothes } from "@/types";
 
@@ -260,11 +273,38 @@
     resourceFolder: "",
   });
 
-  const emit = defineEmits(["saved"]);
+  const emit = defineEmits(["saved", "favoredChange"]);
 
   // 状态管理
   const isDetailVisible = ref(false);
   const isSettingsModalVisible = ref(false);
+  const CHARACTER_FAVORED_KEY = "lingchat.character.favored.v1";
+  const favoredTick = ref(0);
+  function loadCharFavored(): number[] {
+    try {
+      const raw = localStorage.getItem(CHARACTER_FAVORED_KEY);
+      return raw ? (JSON.parse(raw) as number[]) : [];
+    } catch {
+      return [];
+    }
+  }
+  function isCharFavored(id: number): boolean {
+    void favoredTick.value;
+    return loadCharFavored().includes(id);
+  }
+  function handleToggleFavored(): void {
+    let favored = loadCharFavored();
+    favored = favored.includes(props.id)
+      ? favored.filter((id) => id !== props.id)
+      : [...favored, props.id];
+    try {
+      localStorage.setItem(CHARACTER_FAVORED_KEY, JSON.stringify(favored));
+    } catch {
+      // 本地存储不可用时保留当前页面功能。
+    }
+    favoredTick.value++;
+    emit("favoredChange");
+  }
 
   const { t } = useI18n();
   const gameStore = useGameStore();

--- a/src/locales/en/ui.ts
+++ b/src/locales/en/ui.ts
@@ -47,6 +47,8 @@ export default {
     noOutfits: "No outfits available yet",
     confirmSwitch:
       "Switching characters will clear the current character's memory — don't forget to save first if you need it!",
+    fav: "Favorite (move to front)",
+    unfav: "Unfavorite",
   },
   archiveProgress: {
     importing: "Importing",

--- a/src/locales/ja/ui.ts
+++ b/src/locales/ja/ui.ts
@@ -46,6 +46,8 @@ export default {
     noOutfits: "利用可能な衣装はありません",
     confirmSwitch:
       "キャラクターを切り替えると、現在のキャラクターの記憶はクリアされます。必要な場合は忘れずにセーブしてくださいね",
+    fav: "お気に入り（先頭へ移動）",
+    unfav: "お気に入りを解除",
   },
   archiveProgress: {
     importing: "インポート中",

--- a/src/locales/zh-CN/ui.ts
+++ b/src/locales/zh-CN/ui.ts
@@ -45,6 +45,8 @@ export default {
     outfits: "可选服装",
     noOutfits: "暂无可用服装",
     confirmSwitch: "切换角色会导致当前角色记忆清空，有需要的话不要忘记存档哦",
+    fav: "收藏（移到最前）",
+    unfav: "取消收藏",
   },
   archiveProgress: {
     importing: "导入中",

--- a/src/locales/zh-HK/ui.ts
+++ b/src/locales/zh-HK/ui.ts
@@ -46,6 +46,8 @@ export default {
     outfits: "可揀嘅服裝",
     noOutfits: "暫時冇可用嘅服裝",
     confirmSwitch: "轉角色會令而家呢個角色嘅記憶清空，有需要嘅話記住存檔喎",
+    fav: "收藏（移到最前）",
+    unfav: "取消收藏",
   },
   archiveProgress: {
     importing: "匯入緊",


### PR DESCRIPTION
## 改动说明
- 增加角色收藏与取消收藏操作。
- 收藏状态保存在本地，并在完整角色列表中先排序再分页，使收藏角色能够跨页置顶。
- 补充中、英、日界面文案。

## 验证
- Prettier 格式检查通过
- Vue TypeScript 类型检查通过
- Vite 生产构建通过