### PR TITLE
fix: make save line synchronization atomic

### DIFF
--- a/src-tauri/src/db/managers/save_repo.rs
+++ b/src-tauri/src/db/managers/save_repo.rs
@@ -295,12 +295,17 @@ impl SaveRepo {
             // Try ID match first
             if let Some(input_id) = input_line.base.id {
                 if input_id == db_line.id {
-                    // Same ID — update if content changed
+                    // Same ID — update if any persisted field changed
                     if db_line.content != input_line.base.content
                         || db_line.attribute != input_line.base.attribute.0
                         || db_line.sender_role_id != input_line.base.sender_role_id
+                        || db_line.original_emotion != input_line.base.original_emotion
+                        || db_line.predicted_emotion != input_line.base.predicted_emotion
+                        || db_line.tts_content != input_line.base.tts_content
+                        || db_line.audio_file != input_line.base.audio_file
                         || db_line.thinking != input_line.base.thinking
                         || db_line.action_content != input_line.base.action_content
+                        || db_line.display_name != input_line.base.display_name
                         || db_line.tool_call != input_line.base.tool_call
                     {
                         let mut active: line::ActiveModel = db_line.clone().into();
@@ -315,18 +320,24 @@ impl SaveRepo {
                         active.thinking = Set(input_line.base.thinking.clone());
                         active.display_name = Set(input_line.base.display_name.clone());
                         active.tool_call = Set(input_line.base.tool_call.clone());
-                        active.update(db).await.map_err(|e| anyhow!("{e}"))?;
                     }
                     continue;
                 }
             }
 
-            // Try weak match by content + attribute + sender + action_content + tool_call
+            // Try weak match using every persisted field except generated IDs.
             if db_line.content == input_line.base.content
+                && db_line.original_emotion == input_line.base.original_emotion
+                && db_line.predicted_emotion == input_line.base.predicted_emotion
+                && db_line.tts_content == input_line.base.tts_content
                 && db_line.attribute == input_line.base.attribute.0
                 && db_line.sender_role_id == input_line.base.sender_role_id
+                && db_line.audio_file == input_line.base.audio_file
+                && db_line.thinking == input_line.base.thinking
+                && db_line.display_name == input_line.base.display_name
                 && db_line.action_content == input_line.base.action_content
                 && db_line.tool_call == input_line.base.tool_call
+                && db_line.save_id == save_id
             {
                 // Same logical line — no update needed for existing DB row
                 continue;
@@ -337,6 +348,10 @@ impl SaveRepo {
             break;
         }
 
+        // Keep line rows, perceptions, and the save tail pointer consistent if
+        // the process is interrupted or any individual write fails.
+        let txn = db.begin().await.map_err(|e| anyhow!("{e}"))?;
+
         // 3. Delete stale DB lines and their perceptions
         let stale_lines = &db_lines[diverge..];
         if !stale_lines.is_empty() {
@@ -344,15 +359,49 @@ impl SaveRepo {
 
             line_perception::Entity::delete_many()
                 .filter(line_perception::Column::LineId.is_in(stale_ids.clone()))
-                .exec(db)
+                .exec(&txn)
                 .await
                 .map_err(|e| anyhow!("{e}"))?;
 
             line::Entity::delete_many()
                 .filter(line::Column::Id.is_in(stale_ids))
-                .exec(db)
+                .exec(&txn)
                 .await
                 .map_err(|e| anyhow!("{e}"))?;
+        }
+
+        // Updates for matching IDs belong to the same transaction as the
+        // divergence replacement below.
+        for i in 0..diverge {
+            let db_line = &db_lines[i];
+            let input_line = &input_lines[i];
+            if input_line.base.id == Some(db_line.id)
+                && (db_line.content != input_line.base.content
+                    || db_line.attribute != input_line.base.attribute.0
+                    || db_line.sender_role_id != input_line.base.sender_role_id
+                    || db_line.original_emotion != input_line.base.original_emotion
+                    || db_line.predicted_emotion != input_line.base.predicted_emotion
+                    || db_line.tts_content != input_line.base.tts_content
+                    || db_line.audio_file != input_line.base.audio_file
+                    || db_line.thinking != input_line.base.thinking
+                    || db_line.action_content != input_line.base.action_content
+                    || db_line.display_name != input_line.base.display_name
+                    || db_line.tool_call != input_line.base.tool_call)
+            {
+                let mut active: line::ActiveModel = db_line.clone().into();
+                active.content = Set(input_line.base.content.clone());
+                active.attribute = Set(input_line.base.attribute.0.clone());
+                active.sender_role_id = Set(input_line.base.sender_role_id);
+                active.original_emotion = Set(input_line.base.original_emotion.clone());
+                active.predicted_emotion = Set(input_line.base.predicted_emotion.clone());
+                active.tts_content = Set(input_line.base.tts_content.clone());
+                active.action_content = Set(input_line.base.action_content.clone());
+                active.audio_file = Set(input_line.base.audio_file.clone());
+                active.thinking = Set(input_line.base.thinking.clone());
+                active.display_name = Set(input_line.base.display_name.clone());
+                active.tool_call = Set(input_line.base.tool_call.clone());
+                active.update(&txn).await.map_err(|e| anyhow!("{e}"))?;
+            }
         }
 
         // 4. Insert new input lines after divergence point
@@ -383,7 +432,7 @@ impl SaveRepo {
                     ..Default::default()
                 };
 
-                let inserted = new_line.insert(db).await.map_err(|e| anyhow!("{e}"))?;
+                let inserted = new_line.insert(&txn).await.map_err(|e| anyhow!("{e}"))?;
                 let new_id = inserted.id;
 
                 // Insert line_perception rows
@@ -392,7 +441,7 @@ impl SaveRepo {
                         line_id: Set(new_id),
                         role_id: Set(role_id),
                     };
-                    perception.insert(db).await.map_err(|e| anyhow!("{e}"))?;
+                    perception.insert(&txn).await.map_err(|e| anyhow!("{e}"))?;
                 }
 
                 parent_id = Some(new_id);
@@ -409,7 +458,17 @@ impl SaveRepo {
         } else {
             None
         };
-        Self::update_save_last_message(db, save_id, last_id).await?;
+        let save_model = save::Entity::find_by_id(save_id)
+            .one(&txn)
+            .await
+            .map_err(|e| anyhow!("{e}"))?
+            .context("Save not found")?;
+        let mut active: save::ActiveModel = save_model.into();
+        active.last_message_id = Set(last_id);
+        active.update_date = Set(Utc::now().naive_utc());
+        active.update(&txn).await.map_err(|e| anyhow!("{e}"))?;
+
+        txn.commit().await.map_err(|e| anyhow!("{e}"))?;
 
         Ok(())
     }


### PR DESCRIPTION
## 修复说明

修复存档台词同步过程中多步数据库写入不具备原子性的问题，并补齐弱匹配时的持久化字段比较。

## 修复的问题

- [ ] 解决了崩溃问题
- [x] 修复了功能异常
- [ ] 修复了显示问题
- [ ] 修复了性能问题
- [x] 其他

## 相关 Issue

暂无关联 Issue。

## 修复方法

`SaveRepo::sync_lines` 现在将已有台词更新、旧台词及感知关系删除、新台词与感知关系插入、`save.last_message_id` 更新放入同一个 SeaORM transaction 中。任一步失败都会回滚，避免自动存档或回溯时出现历史截断、孤儿关系或尾指针不一致。

同时，弱匹配逻辑现在会比较情绪、TTS、音频、思考链和显示名称等全部持久化字段，避免数据库保留过期元数据。

## 检查清单

- [x] 代码已经本地测试

验证：`pnpm run build` 通过。当前环境未安装 Rust 工具链，未能执行 `cargo check`。

## 截图/示例

不适用。