### PR TITLE
Feat:增加对老处理器兼容支持

### DIFF
--- a/.github/workflows/dev-build-full.yml
+++ b/.github/workflows/dev-build-full.yml
@@ -99,6 +99,8 @@ jobs:
           touch data/.official/game_data/.gitkeep
           touch data/third_party/.gitkeep
           node scripts/prepare-desktop-resources.mjs
+          # 确保 onnxruntime.dll 就位（tauri build 钩子也会执行，这里显式兜底）
+          node scripts/ensure-onnxruntime.mjs
           pip install Pillow
           rm -rf ./src-tauri/icons/icon.png
           python -c "from PIL import Image, ImageDraw; img=Image.new('RGB', (1024,1024), color='#4A90D9'); draw=ImageDraw.Draw(img); draw.ellipse((100,100,924,924), fill='#2C3E50'); img.save('./src-tauri/icons/icon.png')"
@@ -112,9 +114,18 @@ jobs:
             ${{ runner.os == 'macOS' && '' || '' }}
         run: pnpm tauri build --no-bundle
 
+      - name: 收集产物（Windows 附带 onnxruntime.dll）
+        shell: bash
+        run: |
+          mkdir -p "${{ runner.temp }}/dist"
+          cp "${{ matrix.artifact-path }}" "${{ runner.temp }}/dist/"
+          if [ "${{ runner.os }}" = "Windows" ] && [ -f "src-tauri/target/release/onnxruntime.dll" ]; then
+            cp "src-tauri/target/release/onnxruntime.dll" "${{ runner.temp }}/dist/"
+          fi
+
       - name: 上传 artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
-          path: ${{ matrix.artifact-path }}
+          path: ${{ runner.temp }}/dist
           retention-days: 7

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -92,6 +92,8 @@ jobs:
           touch data/.official/game_data/.gitkeep
           touch data/third_party/.gitkeep
           node scripts/prepare-desktop-resources.mjs
+          # 确保 onnxruntime.dll 就位（cargo build 不走 tauri 钩子，需显式调用）
+          node scripts/ensure-onnxruntime.mjs
           pip install Pillow
           rm -rf ./src-tauri/icons/icon.png
           python -c "from PIL import Image, ImageDraw; img=Image.new('RGB', (1024,1024), color='#4A90D9'); draw=ImageDraw.Draw(img); draw.ellipse((100,100,924,924), fill='#2C3E50'); img.save('./src-tauri/icons/icon.png')"

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ ling_chat/static/frontend/
 # src-tauri/gen/schemas/ 为 JSON schema 自动生成文件，可追踪
 src-tauri/bundled_resources/
 src-tauri/.bundled_resources/
+# 外部二进制：onnxruntime.dll 由 scripts/download-onnxruntime.mjs 下载（官方 SSE3 基线，兼容旧 CPU）
+src-tauri/binaries/
 ~/.tauri/
 frontend_vue/
 .tsbuildinfo

--- a/scripts/download-onnxruntime.mjs
+++ b/scripts/download-onnxruntime.mjs
@@ -1,0 +1,103 @@
+// download-onnxruntime.mjs
+//
+// 下载微软官方 onnxruntime Windows x64 动态库，用于解决旧 CPU（无 AVX2，
+// 如三代酷睿）兼容问题：
+//   - pyke 预编译的 onnxruntime 按 x86-64-v3（要求 AVX2/FMA）编译，旧 CPU 上
+//     启动即非法指令崩溃；
+//   - 微软官方包为 SSE3 基线 + MLAS 运行时指令集 dispatch，兼容旧 CPU。
+//
+// 用法:
+//   node scripts/download-onnxruntime.mjs
+//
+// 输出:
+//   src-tauri/binaries/onnxruntime.dll
+//
+// 由开发者/CI 在构建前手动或自动调用。
+// 版本说明：默认 1.27.1，因为 ort 2.0.0-rc.13 编译时默认 api-27（对应 onnxruntime
+// 1.27+），更低的版本（如 1.17.x）会被 ort::init_from 以 BadVersion 拒绝。
+
+import { createWriteStream, existsSync, mkdirSync, readdirSync, renameSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { pipeline } from 'node:stream/promises'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const projectRoot = resolve(__dirname, '..')
+const outDir = join(projectRoot, 'src-tauri', 'binaries')
+const outFile = join(outDir, 'onnxruntime.dll')
+
+// 官方 onnxruntime 版本（win-x64）。必须 ≥1.27 以匹配 ort 2.0.0-rc.13 默认 api-27。
+// 官方 Windows 包为 SSE3 基线 + MLAS 运行时 CPUID dispatch（AVX2 路径受保护），
+// 兼容无 AVX2 的旧 CPU（如三代酷睿）。
+const ORT_VERSION = process.env.ORT_VERSION || '1.27.1'
+const ZIP_URL = `https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-win-x64-${ORT_VERSION}.zip`
+
+// 递归查找文件（官方 zip 内有顶层目录 onnxruntime-win-x64-<ver>/，
+// dll 实际在 <顶层>/lib/onnxruntime.dll，故不能用固定相对路径）
+function findFile(dir, filename) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      const found = findFile(full, filename)
+      if (found) return found
+    } else if (entry === filename) {
+      return full
+    }
+  }
+  return null
+}
+
+async function download(url, dest) {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}`)
+  await pipeline(res.body, createWriteStream(dest))
+}
+
+async function main() {
+  if (existsSync(outFile)) {
+    const size = (await import('node:fs')).statSync(outFile).size
+    console.log(`✅ onnxruntime.dll 已存在: ${outFile} (${(size / 1024 / 1024).toFixed(1)} MB)`)
+    return
+  }
+
+  mkdirSync(outDir, { recursive: true })
+  const tmpZip = join(outDir, `onnxruntime-win-x64-${ORT_VERSION}.zip`)
+
+  console.log(`⬇️  下载 ${ZIP_URL}`)
+  await download(ZIP_URL, tmpZip)
+  console.log('✅ 下载完成，解压 onnxruntime.dll ...')
+
+  // 用系统 unzip（Windows 自带 tar 可解 zip）
+  const { execSync } = await import('node:child_process')
+  const extractDir = join(outDir, `extract-${ORT_VERSION}`)
+  mkdirSync(extractDir, { recursive: true })
+  try {
+    execSync(`tar -xf "${tmpZip}" -C "${extractDir}"`, { stdio: 'inherit' })
+  } catch {
+    // 回退：用 PowerShell Expand-Archive
+    execSync(
+      `powershell -NoProfile -Command "Expand-Archive -Path '${tmpZip}' -DestinationPath '${extractDir}' -Force"`,
+      { stdio: 'inherit' },
+    )
+  }
+
+  // 递归查找解压出的 onnxruntime.dll（兼容顶层目录结构，tar / Expand-Archive 均可）
+  const dll = findFile(extractDir, 'onnxruntime.dll')
+  if (!dll) {
+    throw new Error(`解压后未找到 onnxruntime.dll（${extractDir}），请检查包结构`)
+  }
+  renameSync(dll, outFile)
+
+  // 清理
+  await import('node:fs/promises').then((fs) => fs.rm(extractDir, { recursive: true, force: true }))
+  await import('node:fs/promises').then((fs) => fs.rm(tmpZip, { force: true }))
+
+  const size = (await import('node:fs')).statSync(outFile).size
+  console.log(`✅ onnxruntime.dll 就绪: ${outFile} (${(size / 1024 / 1024).toFixed(1)} MB)`)
+  console.log('   开发运行：请把它复制到 exe 同目录（如 src-tauri/target/debug/onnxruntime.dll）')
+}
+
+main().catch((e) => {
+  console.error('❌ 下载 onnxruntime 失败:', e.message)
+  process.exit(1)
+})

--- a/scripts/ensure-onnxruntime.mjs
+++ b/scripts/ensure-onnxruntime.mjs
@@ -1,0 +1,57 @@
+// ensure-onnxruntime.mjs
+//
+// 幂等确保 onnxruntime.dll 就位（开发/打包零操作）。
+// 由 tauri.conf.json 的 beforeDevCommand / beforeBuildCommand 自动调用：
+//   - dll 缺失时才下载（有则跳过，不重复下载）
+//   - 复制到 target/debug、target/release（exe 同目录，供 ort::init_from 加载）
+//
+// 用法:
+//   node scripts/ensure-onnxruntime.mjs
+//
+// 输出:
+//   src-tauri/binaries/onnxruntime.dll （必要时下载）
+//   src-tauri/target/{debug,release}/onnxruntime.dll （复制）
+
+import { execSync } from "node:child_process";
+import { copyFileSync, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, "..");
+const srcTauri = join(projectRoot, "src-tauri");
+const dll = join(srcTauri, "binaries", "onnxruntime.dll");
+const downloadScript = join(projectRoot, "scripts", "download-onnxruntime.mjs");
+
+// 需要 dll 的输出目录（存在才复制；tauri dev/build 的默认输出）
+const TARGET_DIRS = [join(srcTauri, "target", "debug"), join(srcTauri, "target", "release")];
+
+// 仅 Windows 需要 onnxruntime.dll（load-dynamic 只作用于 Windows target；
+// Linux/macOS 保持 download-binaries 静态链接，无需 dll）。
+// 否则 Linux/macOS 的 CI（beforeBuildCommand 触发本脚本）会白下载 59MB Windows dll。
+if (process.platform !== "win32") {
+  console.log("[onnx] 非 Windows 平台，跳过（load-dynamic 仅限 Windows）");
+  process.exit(0);
+}
+
+// 1. 确保 binaries/onnxruntime.dll 存在（缺失才下载，幂等）
+if (!existsSync(dll)) {
+  console.log("[onnx] onnxruntime.dll 缺失，开始下载（scripts/download-onnxruntime.mjs）...");
+  execSync(`node "${downloadScript}"`, { stdio: "inherit" });
+} else {
+  console.log(`[onnx] onnxruntime.dll 已存在: ${dll}`);
+}
+
+// 2. 复制到各输出目录（幂等：直接覆盖为当前版本）
+let copied = false;
+for (const dir of TARGET_DIRS) {
+  if (existsSync(dir)) {
+    const dest = join(dir, "onnxruntime.dll");
+    copyFileSync(dll, dest);
+    console.log(`[onnx] 已复制到 ${dest}`);
+    copied = true;
+  }
+}
+if (!copied) {
+  console.log("[onnx] 未找到 target/{debug,release} 目录，跳过复制（构建时将由 tauri 打包 resources 处理）");
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5484,6 +5484,7 @@ version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
 dependencies = [
+ "libloading 0.9.0",
  "ndarray",
  "ort-sys",
  "smallvec",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -79,10 +79,13 @@ async-trait = "0.1"
 # 实时 ASR 用官方 /api-ws/v1/inference 端点（标准 GET 升级 + Bearer）；
 # rustls-tls-webpki-roots 与项目 reqwest 的 TLS 栈一致
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
+# ort（ONNX Runtime）：Windows 用 load-dynamic 运行时加载，避免静态链接 pyke 预编译的
+# x86-64-v3（要求 AVX2/FMA）二进制——旧 CPU（如三代酷睿，无 AVX2）上启动会因非法指令崩溃。
+# 改为运行时从应用目录加载官方 onnxruntime.dll（SSE3 基线，兼容旧 CPU）。
+# 注意：load-dynamic 仅限 Windows（见下方 target 配置）；Linux/macOS 保持 download-binaries 静态链接，行为不变。
 ort = { version = "=2.0.0-rc.13", default-features = false, features = [
     "std",
     "ndarray",
-    "download-binaries",
 ] }
 ndarray = "0.17"
 
@@ -133,6 +136,7 @@ tauri-plugin-process = "2"
 [target.'cfg(target_os = "windows")'.dependencies]
 ort = { version = "=2.0.0-rc.13", default-features = false, features = [
     "directml",
+    "load-dynamic",
 ] }
 sbv2_core = { git = "https://gh-proxy.org/github.com/shadow01a/sbv2-api/", default-features = false, features = [
     "directml",
@@ -154,16 +158,22 @@ wgpu = "26"
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
 ort = { version = "=2.0.0-rc.13", default-features = false, features = [
     "webgpu",
+    "download-binaries",
 ] }
 sbv2_core = { git = "https://gh-proxy.org/github.com/shadow01a/sbv2-api/", default-features = false, features = [
     "webgpu",
 ] }
 ash = { version = "0.38", default-features = false, features = ["loaded"] }
 
+[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
+# 与 x86_64 不同：aarch64 无 AVX2 问题，直接静态链接官方/预编译二进制即可
+ort = { version = "=2.0.0-rc.13", default-features = false, features = ["download-binaries"] }
+
 
 [target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
 ort = { version = "=2.0.0-rc.13", default-features = false, features = [
     "coreml",
+    "download-binaries",
 ] }
 sbv2_core = { git = "https://gh-proxy.org/github.com/shadow01a/sbv2-api/", default-features = false, features = [
     "coreml",

--- a/src-tauri/src/ai_service/asr/vad.rs
+++ b/src-tauri/src/ai_service/asr/vad.rs
@@ -70,6 +70,13 @@ impl AsrVad {
     /// 从 bundled 路径加载 Silero VAD 模型。
     /// 失败时返回 Err，由调用方决定是否降级为手动模式。
     pub fn load(app: &AppHandle) -> Result<Self, AsrError> {
+        // ONNX Runtime 不可用（onnxruntime.dll 缺失）时直接降级，绝不创建 Session
+        // （ort 在 dll 缺失时首次创建 Session 会 panic，导致应用崩溃）。
+        if !crate::utils::onnx::onnx_available() {
+            return Err(AsrError::EngineLoadFailed(
+                "ONNX Runtime 不可用（onnxruntime.dll 缺失），VAD 降级".into(),
+            ));
+        }
         let model_path = resolve_vad_model_path(app)?;
         tracing::info!("[ASR/VAD] loading model from {}", model_path.display());
         let session = Session::builder()

--- a/src-tauri/src/ai_service/emotion/classifier.rs
+++ b/src-tauri/src/ai_service/emotion/classifier.rs
@@ -76,6 +76,11 @@ impl EmotionClassifier {
 
     /// 从 `model_dir` 加载模型（目录内需有 `model.onnx`、`vocab.txt`、`label_mapping.json`）。
     pub fn load<P: AsRef<Path>>(model_dir: P) -> Result<Self> {
+        // ONNX Runtime 不可用（onnxruntime.dll 缺失）时直接降级，绝不创建 Session
+        // （ort 在 dll 缺失时首次创建 Session 会 panic，导致应用崩溃）。
+        if !crate::utils::onnx::onnx_available() {
+            return Err(anyhow!("ONNX Runtime 不可用（onnxruntime.dll 缺失），情绪分类器禁用"));
+        }
         let dir: PathBuf = model_dir.as_ref().to_path_buf();
         let onnx_path = dir.join("model.onnx");
         let vocab_path = dir.join("vocab.txt");

--- a/src-tauri/src/ai_service/tts/local/engine.rs
+++ b/src-tauri/src/ai_service/tts/local/engine.rs
@@ -75,6 +75,11 @@ impl LocalTtsEngine {
 
     /// Initialize the holder from on-disk DeBerta + tokenizer bytes.
     pub async fn init(&self, paths: &LocalTtsPaths) -> std::result::Result<(), String> {
+        // ONNX Runtime 不可用（onnxruntime.dll 缺失）时直接降级，绝不创建 Session
+        // （ort 在 dll 缺失时首次创建 Session 会 panic，导致应用崩溃）。
+        if !crate::utils::onnx::onnx_available() {
+            return Err("ONNX Runtime 不可用（onnxruntime.dll 缺失），本地 TTS 停用".into());
+        }
         // 与 unload_all/load_voice/synthesize 保持一致，整个 init 过程串行化，
         // 避免与 unload_all 并发导致关闭后引擎被复活、或被 synthesize 放回的旧 holder 覆盖。
         let _serialize_guard = self.serialize.lock().await;
@@ -107,6 +112,11 @@ impl LocalTtsEngine {
         paths: &LocalTtsPaths,
         voice_id: &str,
     ) -> std::result::Result<(), String> {
+        // ONNX Runtime 不可用（onnxruntime.dll 缺失）时直接降级，绝不创建 Session
+        // （ort 在 dll 缺失时首次创建 Session 会 panic，导致应用崩溃）。
+        if !crate::utils::onnx::onnx_available() {
+            return Err("ONNX Runtime 不可用（onnxruntime.dll 缺失），本地 TTS 停用".into());
+        }
         let sbv2 = paths.voice_dir(voice_id).join("model.sbv2");
         let onnx = paths.voice_dir(voice_id).join("model.onnx");
         let (model_bytes, style_vectors) = if sbv2.exists() {

--- a/src-tauri/src/init/mod.rs
+++ b/src-tauri/src/init/mod.rs
@@ -216,7 +216,14 @@ pub async fn init_asr(
         },
     }
 
-    let vad = AsrVad::load(app)?;
+    let vad = match AsrVad::load(app) {
+        Ok(vad) => vad,
+        Err(e) => {
+            // dll 缺失/加载失败：降级（ASR 不可用），绝不让启动失败
+            tracing::warn!("[ASR] VAD 加载失败，ASR 本次启动降级为不可用: {e}");
+            return Ok(());
+        }
+    };
     // 应用持久化的 VAD 静音计时（设置页可自定义，默认 800ms）
     vad.set_silence_timeout_ms(cfg.vad_silence_ms).await;
     let session = Arc::new(AsrSession::new(Arc::new(vad), providers));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -299,6 +299,13 @@ pub fn run() {
             // 将其传递给独立的本地 TTS crate。
             init::static_copy::init_data_dir(&app.handle());
 
+            // ONNX Runtime：定位 onnxruntime.dll 并显式加载
+            // （仅 Windows 的 load-dynamic 模式，兼容无 AVX2 的旧 CPU，如三代酷睿；
+            //  非 Windows 走 download-binaries 静态链接，无需此调用）。
+            // 必须在任何 ort::Session 创建之前调用。
+            #[cfg(target_os = "windows")]
+            utils::onnx::init_onnx_runtime(app.handle());
+
             // 管理各种状态
             app.manage(api::pet::HitTestState::default());
             app.manage(resource_sync::ResourceSyncState::default());

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -7,6 +7,7 @@ pub mod fs;
 pub mod gpu_perf;
 pub mod llm_request_logger;
 pub mod log_bridge;
+pub mod onnx;
 pub mod path;
 pub mod prompt;
 pub mod proxy;

--- a/src-tauri/src/utils/onnx.rs
+++ b/src-tauri/src/utils/onnx.rs
@@ -1,0 +1,124 @@
+//! ONNX Runtime 运行时初始化（解决旧 CPU 兼容性，issue：三代酷睿无法运行）
+//!
+//! 背景：`ort` 默认 `download-binaries` 会静态链接 pyke.io 预编译的 onnxruntime，
+//! 其 x86-64 二进制按 **x86-64-v3（要求 AVX2/FMA）** 编译。三代酷睿（Ivy Bridge，
+//! 2012）只有 AVX、无 AVX2 → 静态链接进 exe 后启动即执行 AVX2 指令 → 非法指令崩溃。
+//!
+//! 方案：**仅 Windows** 的 `ort` 启用 `load-dynamic`（见 Cargo.toml），运行时通过
+//! `ort::init_from` 从应用目录加载**微软官方 onnxruntime.dll**（SSE3 基线，
+//! 兼容旧 CPU）。本模块在 setup 早期定位 dll 路径并显式加载；找不到 dll 时
+//! 返回 false（上层功能据此降级）。
+//!
+//! 注意：`ort::init_from` 只在 `load-dynamic` feature 下存在，因此本模块整体
+//! 限定 `#[cfg(target_os = "windows")]`。非 Windows 平台保持 `download-binaries`
+//! 静态链接，无需运行时加载。
+
+#[cfg(target_os = "windows")]
+use std::path::PathBuf;
+
+#[cfg(target_os = "windows")]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(target_os = "windows")]
+use tauri::{AppHandle, Manager};
+
+/// ONNX Runtime 是否可用。
+/// Windows（load-dynamic）：取决于 onnxruntime.dll 是否加载成功；
+/// 非 Windows（download-binaries 静态链接）：恒可用。
+///
+/// ⚠️ 必须在任何 `ort::Session` 创建**之前**检查：若 dll 缺失而直接创建
+/// Session，ort 的 `setup_api()` 会因加载失败而 panic（`.expect`），
+/// 导致整个应用崩溃。各 onnx 使用点（情绪分类/VAD/本地 TTS）应据此降级。
+pub fn onnx_available() -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        ONNX_AVAILABLE.load(Ordering::Relaxed)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        true
+    }
+}
+
+#[cfg(target_os = "windows")]
+static ONNX_AVAILABLE: AtomicBool = AtomicBool::new(false);
+
+/// 定位 onnxruntime.dll 并用 `ort::init_from` 显式加载。
+///
+/// 探测顺序：
+/// 1. exe 同目录（开发/便携：`target/debug/onnxruntime.dll` 或 exe 旁）
+/// 2. tauri 资源目录（打包：`resources/onnxruntime.dll`）
+///
+/// 返回 true 表示 dll 已就绪；false 表示未找到或加载失败（调用方应降级 onnx 功能）。
+///
+/// 仅 Windows（`load-dynamic` 限定 Windows target；`ort::init_from` 依赖该 feature）。
+#[cfg(target_os = "windows")]
+pub fn init_onnx_runtime(app: &AppHandle) -> bool {
+    let candidates: Vec<PathBuf> = {
+        let mut v = Vec::new();
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(dir) = exe.parent() {
+                v.push(dir.join("onnxruntime.dll"));
+            }
+        }
+        if let Ok(res) = app.path().resource_dir() {
+            v.push(res.join("onnxruntime.dll"));
+        }
+        v
+    };
+
+    // 找第一个存在的候选（exe 同目录 → resource_dir）。
+    // ⚠️ `ort::init_from` 只能调用一次：加载失败后 ort 内部 `load_dynamic::init`
+    //    的 `G_ORT_LIB` inserter 已被消费，再次调用会走 `unwrap_unchecked` UB，
+    //    实测导致 0xC0000409 崩溃（损坏/空 dll 文件场景）。因此无论成败，
+    //    都只尝试加载第一个存在的文件，绝不循环重试。
+    let Some(path) = candidates.iter().find(|p| p.exists()) else {
+        tracing::warn!(
+            "[ONNX] 未找到 onnxruntime.dll（已尝试: {:?}）。ONNX 相关功能将降级。",
+            candidates
+        );
+        return false;
+    };
+
+    match ort::init_from(path.as_path()) {
+        Ok(_) => {
+            tracing::info!("[ONNX] onnxruntime.dll 就绪: {}", path.display());
+            ONNX_AVAILABLE.store(true, Ordering::Relaxed);
+            // CPU 兼容提示：官方 dll 为 SSE3 基线，但若检测不到 AVX2 仅提示（不影响运行）
+            #[cfg(target_arch = "x86_64")]
+            if !std::arch::is_x86_feature_detected!("avx2") {
+                tracing::info!(
+                    "[ONNX] 当前 CPU 不支持 AVX2，使用官方 onnxruntime（SSE3 基线）可正常推理"
+                );
+            }
+            true
+        }
+        Err(e) => {
+            tracing::warn!(
+                "[ONNX] 加载 {} 失败: {e}。ONNX 相关功能将降级。",
+                path.display()
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(target_os = "windows")]
+mod tests {
+    /// 运行时验证：`ort::init_from` 能否加载官方 onnxruntime.dll 并创建 SessionBuilder。
+    /// 需要先运行 `node scripts/download-onnxruntime.mjs` 生成 dll。
+    #[test]
+    #[ignore = "需要已下载的 onnxruntime.dll（scripts/download-onnxruntime.mjs）"]
+    fn load_official_onnxruntime() {
+        let dll = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("binaries")
+            .join("onnxruntime.dll");
+        assert!(dll.exists(), "onnxruntime.dll 不存在: {}", dll.display());
+
+        let _env = ort::init_from(&dll).expect("ort::init_from 加载失败");
+        // API 兼容性验证：能构建 SessionBuilder 说明 ort api 版本匹配
+        let _builder = ort::session::Session::builder().expect("SessionBuilder 创建失败");
+    }
+}
+

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.5.1",
   "identifier": "com.noiq.ling-chat",
   "build": {
-    "beforeDevCommand": "pnpm dev",
+    "beforeDevCommand": "node scripts/ensure-onnxruntime.mjs && pnpm dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "node scripts/prepare-desktop-resources.mjs && pnpm build",
+    "beforeBuildCommand": "node scripts/ensure-onnxruntime.mjs && node scripts/prepare-desktop-resources.mjs && pnpm build",
     "frontendDist": "../dist"
   },
   "app": {

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,7 @@
+{
+  "bundle": {
+    "resources": {
+      "binaries/onnxruntime.dll": "onnxruntime.dll"
+    }
+  }
+}


### PR DESCRIPTION
# PR 描述：支持无 AVX2 的旧 CPU（三代酷睿等）—— onnxruntime 动态加载官方 DLL

> Closes #761

---

## 背景

三代酷睿（Ivy Bridge，2012）等**无 AVX2** 的 CPU 上，应用**启动即闪退**（0xC000001D Illegal Instruction）。

**根因**：`ort` crate 默认 `download-binaries` 静态链接 pyke.io 预编译的 onnxruntime，其 x86-64 二进制按 **x86-64-v3**（要求 AVX2/FMA3）编译；AVX2 指令被静态链接进 exe，启动即崩溃，无降级机会。

**方案**：Windows 改用 `load-dynamic` + 微软官方 `onnxruntime.dll`（SSE3 基线 + MLAS 运行时 CPUID dispatch），旧 CPU 自动走低指令集路径，无需自编译。**仅 Windows**；Linux/macOS 保持 `download-binaries` 静态链接，行为不变。

## 改动清单

| 文件 | 改动 |
|---|---|
| `src-tauri/Cargo.toml` | `ort` 按平台隔离：Windows `load-dynamic`；Linux x86_64 / macOS aarch64 / Linux aarch64 保持 `download-binaries` |
| `src-tauri/src/utils/onnx.rs` | **新增**：`init_onnx_runtime()`（exe 同目录 → 资源目录探测 → `ort::init_from` → 降级），维护全局 `onnx_available()`；含 `#[ignore]` 运行时验证测试 |
| `src-tauri/src/lib.rs` | setup 早期调用 `utils::onnx::init_onnx_runtime()`（限 Windows） |
| `src-tauri/src/utils/mod.rs` | 注册 `pub mod onnx` |
| `src-tauri/tauri.windows.conf.json` | **新增**（Windows 专属）：resources 打包 `onnxruntime.dll` |
| `scripts/download-onnxruntime.mjs` | **新增**：下载官方 1.27.1（`ORT_VERSION` 可切换），递归解出 dll |
| `scripts/ensure-onnxruntime.mjs` | **新增**：幂等确保 dll，挂 `beforeDevCommand`/`beforeBuildCommand`，仅 Windows |
| `src-tauri/src/ai_service/emotion/classifier.rs` | `load()` 前检查 `onnx_available()`，降级为禁用 |
| `src-tauri/src/ai_service/asr/vad.rs` | `load()` 前检查，降级返回 Err |
| `src-tauri/src/ai_service/tts/local/engine.rs` | `init()`/`load_voice()` 前检查，本地 TTS 停用 |
| `src-tauri/src/init/mod.rs` | VAD 加载失败降级，启动不受影响 |
| `.github/workflows/dev-build.yml` | 显式 ensure（裸 `cargo build` 不走 tauri 钩子） |
| `.github/workflows/dev-build-full.yml` | ensure 兜底 + Windows 产物附带 dll |
| `.gitignore` | 忽略 `src-tauri/binaries/` |

## 关键点

- **版本匹配**：ort `2.0.0-rc.13` 默认 `api-27`，官方 dll 必须 ≥ 1.27（默认 1.27.1）。
- **降级健壮性**：所有 onnx 使用点（情绪/VAD/本地 TTS）创建 Session 前检查 `onnx_available()`，dll 缺失/损坏时优雅降级、不崩溃；`ort::init_from` 只调用一次（避免重调 UB）。
- **开发者零操作**：`pnpm tauri dev/build` 钩子自动确保 dll 就位。

## 已验证

- ✅ `cargo check` 通过；运行时测试成功加载官方 1.27.1 并建 Session
- ✅ 4 平台 CI 全绿（`dev-build` + `dev-build-full`），Windows 产物确凿含 `onnxruntime.dll`
- ✅ **旧 CPU 实机验证**：无 AVX2 的三代酷睿运行打包 exe，正常启动，情绪/VAD/本地 TTS 正常工作
- ✅ **dll 缺失 / 损坏降级实测**：进程存活不崩溃（含修复 `0xC0000409` UB）
- ✅ 正式版打包验证：exe + NSIS 安装包正常生成、含 dll

## 兼容性 / 风险

- 范围**仅 Windows**；Linux/macOS 行为与改动前完全一致。
- 安装包 +~15MB（NSIS 压缩后更小）。
- 旧 CPU 无 AVX2 时推理走 SSE 内核，速度略慢（可接受）。

## 依旧实机图
<img width="1088" height="720" alt="老u1" src="https://github.com/user-attachments/assets/a45445fc-927b-4f51-9bde-b7d409407a26" />
<img width="1088" height="720" alt="老u2" src="https://github.com/user-attachments/assets/d82e9a33-f31d-44e4-bd54-db1b861f6610" />
<img width="1433" height="832" alt="老u3" src="https://github.com/user-attachments/assets/df6fbf66-37da-461c-8082-42527b094318" />
