### PR TITLE
Fix:修复打包发行版 Linux 产物缺失

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           - platform: macos
             os: macos-latest
             target: ""
-          - platform: linux-arm64
+          - platform: linux-amd64
             os: ubuntu-latest
             target: ""
           - platform: linux-aarch64
@@ -118,7 +118,9 @@ jobs:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/dev' }}
 
+      # 其它平台：tauri-action 直接构建
       - name: 构建 Tauri 应用
+        if: matrix.platform != 'linux-amd64'
         uses: tauri-apps/tauri-action@v1
         continue-on-error: true
         env:
@@ -130,9 +132,43 @@ jobs:
             ${{ runner.os == 'Windows' && '-C linker=rust-lld' || '' }}
             ${{ runner.os == 'macOS' && '' || '' }}
         with:
-          uploadWorkflowArtifacts: true
-          workflowArtifactNamePattern: "${{ matrix.platform }}-build"
+          # 不用 tauri-action 内置的 uploadWorkflowArtifacts：
+          # 它会对每个 bundle 循环 create artifact，若名字不含 [bundle] 会重复 create 同名 → 409，
+          # 导致后续产物（AppImage / .sig 等）丢失。改由下方独立 step 一次性上传整个 bundle 目录。
           args: ${{ matrix.target }}
+
+      # linux-amd64 特例：ort `webgpu` feature 链接 libwebgpu_dawn.so（Dawn dylib，无法静态链接）。
+      # 该库随 ort download-binaries 下载，cargo build 后由 ort `copy-dylibs` symlink 到 target/release。
+      # linuxdeploy 打包 AppImage 时必须在库路径解析到它，否则报 `Could not find dependency: libwebgpu_dawn.so`。
+      # 这里先 cargo build，把 dawn.so 复制到系统库路径，再 tauri build（增量）让 linuxdeploy 找到它。
+      - name: 构建 Tauri 应用（linux-amd64：放置 libwebgpu_dawn.so）
+        if: matrix.platform == 'linux-amd64'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          cd src-tauri
+          cargo build --release
+          DAWN=$(find target/release -name "libwebgpu_dawn.so" 2>/dev/null | head -1)
+          if [ -z "$DAWN" ]; then
+            echo "!! 未找到 libwebgpu_dawn.so（检查 ort webgpu feature）"
+          else
+            sudo cp -L "$DAWN" /usr/lib/x86_64-linux-gnu/libwebgpu_dawn.so
+            sudo ldconfig
+            echo "已放置 /usr/lib/x86_64-linux-gnu/libwebgpu_dawn.so"
+          fi
+          cd ..
+          pnpm tauri build
+
+      - name: 上传构建产物（bundle 全量）
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform }}-build
+          path: src-tauri/target/release/bundle/**
+          if-no-files-found: warn
 
   release:
     needs: [generate-data, build]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8645,9 +8645,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-notification"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+checksum = "ad2fd40946aef810c4be9fd33a2d1b9b397cb79042b2d21c81a0a8f204354fd1"
 dependencies = [
  "log",
  "notify-rust",


### PR DESCRIPTION
# PR 描述：修复打包发行版 Linux 产物缺失（x86_64 无包、aarch64 丢 AppImage）
## 背景

- v0.5.0 / v0.5.0fix1 / v0.5.1 的 Release **一直缺少 x86_64 Linux 安装包**（.deb / .AppImage 均无），aarch64 也只有 deb、缺 AppImage。
- run 页面长期显示 Success（被 `continue-on-error` 掩盖），直到排查 artifact 才暴露。

## 修复内容（两笔提交）

- `9dcdb5f1` ci(release): release.yml 三项修复（见下）
- `22273713` chore: Cargo.lock 同步 tauri-plugin-notification 2.4.0（修复 CLI 版本检查，见下第 4 节）

### 1. matrix 平台名错误
`release.yml` 中 x86_64 job 的 platform 名为 `linux-arm64`，却跑在 `ubuntu-latest`（x86_64）上 → 改名 `linux-amd64`（否则产物命名/排查都被误导）。

### 2. aarch64 等平台 artifact 上传 409（AppImage/.sig 丢失）
tauri-action `uploadWorkflowArtifacts` 会对**每个 bundle 循环 create 独立 artifact**，而 `workflowArtifactNamePattern: "${{ matrix.platform }}-build"` 不含 `[bundle]` → 同一 job 内 deb/sig/AppImage 全部同名 → 第 2 个产物 create 同名被 GitHub **409** 拒绝，后续产物丢失（release 只有 deb、缺 AppImage/.sig）。

**修复**：关闭 `uploadWorkflowArtifacts`，改用独立 `actions/upload-artifact@v4` 一次性上传 `src-tauri/target/release/bundle/**` 到 `{platform}-build`：
- 同 job 只 create 一次，无 409，deb/AppImage/sig 全量保留
- `if: always()`：即使 updater 签名失败（无密钥），已生成产物也上传

### 3. x86_64 AppImage 打包失败（真正根因：缺 `libwebgpu_dawn.so`）
`--verbose` 日志显示 linuxdeploy 部署依赖时 `Could not find dependency: libwebgpu_dawn.so`。

- Linux x86_64 的 ort 启用 `webgpu` feature（WebGPU EP），其 Dawn 后端**无法静态链接**（ort-sys 注释原文），`ling_chat` 硬链接 dylib `libwebgpu_dawn.so`。
- 该库随 ort `download-binaries` 分发、开发期由 `copy-dylibs` symlink 到 `target/release`，但**生产打包需自行提供**（ort 文档明示）。
- 上游未处理 → linuxdeploy 找不到 → AppImage 失败 → 整个 `tauri build` exit 1 → 连已生成的 deb 都不上传。

**修复**：`linux-amd64` job 走专用构建步骤：
1. `cargo build --release`（触发 ort `copy-dylibs` 生成 dawn.so）
2. 复制 `libwebgpu_dawn.so` 到 `/usr/lib/x86_64-linux-gnu/` + `ldconfig`
3. `pnpm tauri build`（增量）→ linuxdeploy 可解析 dawn.so → AppImage 打包成功

> 其它平台不受影响（aarch64 无 webgpu、macOS coreml、Windows directml）。

### 4. Cargo.lock 与 npm 版本同步（tauri-plugin-notification 2.4.0）

上游 dev 的 `@tauri-apps/plugin-notification`（npm）已升到 2.4.0，但 `src-tauri/Cargo.lock` 仍锁 `tauri-plugin-notification` 2.3.3 → tauri CLI 启动时的**版本一致性预检**直接失败，**所有平台**的 `tauri build` 都会在几百毫秒内退出（阻塞一切 CI/发版）。

**修复**：`cargo update` 将 `tauri-plugin-notification` 对齐到 2.4.0（仅改 Cargo.lock 的 version + checksum，无依赖树变化）。

## 已验证（fork 实测通过）

- ✅ `linux-amd64-build`：deb + **AppImage**（x86_64 AppImage 首次成功）
- ✅ `linux-aarch64-build`：deb + **AppImage** 全量（409 修复，体积从 189MB → ~1GB）
- ✅ windows / macos 产物正常
- ⚠️ fork 无 `TAURI_SIGNING_PRIVATE_KEY`，updater 签名阶段失败属预期（产物已先上传）；上游用真实密钥可完整产出 `.sig` / `latest.json`

## 遗留事项（建议后续处理）

1. **deb 运行时 dawn 依赖**：x86_64 deb 安装后若用 WebGPU 推理，需系统有 `libwebgpu_dawn.so`（可后续通过 deb `files` 配置装入 `/usr/lib`）。
2. ~~上游 dev 的 `Cargo.lock` 未同步~~（已在本 PR 修复，见上第 4 节）
