### PR TITLE
fix: 存档历史对话被抹除（issue #796）——会话代号守卫 + 存档同步安全网 + 切换清事件队列

### DIFF
--- a/src-tauri/src/ai_service/message_system/generator.rs
+++ b/src-tauri/src/ai_service/message_system/generator.rs
@@ -691,6 +691,16 @@ pub(crate) async fn consume_sentence(
     // 4. 写入 GameStatus
     add_assistant_line(deps, &response).await?;
 
+    // 会话代号复核（与 add_assistant_line 内守卫一致）：若本句写入已被丢弃，
+    // 说明读档/切角色/清对话已切换会话（旧流式任务游离），前端也已切到新会话——
+    // 这里返回 None，不再把这条过期回复发布给前端（防旧角色台词串进新对话展示）。
+    {
+        let gs = deps.game_status.lock().await;
+        if gs.preview_generation != deps.generation {
+            return Ok(None);
+        }
+    }
+
     Ok(Some(response))
 }
 

--- a/src-tauri/src/ai_service/service.rs
+++ b/src-tauri/src/ai_service/service.rs
@@ -181,6 +181,11 @@ impl AIService {
         gs.onstage_role_ids.clear();
         gs.present_role_ids.clear();
         gs.player_entered = false;
+        // 会话边界代号：切换角色 / 读档 / 清空对话都会清空 GameStatus 并重建，
+        // 旧一轮自由对话的流式任务（consumer/publisher）可能仍在游离生成。
+        // 递增代号后，它们的迟到 `add_assistant_line` / 工具回填会因
+        // `preview_generation != 捕获代号` 被丢弃，避免 A 的台词串进 B 的 line_list。
+        gs.preview_generation = gs.preview_generation.wrapping_add(1);
     }
 
     pub async fn set_active_save_id(&mut self, save_id: Option<i32>) {

--- a/src-tauri/src/db/managers/save_repo.rs
+++ b/src-tauri/src/db/managers/save_repo.rs
@@ -348,6 +348,18 @@ impl SaveRepo {
             break;
         }
 
+        // 安全网：输入与 DB 链在首行即分歧（diverge=0）且双方都非空时，
+        // 说明输入不是"同一段对话的演进"（正常续写/回溯/语音回填首行都会匹配），
+        // 而是把另一段对话（如跨角色残留、错位回溯）误当成当前存档内容——
+        // 若继续会让下面 diverge.. 删除把整个存档历史抹空。拒绝覆盖以保护存档。
+        if diverge == 0 && !db_lines.is_empty() && !input_lines.is_empty() {
+            return Err(anyhow!(
+                "sync_lines 安全保护：输入与存档无共同锚点，拒绝全量覆盖（save_id={save_id}，db_lines={}，input_lines={}）",
+                db_lines.len(),
+                input_lines.len()
+            ));
+        }
+
         // Keep line rows, perceptions, and the save tail pointer consistent if
         // the process is interrupted or any individual write fails.
         let txn = db.begin().await.map_err(|e| anyhow!("{e}"))?;

--- a/src/components/settings/pages/SettingsSave.vue
+++ b/src/components/settings/pages/SettingsSave.vue
@@ -185,6 +185,7 @@
   import { Input } from "../../base";
   import { useGameStore } from "../../../stores/modules/game";
   import { applyWebInitData } from "../../../stores/modules/game/actions";
+  import { eventQueue } from "../../../core/events/event-queue";
   import { useUIStore } from "../../../stores/modules/ui/ui";
   import { useDialogStore } from "../../../stores/modules/ui/dialog";
   import { invoke, convertFileSrc } from "@tauri-apps/api/core";
@@ -334,6 +335,9 @@
     try {
       const gameInfo = await invoke<WebInitData>("load_save", { saveId });
       applyWebInitData(gameStore.$state, gameInfo);
+      // 读档后丢弃旧会话残留事件队列（防止旧角色未说完的回复串进新存档对话，issue #796）
+      eventQueue.clear();
+      eventQueue.resume();
       uiStore.showSuccess({
         title: t("settings.save.msg.loadSuccessTitle"),
         message: t("settings.save.msg.loadSuccessMsg"),

--- a/src/components/ui/Menu/CharacterCard.vue
+++ b/src/components/ui/Menu/CharacterCard.vue
@@ -237,6 +237,7 @@
   } from "@/api/services/character";
   import { useGameStore } from "@/stores/modules/game";
   import { applyWebInitData } from "@/stores/modules/game/actions";
+  import { eventQueue } from "@/core/events/event-queue";
   import { useDialogStore } from "@/stores/modules/ui/dialog";
   import { Settings } from "lucide-vue-next";
   import { Cat, Check } from "lucide-vue-next";
@@ -288,6 +289,9 @@
     try {
       const data = await selectCharacterApi(props.id);
       applyWebInitData(gameStore.$state, data);
+      // 切换角色后丢弃旧角色残留事件队列（防止未说完的回复串进新角色对话，issue #796）
+      eventQueue.clear();
+      eventQueue.resume();
     } catch (error) {
       console.error("切换角色失败:", error);
     }

--- a/src/components/views/MainMenu.vue
+++ b/src/components/views/MainMenu.vue
@@ -92,6 +92,7 @@
   import { useRouter } from "vue-router";
   import { useGameStore } from "../../stores/modules/game";
   import { applyWebInitData } from "../../stores/modules/game/actions";
+  import { eventQueue } from "../../core/events/event-queue";
   import { useSettingsStore } from "../../stores/modules/settings";
   import { useUIStore } from "../../stores/modules/ui/ui";
   import MeteorAnimation from "../game/standard/animations/MeteorAnimation.vue";
@@ -180,6 +181,9 @@
       const gameInfo = await invoke<WebInitData>("load_save", { saveId: saves[0].id });
       const gameStore = useGameStore();
       applyWebInitData(gameStore.$state, gameInfo);
+      // 继续游戏后丢弃残留事件队列（防止上次会话未消费的回复串进新会话，issue #796）
+      eventQueue.clear();
+      eventQueue.resume();
       router.push("/chat");
     } catch (error) {
       console.error("继续游戏失败:", error);


### PR DESCRIPTION
# PR 描述：修复「存档里的历史对话被抹除」（issue #796）

> Closes #796

---

## 问题

意外操作可以抹除聊天存档中的聊天记录。复现：角色 A 说话在"★ 未说完"处停顿 → 切换角色 B 读取有历史的存档 → 继续推进 A 未说完的话 → 回溯 → **B 存档历史被抹空**。

## 根因（三道环节叠加）

1. **前端事件串扰**：切角色/读档**不清事件队列**，角色 A 未消费完的回复事件在 B 的界面被继续推进 → A 的台词被追加进 B 的 `dialogHistory`
2. **回溯用裸序号定位**：A 残留块携带 A 语境下的 `user_message_seq`（如 =1），在 B 历史点回溯时，`rollback_conversation` 按"第 N 条用户消息"在 **B 的 line_list** 里截断 → 命中 B 的第一条用户消息
3. **存档同步无脑删分歧**：截断后的内存列表与 B 存档链无共同锚点，`sync_lines` 分歧点之后**全删重插** → B 存档整档被抹空

## 修复（四道防线，单笔提交）

### ① 后端：会话边界递增代号（`service.rs` `clear_game_status`）
切角色 / 读档 / 清对话都会清空 `GameStatus` 重建 → 递增 `preview_generation`。旧一轮自由对话的游离流式任务（consumer 仍带着旧代号）写入时会被现有 `add_assistant_line` 代号守卫**丢弃**，杜绝 A 的台词写入 B 的 `line_list`。

### ② 后端：迟到句子不再发布（`generator.rs` `consume_sentence`）
写入已被代号守卫丢弃的句子返回 `None`，不再 emit 给前端——旧角色回复不会串进新会话的展示/历史。

### ③ 后端：存档同步安全网（`save_repo.rs` `sync_lines`）
输入与存档链**首行即分歧**（`diverge=0`）且双方都非空时，说明输入不是同一段对话的演进（串台/错位回溯），**拒绝全量删除重写** → 即使前两道失守也不会把整个存档抹空。

### ④ 前端：会话切换清事件队列（`SettingsSave` / `CharacterCard` / `MainMenu`）
读档 / 切换角色 / 继续游戏成功加载后 `eventQueue.clear() + resume()`，丢弃旧会话残留事件（`resume` 保持队列可消费，参照历史回溯已有的清队列模式）。

## 影响面 / 兼容性

- 代号守卫复用现有 `preview_generation` 机制（试玩已在用），自由对话切换后单调递增，正常连续对话内恒等、行为不变
- `sync_lines` 安全网仅拦截"输入与存档无共同锚点"的异常覆盖；正常续写 / 回溯 / 语音回填 / 新建空档（`db_lines` 或 `input_lines` 为空）不受影响
- 前端清队列仅在三个会话切换成功路径触发

## 验证

- ✅ `cargo check` 通过
- ✅ `vue-tsc` 类型检查通过（exit 0）
- ✅ 本地 `pnpm tauri dev` 运行正常
- 建议按 issue #796 复现步骤实测：角色 A 未说完 → 切 B 读档 → 推进 → 回溯，确认 B 存档历史不被抹除
